### PR TITLE
Activate additional physics constructors

### DIFF
--- a/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
+++ b/core/opengate_core/g4_bindings/pyG4VModularPhysicsList.cpp
@@ -74,6 +74,7 @@ void init_G4VModularPhysicsList(py::module &m) {
                                     py::const_),
            py::return_value_policy::reference)
       .def("RegisterPhysics", &G4VModularPhysicsList::RegisterPhysics)
+      .def("ReplacePhysics", &G4VModularPhysicsList::ReplacePhysics)
       .def("RemovePhysics", py::overload_cast<G4VPhysicsConstructor *>(
                                 &G4VModularPhysicsList::RemovePhysics));
 }

--- a/core/opengate_core/g4_bindings/pyPhysicsLists.cpp
+++ b/core/opengate_core/g4_bindings/pyPhysicsLists.cpp
@@ -55,26 +55,24 @@ namespace py = pybind11;
 #include "G4VUserPhysicsList.hh"
 
 // macro for adding physics lists: no parameter
-#define ADD_PHYSICS_LIST0(m, plname)                                           \
-  py::class_<plname, G4VModularPhysicsList>(m, #plname).def(py::init<>());     \
-  AddPhysicsList(#plname);
+// #define ADD_PHYSICS_LIST0(m, plname) \
+//   py::class_<plname, G4VModularPhysicsList>(m, #plname).def(py::init<>()); \
+//   AddPhysicsList(#plname);
 
 // macro for adding physics lists: one int parameter
-#define ADD_PHYSICS_LIST1(m, plname)                                           \
-  py::class_<plname, G4VUserPhysicsList>(m, #plname).def(py::init<G4int>());   \
-  AddPhysicsList(#plname);
+// #define ADD_PHYSICS_LIST1(m, plname) \
+//   py::class_<plname, G4VUserPhysicsList>(m, #plname).def(py::init<G4int>());
+//   \ AddPhysicsList(#plname);
 
 // macro for adding physics lists: int+str parameter
-#define ADD_PHYSICS_LIST2(m, plname)                                           \
-  py::class_<plname, G4VUserPhysicsList>(m, #plname)                           \
-      .def(py::init<G4int, G4String>());                                       \
-  AddPhysicsList(#plname);
+// #define ADD_PHYSICS_LIST2(m, plname) \
+//   py::class_<plname, G4VUserPhysicsList>(m, #plname) \
+//       .def(py::init<G4int, G4String>()); \
+//   AddPhysicsList(#plname);
 
-// macro for adding physics constructor: one int parameter
-// (nodelete is needed because it is deleted in cpp side (runmanager?)
-// NK: Yes, the RunManager destructor calls the destructors of all
-// G4VPhysicsConstructor objects in a physics list
-// then also on py side, so seg fault during garbage collection)
+// macro for adding physics constructor: one int parameter (verbosity),
+// nodelete is needed because the G4 run manager deletes the physics list
+// on the cpp side, python should not delete the object
 #define ADD_PHYSICS_CONSTRUCTOR(plname)                                        \
   py::class_<plname, G4VPhysicsConstructor,                                    \
              std::unique_ptr<plname, py::nodelete>>(m, #plname)                \

--- a/opengate/physics/PhysicsEngine.py
+++ b/opengate/physics/PhysicsEngine.py
@@ -81,7 +81,6 @@ class PhysicsEngine(gate.EngineBase):
 
         """
         self.initialize_physics_list()
-        self.initialize_decay()
         self.initialize_em_options()
         self.initialize_user_limits_physics()
         self.initialize_parallel_world_physics()
@@ -94,7 +93,6 @@ class PhysicsEngine(gate.EngineBase):
         # the global cuts with the physics list defaults.
         self.initialize_global_cuts()
         self.initialize_regions()
-
         self.initialize_g4_em_parameters()
 
     def initialize_parallel_world_physics(self):
@@ -115,28 +113,6 @@ class PhysicsEngine(gate.EngineBase):
                 physics_list_name
             )
         )
-
-    def initialize_decay(self):
-        """
-        G4DecayPhysics - defines all particles and their decay processes
-        G4RadioactiveDecayPhysics - defines radioactiveDecay for GenericIon
-        """
-        ui = self.physics_manager.user_info
-        if not ui.enable_decay:
-            return
-        # check if decay/radDecay already exist in the physics list
-        # (keep p and pp in self to prevent destruction)
-        # NOTE: can we use Replace() method from G4VModularPhysicsList?
-        self.g4_decay = self.g4_physics_list.GetPhysics("Decay")
-        if not self.g4_decay:
-            self.g4_decay = g4.G4DecayPhysics(1)
-            self.g4_physics_list.RegisterPhysics(self.g4_decay)
-        self.g4_radioactive_decay = self.g4_physics_list.GetPhysics(
-            "G4RadioactiveDecay"
-        )
-        if not self.g4_radioactive_decay:
-            self.g4_radioactive_decay = g4.G4RadioactiveDecayPhysics(1)
-            self.g4_physics_list.RegisterPhysics(self.g4_radioactive_decay)
 
     def initialize_em_options(self):
         # later

--- a/opengate/physics/PhysicsManager.py
+++ b/opengate/physics/PhysicsManager.py
@@ -65,7 +65,6 @@ class PhysicsManager:
         # keep the name to be able to come back to default
         self.default_physic_list = "QGSP_BERT_EMV"
         ui.physics_list_name = self.default_physic_list
-        ui.enable_decay = False
         """
         FIXME Energy range not clear : does not work in mono-thread mode
         Ignored for the moment (keep them to None)

--- a/opengate/physics/PhysicsUserInfo.py
+++ b/opengate/physics/PhysicsUserInfo.py
@@ -1,7 +1,8 @@
-import opengate as gate
 import opengate_core as g4
 from box import Box
 from .PhysicsManager import PhysicsManager
+from .PhysicsListManager import PhysicsListManager
+from ..helpers import fatal
 
 
 class PhysicsUserInfo:
@@ -14,9 +15,14 @@ class PhysicsUserInfo:
         # keep pointer to ref
         self.simulation = simulation
 
-        # physics list and decay
+        # physics list and optional physics constructors
         self.physics_list_name = None
-        self.enable_decay = False
+        # dictionary with names of additional physics constructors
+        # to be added to physics list (False = off by default)
+        # content is maintained by the PhysicsListManager
+        self.special_physics_constructors = {}
+        for spc in PhysicsListManager.special_physics_constructor_classes:
+            self.special_physics_constructors[spc] = False
 
         # options related to the cuts and user limits
         # self.production_cuts = Box()
@@ -59,3 +65,28 @@ class PhysicsUserInfo:
             f"user limits particles : {self.user_limits_particles}"
         )
         return s
+
+    # properties to quickly enable decay
+    # makes tests backwards compatible
+    # To be discussed whether an enable_decay switch makes sense
+    # Issue: if a physics list has already G4Decay in it, Gate will not
+    # deactivate it even if enable_decay = False
+    # Either enhance the logic, or leave it to the user to understand
+    # what is in the physics list they use
+    @property
+    def enable_decay(self):
+        switch1 = self.special_physics_constructors["G4DecayPhysics"]
+        switch2 = self.special_physics_constructors["G4RadioactiveDecayPhysics"]
+        if switch1 is True and switch2 is True:
+            return True
+        elif switch1 is False and switch2 is False:
+            return False
+        else:
+            fatal(
+                f"Inconsistent G4Decay constructors: G4DecayPhysics = {switch1}, G4RadioactiveDecayPhysics = {switch2}."
+            )
+
+    @enable_decay.setter
+    def enable_decay(self, value):
+        self.special_physics_constructors["G4DecayPhysics"] = value
+        self.special_physics_constructors["G4RadioactiveDecayPhysics"] = value

--- a/opengate/physics/PhysicsUserInfo.py
+++ b/opengate/physics/PhysicsUserInfo.py
@@ -20,7 +20,7 @@ class PhysicsUserInfo:
         # dictionary with names of additional physics constructors
         # to be added to physics list (False = off by default)
         # content is maintained by the PhysicsListManager
-        self.special_physics_constructors = {}
+        self.special_physics_constructors = Box()
         for spc in PhysicsListManager.special_physics_constructor_classes:
             self.special_physics_constructors[spc] = False
 

--- a/opengate/tests/src/test013_phys_lists_1.py
+++ b/opengate/tests/src/test013_phys_lists_1.py
@@ -18,7 +18,11 @@ sim.source_manager.user_info_sources.pop("ion2")
 # change physics
 p = sim.get_physics_user_info()
 p.physics_list_name = "G4EmStandardPhysics_option4"
-p.enable_decay = True
+# enable decay via switch:
+# p.enable_decay = True
+# or by activating the physics constructors:
+p.special_physics_constructors.G4DecayPhysics = True
+p.special_physics_constructors.G4RadioactiveDecayPhysics = True
 
 um = gate.g4_units("um")
 global_cut = 7 * um


### PR DESCRIPTION
This PR implements a general functionality to activate "special" physics, such as Decay, Optical, DNA. It uses the recently introduced PhysicsListManager which keeps a dictionary of available special physics constructors. Currently, these are: 

G4DecayPhysics
G4RadioactiveDecayPhysics
G4OpticalPhysics
G4EmDNAPhysics

The PhysicsListManager uses G4VModularPhysicsList::ReplacePhysics to inject the physics constructor into the physics list when the physics list object is created. ReplacePhysics checks internally whether the physics constructor needs to be added or whether it replacing a "competing" constructor of the same physics type. 

All available special physics constructors are off by default. This is handled via a dictionary in the PhysicsUserInfo class. This dictionary draws the entries from the PhysicsListManager, which is the place where available constructor classes should be stored and handled. 

test013_phys_list_1.py shows how to use the new user_info: 

p = sim.get_physics_user_info()
p.special_physics_constructors.G4DecayPhysics = True
p.special_physics_constructors.G4RadioactiveDecayPhysics = True

... and equivalent for all other physics constructors, such as G4OpticalPhysics. 

PhysicsUserInfo now implements a property enable_decay instead of the previous boolean flag. The property automatically handles the two physics constructors, for the user's convenience. The name 'enable_decay' is (and was) not ideal, however, because enable_decay does not remove the physics constructors in question from the physics list. It only adds them if enable_decay=True. A more appropriate name would be: 'ensure_decay' or 'force_decay' or similar. Ideas welcome. 

Finally, since decay is now handled by the PhysicsListManager in a general way along with other special physics constructors, the initialize_decay method in PhysicsEngine has become obsolete and was removed. 
 