### PR TITLE
Add _getstate__ function to geometry/VolumeManager.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,6 @@ jobs:
           brew update
           brew cleanup
           brew config
-          brew doctor
           rm -rf /usr/local/bin/python3.11-config /usr/local/bin/2to3-3.11 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3.11 /usr/local/bin/python3.11
           rm -rf /usr/local/bin/python3-config /usr/local/bin/2to3 /usr/local/bin/idle3 /usr/local/bin/pydoc3 /usr/local/bin/python3
           brew install --force --verbose --overwrite \

--- a/opengate/actor/ARFActor.py
+++ b/opengate/actor/ARFActor.py
@@ -56,6 +56,14 @@ class ARFActor(g4.GateARFActor, gate.ActorBase):
         s = f'ARFActor "{u.name}"'
         return s
 
+    def __getstate__(self):
+        # needed to not pickle. Need to reset some attributes
+        gate.ActorBase.__getstate__(self)
+        self.garf = None
+        self.nn = None
+        self.output_image = None
+        return self.__dict__
+
     def initialize(self, volume_engine=None):
         super().initialize(volume_engine)
         # self.user_info.arf_detector.initialize(self)

--- a/opengate/actor/ActorBase.py
+++ b/opengate/actor/ActorBase.py
@@ -34,11 +34,9 @@ class ActorBase(gate.UserElement):
     def __getstate__(self):
         """
         This is important : to get actor's outputs from a simulation run in a separate process,
-        the class must be serializable (pickle). The attribute "simulation" should not be
-        included in the pickle (do know exactly why), so we remove it first.
+        the class must be serializable (pickle).
         The engines (volume, actor, etc.) and G4 objects are also removed if exists.
         """
-        self.simulation = None
         # do not pickle engines and g4 objects
         for v in self.__dict__:
             if "_engine" in v or "g4_" in v:

--- a/opengate/actor/ActorManager.py
+++ b/opengate/actor/ActorManager.py
@@ -19,6 +19,11 @@ class ActorManager:
         # print("del ActorManager")
         pass
 
+    def __getstate__(self):
+        # needed to not pickle. Need to reset user_info_actors to avoid to store the actors
+        self.user_info_actors = {}
+        return self.__dict__
+
     def dump(self):
         n = len(self.user_info_actors)
         s = f"Number of Actors: {n}"

--- a/opengate/actor/KineticEnergyFilter.py
+++ b/opengate/actor/KineticEnergyFilter.py
@@ -16,3 +16,7 @@ class KineticEnergyFilter(g4.GateKineticEnergyFilter, gate.UserElement):
         g4.GateKineticEnergyFilter.__init__(self)  # no argument in cpp side
         gate.UserElement.__init__(self, user_info)
         # type_name MUST be defined in class that inherit from a Filter
+
+    def __getstate__(self):
+        # needed to not pickle the g4.GateKineticEnergyFilter
+        return self.__dict__

--- a/opengate/actor/MotionVolumeActor.py
+++ b/opengate/actor/MotionVolumeActor.py
@@ -36,6 +36,12 @@ class MotionVolumeActor(g4.GateMotionVolumeActor, gate.ActorBase):
         s = f"MotionVolumeActor {self.user_info.name}"
         return s
 
+    def __getstate__(self):
+        # needed to not pickle the G4Transform3D
+        gate.ActorBase.__getstate__(self)
+        self.user_info.rotations = []
+        return self.__dict__
+
     def initialize(self, volume_engine=None):
         super().initialize(volume_engine)
         # check translations and rotations

--- a/opengate/actor/PhaseSpaceActor.py
+++ b/opengate/actor/PhaseSpaceActor.py
@@ -19,6 +19,11 @@ class PhaseSpaceActor(g4.GatePhaseSpaceActor, gate.ActorBase):
         user_info.store_absorbed_event = False
         user_info.debug = False
 
+    def __getstate__(self):
+        # needed to not pickle. Need to copy fNumberOfAbsorbedEvents from c++ part
+        gate.ActorBase.__getstate__(self)
+        return self.__dict__
+
     def __init__(self, user_info):
         gate.ActorBase.__init__(self, user_info)
         g4.GatePhaseSpaceActor.__init__(self, user_info.__dict__)
@@ -35,4 +40,5 @@ class PhaseSpaceActor(g4.GatePhaseSpaceActor, gate.ActorBase):
         g4.GatePhaseSpaceActor.StartSimulationAction(self)
 
     def EndSimulationAction(self):
+        self.user_info.fNumberOfAbsorbedEvents = self.fNumberOfAbsorbedEvents
         g4.GatePhaseSpaceActor.EndSimulationAction(self)

--- a/opengate/bin/opengate_tests
+++ b/opengate/bin/opengate_tests
@@ -7,6 +7,7 @@ import time
 from opengate.helpers import *
 import pathlib
 import click
+import hashlib
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -25,6 +26,35 @@ def go(test_id):
         )
 
     print("Look for tests in: " + mypath)
+
+    # look if the data for the tests are present
+    if "patient-4mm.raw" not in listdir(os.path.join(mypath, "..", "data")):
+        print(
+            colored.stylize(
+                "The data are not present in: " + os.path.join(mypath, "..", "data"),
+                color_error,
+            )
+        )
+        print("Download them with:")
+        print("git submodule update --init --recursive")
+        return False
+
+    lfsFile = open(os.path.join(mypath, "..", "data", "patient-4mm.raw"), "rb")
+    bytesLfsFile = lfsFile.read()
+    readable_hash = hashlib.sha256(bytesLfsFile).hexdigest()
+    if (
+        not readable_hash
+        == "91c3bbac271f75ac6cbeb413d892933f4b3369fa5a747a55004e113b31d1c84c"
+    ):
+        print(
+            colored.stylize(
+                "The data are not correct in: " + os.path.join(mypath, "..", "data"),
+                color_error,
+            )
+        )
+        print("Activate LFS and download them with:")
+        print("git submodule update --init --recursive")
+        return False
 
     onlyfiles = [f for f in listdir(mypath) if isfile(join(mypath, f))]
 

--- a/opengate/geometry/VolumeManager.py
+++ b/opengate/geometry/VolumeManager.py
@@ -36,6 +36,16 @@ class VolumeManager:
         s = f"{len(self.user_info_volumes)} volumes"
         return s
 
+    def __getstate__(self):
+        """
+        This is important : to get actor's outputs from a simulation run in a separate process,
+        the class must be serializable (pickle).
+        The g4 material databases and the info_volume containing volume from solid have to be removed first.
+        """
+        self.material_database = {}
+        self.user_info_volumes = {}
+        return self.__dict__
+
     def get_volume_user_info(self, name):
         if name not in self.user_info_volumes:
             gate.fatal(

--- a/opengate/helpers_image.py
+++ b/opengate/helpers_image.py
@@ -253,7 +253,8 @@ def voxelize_volume(se, vol_name, image):
 
 def transform_images_point(p, img1, img2):
     index = img1.TransformPhysicalPointToIndex(p)
-    return img2.TransformIndexToPhysicalPoint(index)
+    pbis = img2.TransformIndexToPhysicalPoint(index)
+    return [i for i in pbis]
 
 
 def compute_image_3D_CDF(image):

--- a/opengate/source/GANSourceConditionalPairsGenerator.py
+++ b/opengate/source/GANSourceConditionalPairsGenerator.py
@@ -19,6 +19,14 @@ class GANSourceConditionalPairsGenerator(GANSourceDefaultGenerator):
         self.sphere_radius = sphere_radius
         self.generate_condition = generate_condition_function
 
+    def __getstate__(self):
+        # needed to not pickle. Need to reset some attributes
+        self.gan = None
+        self.gaga = None
+        self.generate_condition = None
+        self.lock = None
+        return self.__dict__
+
     def generate_condition(self, n):
         gate.fatal(
             f'Error: to use GANSourceConditionalPairsGenerator,  you must provide a function "f" '

--- a/opengate/tests/src/test023_filters_iec_phantom.py
+++ b/opengate/tests/src/test023_filters_iec_phantom.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import opengate as gate
+import opengate_core as g4
+import pathlib
+import os
+import opengate.contrib.phantom_nema_iec_body as gate_iec
+
+pathFile = pathlib.Path(__file__).parent.resolve()
+
+# create the simulation
+sim = gate.Simulation()
+
+# main options
+ui = sim.user_info
+ui.g4_verbose = False
+ui.g4_verbose_level = 1
+ui.visu = False
+ui.random_seed = 123456
+
+# units
+m = gate.g4_units("m")
+cm = gate.g4_units("cm")
+keV = gate.g4_units("keV")
+MeV = gate.g4_units("MeV")
+Bq = gate.g4_units("Bq")
+nm = gate.g4_units("nm")
+mm = gate.g4_units("mm")
+
+#  change world size
+world = sim.world
+world.size = [1 * m, 1 * m, 1 * m]
+
+# iec phantom
+iec_phantom = gate_iec.add_phantom(sim)
+
+# default source for tests
+source = sim.add_source("Generic", "mysource")
+source.energy.mono = 50 * MeV
+source.particle = "proton"
+source.position.type = "sphere"
+source.position.radius = 1 * cm
+source.direction.type = "iso"
+source.activity = 10000 * Bq
+
+# filter : keep gamma
+f = sim.add_filter("ParticleFilter", "f")
+f.particle = "gamma"
+fp = sim.add_filter("ParticleFilter", "fp")
+fp.particle = "e-"
+fk = sim.add_filter("KineticEnergyFilter", "fk")
+fk.energy_min = 100 * keV
+
+# add dose actor
+dose = sim.add_actor("DoseActor", "dose")
+dose.output = pathFile / ".." / "output" / "test023-edep.mhd"
+# dose.output = 'output_ref/test023-edep.mhd'
+dose.mother = "iec"
+dose.size = [100, 100, 100]
+dose.spacing = [2 * mm, 2 * mm, 2 * mm]
+dose.filters.append(fp)
+dose.filters.append(fk)
+
+# add stat actor
+s = sim.add_actor("SimulationStatisticsActor", "Stats")
+s.track_types_flag = True
+s.filters.append(f)
+
+print(s)
+print(dose)
+print("Filters: ", sim.filter_manager)
+print(sim.filter_manager.dump())
+
+# change physics
+p = sim.get_physics_user_info()
+p.physics_list_name = "QGSP_BERT_EMZ"
+cuts = p.production_cuts
+cuts.world.gamma = 0.1 * mm
+cuts.world.proton = 0.1 * mm
+cuts.world.electron = 0.1 * mm
+cuts.world.positron = 0.1 * mm
+
+# start simulation
+output = sim.start(True)
+
+# print results at the end
+stat = output.get_actor("Stats")
+print(stat)
+# stat.write('output_ref/test023_stats_iec_phantom.txt')
+
+# tests
+stats_ref = gate.read_stat_file(
+    pathFile / ".." / "data" / "output_ref" / "test023_stats_iec_phantom.txt"
+)
+is_ok = gate.assert_stats(stat, stats_ref, 0.8)
+is_ok = is_ok and gate.assert_images(
+    pathFile / ".." / "data" / "output_ref" / "test023_iec_phantom-edep.mhd",
+    pathFile / ".." / "output" / "test023-edep.mhd",
+    stat,
+    tolerance=50,
+)
+
+gate.test_ok(is_ok)

--- a/opengate/tests/src/test023_filters_material.py
+++ b/opengate/tests/src/test023_filters_material.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import opengate as gate
+import opengate_core as g4
+import pathlib
+import os
+
+pathFile = pathlib.Path(__file__).parent.resolve()
+
+# create the simulation
+sim = gate.Simulation()
+sim.add_material_database(pathFile / ".." / "data" / "GateMaterials.db")
+
+# main options
+ui = sim.user_info
+ui.g4_verbose = False
+ui.g4_verbose_level = 1
+ui.visu = False
+ui.random_seed = 123456
+
+# units
+m = gate.g4_units("m")
+cm = gate.g4_units("cm")
+MeV = gate.g4_units("MeV")
+Bq = gate.g4_units("Bq")
+nm = gate.g4_units("nm")
+mm = gate.g4_units("mm")
+
+#  change world size
+world = sim.world
+world.size = [1 * m, 1 * m, 1 * m]
+
+# waterbox
+waterbox = sim.add_volume("Box", "waterbox")
+waterbox.size = [10 * cm, 10 * cm, 10 * cm]
+waterbox.material = "Water"
+waterbox.color = [0, 0, 1, 1]
+
+# default source for tests
+source = sim.add_source("Generic", "mysource")
+source.energy.mono = 50 * MeV
+source.particle = "proton"
+source.position.type = "sphere"
+source.position.radius = 1 * cm
+source.direction.type = "iso"
+source.activity = 10000 * Bq
+
+# filter : keep gamma
+f = sim.add_filter("ParticleFilter", "f")
+f.particle = "gamma"
+fp = sim.add_filter("ParticleFilter", "fp")
+fp.particle = "e-"
+
+# add dose actor
+dose = sim.add_actor("DoseActor", "dose")
+dose.output = pathFile / ".." / "output" / "test023-edep.mhd"
+# dose.output = 'output_ref/test023-edep.mhd'
+dose.mother = "waterbox"
+dose.size = [100, 100, 100]
+dose.spacing = [2 * mm, 2 * mm, 2 * mm]
+dose.filters.append(fp)
+
+# add stat actor
+s = sim.add_actor("SimulationStatisticsActor", "Stats")
+s.track_types_flag = True
+s.filters.append(f)
+
+print(s)
+print(dose)
+print("Filters: ", sim.filter_manager)
+print(sim.filter_manager.dump())
+
+# change physics
+p = sim.get_physics_user_info()
+p.physics_list_name = "QGSP_BERT_EMZ"
+cuts = p.production_cuts
+cuts.world.gamma = 0.1 * mm
+cuts.world.proton = 0.1 * mm
+cuts.world.electron = 0.1 * mm
+cuts.world.positron = 0.1 * mm
+
+# start simulation
+output = sim.start(True)
+
+# print results at the end
+stat = output.get_actor("Stats")
+print(stat)
+# stat.write('output_ref/test023_stats.txt')
+
+# tests
+stats_ref = gate.read_stat_file(
+    pathFile / ".." / "data" / "output_ref" / "test023_stats.txt"
+)
+is_ok = gate.assert_stats(stat, stats_ref, 0.8)
+is_ok = is_ok and gate.assert_images(
+    pathFile / ".." / "data" / "output_ref" / "test023-edep.mhd",
+    pathFile / ".." / "output" / "test023-edep.mhd",
+    stat,
+    tolerance=50,
+)
+
+gate.test_ok(is_ok)

--- a/opengate/tests/src/test028_ge_nm670_spect_2_helpers.py
+++ b/opengate/tests/src/test028_ge_nm670_spect_2_helpers.py
@@ -323,7 +323,7 @@ def test_spect_proj(output, paths, proj, version="3"):
     print("Compare images (old spacing/origin)")
     # read image and force change the offset to be similar to old Gate
     img = itk.imread(str(paths.output / "proj028.mhd"))
-    spacing = np.array(proj.spacing)
+    spacing = np.array(proj.user_info.spacing)
     origin = spacing / 2.0
     origin[2] = 0.5
     spacing[2] = 1

--- a/opengate/tests/src/test028_ge_nm670_spect_3_proj.py
+++ b/opengate/tests/src/test028_ge_nm670_spect_3_proj.py
@@ -27,6 +27,7 @@ output = sim.start()
 is_ok = test_spect_hits(output, paths, version="3")
 
 # check
+proj = output.get_actor("Projection")
 is_ok = test_spect_proj(output, paths, proj, version="3")
 
 gate.test_ok(is_ok)

--- a/opengate/tests/src/test028_ge_nm670_spect_3_proj_MT.py
+++ b/opengate/tests/src/test028_ge_nm670_spect_3_proj_MT.py
@@ -22,4 +22,5 @@ spect.translation, spect.rotation = gate.get_transform_orbiting(p, "y", -15)
 output = sim.start()
 
 # check
+proj = output.get_actor("Projection")
 test_spect_proj(output, paths, proj)

--- a/opengate/tests/src/test028_ge_nm670_spect_3_proj_blur.py
+++ b/opengate/tests/src/test028_ge_nm670_spect_3_proj_blur.py
@@ -75,6 +75,7 @@ is_ok = gate.compare_root2(
 )
 
 # check projection
+proj = output.get_actor("Projection")
 is_ok = test_spect_proj(output, paths, proj, version="3_blur") and is_ok
 
 gate.test_ok(is_ok)

--- a/opengate/tests/src/test029_volume_time_rotation_1_process.py
+++ b/opengate/tests/src/test029_volume_time_rotation_1_process.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test029_volume_time_rotation_helpers import *
+
+paths = gate.get_default_test_paths(__file__, "gate_test029_volume_time_rotation")
+
+# create the main simulation object
+sim = gate.Simulation()
+
+# create sim without AA
+create_simulation(sim, False)
+
+# initialize & start
+output = sim.start(True)
+
+"""
+# use to create the (fake) reference for test029_volume_time_rotation_2.py
+import itk
+scaling = 0.90
+img = itk.imread(str(paths.output_ref / "proj029.mhd"))
+arr = itk.array_view_from_image(img)
+arr *= scaling
+itk.imwrite(img, str(paths.output_ref / "proj029_scaled.mhd"))
+"""
+
+# -------------------------
+gate.warning("Compare stats")
+stats = gate.read_stat_file(paths.output / "stats029.txt")
+print(stats)
+stats_ref = gate.read_stat_file(paths.output_ref / "stats029.txt")
+print(
+    f"Number of steps was {stats.counts.step_count}, forced to the same value (because of angle acceptance). "
+)
+stats.counts.step_count = stats_ref.counts.step_count  # force to id
+is_ok = gate.assert_stats(stats, stats_ref, tolerance=0.01)
+print(is_ok)
+
+gate.warning("Compare images")
+# read image and force change the offset to be similar to old Gate
+is_ok = (
+    gate.assert_images(
+        paths.output_ref / "proj029.mhd",
+        paths.output / "proj029.mhd",
+        stats,
+        tolerance=47,
+        ignore_value=0,
+        axis="x",
+        sum_tolerance=0.5,
+    )
+    and is_ok
+)
+print(is_ok)
+
+gate.test_ok(is_ok)

--- a/opengate/tests/src/test040_gan_phsp_pet_aref.py
+++ b/opengate/tests/src/test040_gan_phsp_pet_aref.py
@@ -127,7 +127,7 @@ is_ok = gate.assert_stats(stats, stats_ref, 0.01)
 
 phsp = output.get_actor("phsp")
 ref = 17299
-ae = phsp.fNumberOfAbsorbedEvents
+ae = phsp.user_info.fNumberOfAbsorbedEvents
 err = abs(ae - ref) / ref
 tol = 0.02
 is_ok = err < tol and is_ok

--- a/opengate/tests/src/test043_garf.py
+++ b/opengate/tests/src/test043_garf.py
@@ -68,7 +68,7 @@ print(stat)
 # print info
 print("")
 arf = output.get_actor("arf")
-img = arf.output_image
+img = itk.imread(arf.user_info.output)
 # set the first channel to the same channel (spectrum) than the analog
 img[0, :] = img[1, :] + img[2, :]
 print(f"Number of batch: {arf.batch_nb}")

--- a/opengate/tests/src/test043_garf_analog.py
+++ b/opengate/tests/src/test043_garf_analog.py
@@ -63,10 +63,11 @@ print(stat)
 print("We change the spacing/origin to be compared to the old gate")
 proj = output.get_actor(f"Projection_{crystal_name}")
 spacing = np.array([4.41806 * mm, 4.41806 * mm, 1])
-proj.output_image.SetSpacing(spacing)
-proj.output_image.SetOrigin(spacing / 2.0)
+img = itk.imread(proj.user_info.output)
+img.SetSpacing(spacing)
+img.SetOrigin(spacing / 2.0)
 fn = str(proj.user_info.output).replace(".mhd", "_offset.mhd")
-itk.imwrite(proj.output_image, fn)
+itk.imwrite(img, fn)
 
 # ----------------------------------------------------------------------------------------------------------------
 # tests


### PR DESCRIPTION
We noticed with your own material database or with volume from solid, we needed to serialize something The two were saved inside VolumeManager, so I removed them.

And it seems that in ActorBase, setting the simulation to None is not needed anymore

Add serialization to KineticEnergyFilter

Add tests for KineticEnergyFilter, volume from solid and material database