### PR TITLE
Wheel for M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,131 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-ventura-base:latest
+
+build_wheel_task:
+
+  env:
+     PATH: $HOME/miniconda3/bin/:$PATH
+
+  clone_submodules_script:
+    - git submodule update --init
+
+  conda_script:
+    - wget  --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-arm64.sh -O ~/miniconda.sh
+    - bash ~/miniconda.sh -b -p $HOME/miniconda3
+    - export PATH="$HOME/miniconda3/bin/:$PATH"
+
+  software_cache:
+    folder: $HOME/software
+
+  build_dependencies_script:
+    - sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+    - brew update
+    - brew install --force --verbose
+                       ccache
+                       fftw
+                       llvm
+                       libomp
+                       xquartz
+                       wget
+    - export LDFLAGS="-L/usr/local/opt/llvm/lib"
+    - export CPPFLAGS="-I/usr/local/opt/llvm/include -fopenmp"
+    - conda info
+    - conda list
+    - which python
+    - pip install wget colored
+    - pip install cibuildwheel==2.11.2
+    - conda install -c anaconda qt==5.15.9
+    - mkdir -p $HOME/software
+    - cd $HOME/software
+    - mkdir -p geant4
+    - cd geant4
+    - mkdir -p src bin data
+    - if [ ! -d "src/source" ] ; then git clone --branch v11.0.2 https://github.com/Geant4/geant4.git --depth 1 src ; fi
+    - cd bin
+    - cmake -DCMAKE_CXX_FLAGS=-std=c++17
+            -DGEANT4_INSTALL_DATA=ON
+            -DGEANT4_INSTALL_DATADIR=$HOME/software/geant4/data
+            -DGEANT4_USE_QT=ON
+            -DGEANT4_USE_OPENGL_X11=ON
+            -DGEANT4_BUILD_MULTITHREADED=ON
+            ../src
+    - make -j4
+    - cd $HOME/software
+    - mkdir -p itk
+    - cd itk
+    - mkdir -p src bin
+    - if [ ! -d "src/CMake" ] ; then git clone --branch v5.2.1 https://github.com/InsightSoftwareConsortium/ITK.git --depth 1 src ; fi
+    - cd bin
+    - cmake -DCMAKE_CXX_FLAGS=-std=c++17
+            -DBUILD_TESTING=OFF
+            -DITK_USE_FFTWD=ON
+            -DITK_USE_FFTWF=ON
+            -DITK_USE_SYSTEM_FFTW:BOOL=ON
+            ../src
+    - make -j4
+
+  opengate_core_script:
+    - echo $PWD
+    - ls $HOME/miniconda3/plugins/platforms
+    - source $HOME/software/geant4/bin/geant4make.sh
+    - export CMAKE_PREFIX_PATH=$HOME/software/geant4/bin:$HOME/software/itk/bin/:${CMAKE_PREFIX_PATH}
+    - ls
+    - cd core
+    - mkdir opengate_core/plugins
+    - mkdir opengate_core/plugins/miniconda
+    - ls $HOME/miniconda3/lib/
+    - rm -rf dist
+    - export CIBW_BEFORE_BUILD="python -m pip install colored;
+                                python -c \"import os,delocate; print(os.path.join(os.path.dirname(delocate.__file__), 'tools.py'));quit()\" | xargs -I{} sed -i.\"\" \"s/first, /input.pop('i386',None); first, /g\" {}"
+    - python -m cibuildwheel --output-dir dist
+    - cd dist
+    - find . -name '*whl' -exec bash -c ' mv $0 ${0/macosx_11_0/macosx_10_9}' {} \;
+    - cd ../..
+    - mv core/dist .
+
+  binaries_artifacts:
+    path: dist/*
+
+pypi_push_task:
+  depends_on:
+    - build_wheel
+  only_if: $CIRRUS_TAG =~ 'v\d.*'
+  env:
+     PATH: $HOME/miniconda3/bin/:$PATH
+
+  conda_script:
+    - wget  --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-arm64.sh -O ~/miniconda.sh
+    - bash ~/miniconda.sh -b -p $HOME/miniconda3
+    - export PATH="$HOME/miniconda3/bin/:$PATH"
+
+  software_cache:
+    folder: $HOME/software
+
+  env:
+    TWINE_REPOSITORY: pypi
+    TWINE_USERNAME: __token__
+    TWINE_PASSWORD: $PYPI_TOKEN
+
+  build_dependencies_script:
+    - sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+    - brew update
+    - brew install --force --verbose
+                       ccache
+                       fftw
+                       llvm
+                       libomp
+                       xquartz
+                       wget
+    - export LDFLAGS="-L/usr/local/opt/llvm/lib"
+    - export CPPFLAGS="-I/usr/local/opt/llvm/include -fopenmp"
+    - conda info
+    - conda list
+    - which python
+    - pip install wget colored
+    - pip install cibuildwheel==2.11.2
+    - pip install twine
+
+  publish_script:
+    - wget https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/build_wheel/binaries.zip
+    - unzip binaries
+    - twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/OpenGATE/opengate?logo=github)
 [![CI](https://github.com/OpenGATE/opengate/actions/workflows/main.yml/badge.svg)](https://github.com/OpenGATE/opengate/actions/workflows/main.yml)
+[![cirrus CI](https://api.cirrus-ci.com/github/OpenGATE/opengate.svg)](https://cirrus-ci.com/github/OpenGATE/opengate)
 [![Read the Docs](https://img.shields.io/readthedocs/opengate-python?logo=read-the-docs&style=plastic)](https://opengate-python.readthedocs.io/)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/OpenGATE/opengate/master.svg)](https://results.pre-commit.ci/latest/github/OpenGATE/opengate/master)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OpenGATE/gam-gate/c65a0d55c616748454f066470aa836331eb107ac)


### PR DESCRIPTION
Create the wheel for Mac OS M1
Use Cirrus CI because M1 is not available on github Actions

Use cibuildwheel to create the wheel and easily manage the library on MacOS
Use that turnaround for delocate https://github.com/neuronsimulator/nrn/pull/1897/files

Push the artifacts on Pypi only for tagged version
Add cirrus CI badge in the readme