### PR TITLE
Debug visualisation

### DIFF
--- a/gam_g4/gam_g4/gam_lib/GamSourceManager.cpp
+++ b/gam_g4/gam_g4/gam_lib/GamSourceManager.cpp
@@ -203,9 +203,10 @@ void GamSourceManager::GeneratePrimaries(G4Event *event) {
 
 void GamSourceManager::InitializeVisualization() {
     if (!fVisualizationFlag) return;
-    char *argv[1]; // ok on osx
+    //char *argv[1]; // ok on osx
     //char **argv = new char*[1]; // not ok on osx
-    fUIEx = new G4UIExecutive(1, argv, "qt");
+    const char* args[] = {"cmd"};
+    fUIEx = new G4UIExecutive(1, (char**)args, "qt");
     // FIXME does not always work on Linux ? only OSX for the moment
     if (fVisEx == nullptr) {
         std::string v = "quiet";


### PR DESCRIPTION
**DO NOT MERGE**

The visualisation for Linux does not work leading to a segfault.
I change the optimisation flag from O3 to O2 and it works.

Maybe the error is deeper but it's a short term fix

Hints for bugs:
 - https://github.com/OpenGATE/gam-gate/blob/master/gam_g4/gam_g4/gam_lib/GamSourceManager.cpp#L192
 - https://github.com/OpenGATE/gam-gate/issues/8