### PR TITLE
Be sure to use python-box < 7.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "gatetools",
         "tqdm",
         "click",
-        "python-box",
+        "python-box<7.0.0",
         "anytree",
         "numpy",
         "itk",


### PR DESCRIPTION
With python-box == 7.0.0, there is this error:
```
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/gaga_phsp/gaga_helpers.py", line 131, in check_input_params
    params["cond_keys"] = []
  File "box/box.py", line 660, in box.box.Box.__setitem__
  File "box/box.py", line 578, in box.box.Box.__convert_and_store
  File "box/box.py", line 541, in box.box.Box.__box_config
KeyError: 'box_namespace'
```

