### PR TITLE
Physic list bug

### DIFF
--- a/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
+++ b/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
@@ -72,5 +72,9 @@ void init_G4VModularPhysicsList(py::module &m) {
            py::overload_cast<G4int>(&G4VModularPhysicsList::GetPhysics,
                                     py::const_),
            py::return_value_policy::reference)
-      .def("RegisterPhysics", &G4VModularPhysicsList::RegisterPhysics);
+      .def("RegisterPhysics", &G4VModularPhysicsList::RegisterPhysics)
+      .def("RemovePhysics",
+           [](G4VModularPhysicsList *s, G4VPhysicsConstructor *p) {
+             s->RemovePhysics(p);
+           });
 }

--- a/opengate/physics/PhysicsEngine.py
+++ b/opengate/physics/PhysicsEngine.py
@@ -60,8 +60,19 @@ class PhysicsEngine(gate.EngineBase):
         G4RadioactiveDecayPhysics - defines radioactiveDecay for GenericIon
         """
         ui = self.physics_manager.user_info
+
+        # special case : user asked to remove 'radioactive_decay_physics'
+        if ui.remove_radioactive_decay_physics:
+            self.g4_radioactive_decay = self.g4_physic_list.GetPhysics(
+                "G4RadioactiveDecay"
+            )
+            if self.g4_radioactive_decay:
+                self.g4_physic_list.RemovePhysics(self.g4_radioactive_decay)
+
+        # user asked for no decay
         if not ui.enable_decay:
             return
+
         # check if decay/radDecay already exist in the physics list
         # (keep p and pp in self to prevent destruction)
         self.g4_decay = self.g4_physic_list.GetPhysics("Decay")

--- a/opengate/physics/PhysicsUserInfo.py
+++ b/opengate/physics/PhysicsUserInfo.py
@@ -16,6 +16,7 @@ class PhysicsUserInfo:
         # physics list and decay
         self.physics_list_name = None
         self.enable_decay = False
+        self.remove_radioactive_decay_physics = False
 
         # options related to the cuts
         self.production_cuts = Box()

--- a/opengate/tests/src/test013_phys_lists_6.py
+++ b/opengate/tests/src/test013_phys_lists_6.py
@@ -29,8 +29,10 @@ def start_simulation(phlist):
     # physics
     p = sim.get_physics_user_info()
     p.physics_list_name = phlist
+    print()
     print("phys list = ", p.physics_list_name)
     p.enable_decay = False
+    p.remove_radioactive_decay_physics = True
     sim.set_cut("world", "all", 1000 * km)
 
     #  change world size
@@ -97,14 +99,15 @@ ref_filename = f"edep_{ref_phlist}.mhd"
 ok = True
 
 for phlist in physics_list_test:
-    print("=========================")
+    print()
     print(f"Checking {phlist=} vs {ref_phlist=}")
     ok = (
         gate.assert_images(
             output_path / ref_filename,
             output_path / f"edep_{phlist}.mhd",
             axis="x",
-            tolerance=5,
+            tolerance=110,
+            sum_tolerance=7,
         )
         and ok
     )

--- a/opengate/tests/src/test013_phys_lists_6.py
+++ b/opengate/tests/src/test013_phys_lists_6.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import opengate as gate
+import os
+from scipy.spatial.transform import Rotation
+
+
+def start_simulation(phlist):
+    # units
+    km = gate.g4_units("km")
+    cm = gate.g4_units("cm")
+    mm = gate.g4_units("mm")
+    MeV = gate.g4_units("MeV")
+
+    # create the simulation
+    sim = gate.Simulation()
+
+    # add a material database
+    sim.add_material_database(paths.gate_data / "HFMaterials2014.db")
+
+    # main options
+    ui = sim.user_info
+    # ui.start_new_process = True
+    ui.g4_verbose = False
+    ui.g4_verbose_level = 2
+    ui.visu = False
+    ui.random_seed = "auto"  # 12365478910
+    ui.random_engine = "MersenneTwister"
+
+    # physics
+    p = sim.get_physics_user_info()
+    p.physics_list_name = phlist
+    print("phys list = ", p.physics_list_name)
+    p.enable_decay = False
+    sim.set_cut("world", "all", 1000 * km)
+
+    #  change world size
+    world = sim.world
+    world.size = [600 * cm, 500 * cm, 500 * cm]
+
+    # target
+    phantom = sim.add_volume("Box", f"phantom_{phlist}")
+    phantom.size = [200 * mm, 200 * mm, 200 * mm]
+    phantom.translation = [-100 * mm, 0, 0]
+    phantom.material = "G4_WATER"
+    phantom.color = [0, 0, 1, 1]
+
+    # dose actor
+    dose = sim.add_actor("DoseActor", f"doseInXYZ_{phlist}")
+    dose.output = output_path / f"edep_{phlist}.mhd"
+    dose.mother = phantom.name
+    dose.size = [200, 200, 200]
+    dose.spacing = [1 * mm, 1 * mm, 1 * mm]
+    dose.hit_type = "random"
+
+    # source
+    source = sim.add_source("GenericSource", "mysource")
+    source.energy.mono = 1440 * MeV
+    source.particle = "ion 6 12"
+    source.position.type = "disc"
+    source.position.rotation = Rotation.from_euler("y", 90, degrees=True).as_matrix()
+    source.position.sigma_x = 8 * mm
+    source.position.sigma_y = 8 * mm
+    source.direction.type = "momentum"
+    source.direction.momentum = [-1, 0, 0]
+    source.n = 20
+
+    # add stat actor
+    s = sim.add_actor("SimulationStatisticsActor", "Stats")
+    s.track_types_flag = True
+
+    # start simulation
+    sim = gate.SimulationEngine(sim, start_new_process=True)
+    output = sim.start()
+
+    # print results at the end
+    stat = output.get_actor("Stats")
+    print(stat)
+
+
+# ------ INITIALIZE SIMULATION ENVIRONMENT ----------
+paths = gate.get_default_test_paths(__file__, "gate_test044_pbs")
+output_path = paths.output / "output_test051_rtp"
+
+# create output dir, if it doesn't exist
+if not os.path.isdir(output_path):
+    os.mkdir(output_path)
+
+
+physics_list_test = ["QGSP_BIC_HP", "QGSP_BIC"]
+ref_phlist = physics_list_test[1]
+
+for phlist in physics_list_test:
+    start_simulation(phlist)
+
+# ------ TESTS -------#
+ref_filename = f"edep_{ref_phlist}.mhd"
+ok = True
+
+for phlist in physics_list_test:
+    print("=========================")
+    print(f"Checking {phlist=} vs {ref_phlist=}")
+    ok = (
+        gate.assert_images(
+            output_path / ref_filename,
+            output_path / f"edep_{phlist}.mhd",
+            axis="x",
+            tolerance=5,
+        )
+        and ok
+    )
+
+gate.test_ok(ok)


### PR DESCRIPTION
From: @MartiDvrk
There is a strange behaviour with some physic lists that lead to zero output. 

"We have a suspicion that is related to “G4TENDL1.4”, which is new since the last or previous G4 release. We were a bit slowed down by having compiling issues since we pulled last days from the main branch. seems to be solved now.
I looked into the G4 examples and the G4 source code of the phys lists. There was nothing obvious, why it should work for BIC, but not for BIC_HP, which inherits from BIC and overloads few functions. On the other hand “Shielding”, does not inherit from another phys list, but also doesn’t work (has the HP inside)."

This is an example that shows the bug. It may be related to the "G4RadioactiveDecayPhysics". When it is enabled it fails. 
- QGSP_BIC do not enable G4RadioactiveDecayPhysics: it is correct
- QGSP_BIC_HP enable it: it fails. 

If we force QGSP_BIC_HP to remove the process (using RemovePhysics), it works. 

