### PR TITLE
fix initialize_physics_list 

### DIFF
--- a/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
+++ b/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
@@ -72,5 +72,6 @@ void init_G4VModularPhysicsList(py::module &m) {
            py::overload_cast<G4int>(&G4VModularPhysicsList::GetPhysics,
                                     py::const_),
            py::return_value_policy::reference)
-      .def("RegisterPhysics", &G4VModularPhysicsList::RegisterPhysics);
+      .def("RegisterPhysics", &G4VModularPhysicsList::RegisterPhysics)
+      .def("ReplacePhysics", &G4VModularPhysicsList::ReplacePhysics);
 }

--- a/opengate/physics/helpers_physics.py
+++ b/opengate/physics/helpers_physics.py
@@ -113,4 +113,4 @@ def create_modular_physics_list(pl_name):
     # Create the class
     b = gate.create_modular_physics_list_class(a)
     # Create the object
-    return b()
+    return b


### PR DESCRIPTION
Changes comes from geant4 example where using `G4EmStandardPhysics_option4 `  is always preceded by instantiating FTFP_BERT and use method `ReplacePhysics` with  `G4EmStandardPhysics_option4 ` as argument. 

This will also allow us to add `G4OpticalPhysics` (wich can not be used directly on  `G4EmStandardPhysics_option4 `). 