### PR TITLE
beta_minus_spectra

### DIFF
--- a/opengate/source/GenericSource.py
+++ b/opengate/source/GenericSource.py
@@ -117,7 +117,7 @@ class GenericSource(gate.SourceBase):
                 gate.fatal(
                     f"Cannot find the energy type {self.user_info.energy.type} for the source {self.user_info.name}.\n"
                     f"Available types are {l}"
-            )
+                )
 
         # special case for beta plus energy spectra
         if self.user_info.particle == "e+":
@@ -133,8 +133,8 @@ class GenericSource(gate.SourceBase):
                 self.g4_source.SetProbabilityCDF(cdf)
 
         # special case for beta minus energy spectra
-        #TODO
-        
+        # TODO
+
         # initialize
         gate.SourceBase.initialize(self, run_timing_intervals)
 

--- a/opengate/source/GenericSource.py
+++ b/opengate/source/GenericSource.py
@@ -58,8 +58,8 @@ class GenericSource(gate.SourceBase):
         user_info.energy.mono = 0
         user_info.energy.sigma_gauss = 0
         user_info.energy.is_cdf = False
-        user_info.energy.min_energy = None
-        user_info.energy.max_energy = None
+        user_info.energy.min_energy = 0
+        user_info.energy.max_energy = 0
 
     def __del__(self):
         pass
@@ -112,9 +112,11 @@ class GenericSource(gate.SourceBase):
         ]
         l.extend(gate.all_beta_plus_radionuclides)
         if not self.user_info.energy.type in l:
-            gate.fatal(
-                f"Cannot find the energy type {self.user_info.energy.type} for the source {self.user_info.name}.\n"
-                f"Available types are {l}"
+            l.extend(gate.all_beta_minus_radionuclides)
+            if not self.user_info.energy.type in l:
+                gate.fatal(
+                    f"Cannot find the energy type {self.user_info.energy.type} for the source {self.user_info.name}.\n"
+                    f"Available types are {l}"
             )
 
         # special case for beta plus energy spectra
@@ -130,6 +132,9 @@ class GenericSource(gate.SourceBase):
                 self.g4_source.SetEnergyCDF(ene)
                 self.g4_source.SetProbabilityCDF(cdf)
 
+        # special case for beta minus energy spectra
+        #TODO
+        
         # initialize
         gate.SourceBase.initialize(self, run_timing_intervals)
 

--- a/opengate/source/helpers_source.py
+++ b/opengate/source/helpers_source.py
@@ -1,5 +1,6 @@
 from .VoxelsSource import *
 from .GANSource import *
+from .PBSource import *
 import pathlib
 
 """
@@ -8,7 +9,7 @@ import pathlib
     Energy spectra for beta+ and beta- emitters
 """
 
-source_type_names = {GenericSource, VoxelsSource, GANSource}
+source_type_names = {GenericSource, VoxelsSource, GANSource, PBSource}
 source_builders = gate.make_builders(source_type_names)
 
 gate_source_path = pathlib.Path(__file__).parent.resolve()

--- a/opengate/source/helpers_source.py
+++ b/opengate/source/helpers_source.py
@@ -45,6 +45,7 @@ def read_beta_plus_spectra(rad_name):
     data = np.genfromtxt(filename, usecols=(0, 1), skip_header=15, dtype=float)
     return data
 
+
 def read_beta_minus_spectra(rad_name):
     """
     read the file downloaded from LNHB
@@ -60,23 +61,24 @@ def read_beta_minus_spectra(rad_name):
     return data
 
 
-
 def get_rad_yield(rad_name):
     if rad_name in all_beta_plus_radionuclides:
-       data = read_beta_plus_spectra(rad_name)
-       ene = data[:, 0] / 1000  # convert from KeV to MeV
-       proba = data[:, 1]
-       cdf, total = gate.compute_cdf_and_total_yield(proba, ene)
-       total = total * 1000  # (because was in MeV)
-       return total
+        data = read_beta_plus_spectra(rad_name)
+        ene = data[:, 0] / 1000  # convert from KeV to MeV
+        proba = data[:, 1]
+        cdf, total = gate.compute_cdf_and_total_yield(proba, ene)
+        total = total * 1000  # (because was in MeV)
+        return total
     elif rad_name in all_beta_minus_radionuclides:
-       data = read_beta_minus_spectra(rad_name)
-       ene = data[:, 0] / 1000  
-       proba = data[:, 1]
-       cdf, total = gate.compute_cdf_and_total_yield(proba, ene)
-       total = total * 1000  
-       return total
-    else: return 1.0
+        data = read_beta_minus_spectra(rad_name)
+        ene = data[:, 0] / 1000
+        proba = data[:, 1]
+        cdf, total = gate.compute_cdf_and_total_yield(proba, ene)
+        total = total * 1000
+        return total
+    else:
+        return 1.0
+
 
 def compute_bins_density(bins):
     """
@@ -87,6 +89,7 @@ def compute_bins_density(bins):
     upper = bins
     dx = upper - lower
     return dx
+
 
 def compute_cdf_and_total_yield(data, bins):
     """
@@ -125,6 +128,7 @@ def generate_isotropic_directions(
     # concat
     v = np.column_stack((px, py, pz))
     return v
+
 
 def get_rad_energy_spectrum(rad):
     weights = {}


### PR DESCRIPTION
Hello,

Let me first introduce the background, suppose one wants to simulate the **Vivo radiation therapy**. The protocol is as follows:

- A voxelized source is added in the form of a dose map;
- "Lu177" is used as particles of source;

The test file is [here](https://gist.github.com/jizhang02/6778a73b5ba245aa404eb371584b049f).
According to [LNHB](http://www.lnhb.fr/nuclear-data/module-lara/) points out, "Lu177" is beta minus radionuclides.

However, the current code seems does not support it. 
Thus, the goal of this pull request is to **extend from beta plus to beta minus radionuclides**.
Thus, in this case, some minor changes are added in the file `GenericSource.py` and `helpers_source.py`. Please see the code below and consider if it is reasonable.

Also, there are two things that I'm not sure about.

1. Is `energy.type = "Lu177" ` the same as `energy.type = "spectrum"`?, I do not quite understand the format here.
2. In  `GenericSource.py`, line 122, it writes `# special case for beta plus energy spectra`, below it, I write `# special case for beta minus energy spectra`, but I mark it as `#TODO`, because I'm not sure how to implement, are they the same? Which is beyond my knowledge.

That's all, thank you!