### PR TITLE
Change axis for vrml vizualisation

### DIFF
--- a/docs/source/user_guide_2_0_simulation.md
+++ b/docs/source/user_guide_2_0_simulation.md
@@ -98,6 +98,8 @@ The visualisation with qt is still work in progress. First, it does not work on 
 
 You can choose vrml visualization with `ui.visu_type = "vrml"`. Opengate uses `pyvista` for the GUI, so you need to install it before with `pip install pyvista`. Alternatively, if you want to use an external VRML viewer, you can save a VRML file with `ui.visu_type = "vrml_file_only"`. In such case, the GUI is not open, and you do not need pyvista. In both cases, you need to set `ui.visu_filename = "geant4VisuFile.wrl"` to save the VRML file.
 
+If you want to personalized the pyvista GUI, you can set `ui.visu_type = "vrml_file_only"` and execute you own code in your python script. You can find an example in [test004_simple_visu_vrml.py](https://github.com/OpenGATE/opengate/blob/master/opengate/tests/src/test004_simple_visu_vrml.py#L69-L90)
+
 ##### GDML
 
 ![](figures/visu_gdml.png)

--- a/opengate/SimulationEngine.py
+++ b/opengate/SimulationEngine.py
@@ -365,18 +365,7 @@ class SimulationEngine(gate.EngineBase):
             return
         pl = pyvista.Plotter()
         pl.import_vrml(self.simulation.user_info.visu_filename)
-        axes = pyvista.Axes()
-        axes.axes_actor.total_length = 1000  # mm
-        axes.axes_actor.shaft_type = axes.axes_actor.ShaftType.CYLINDER
-        axes.axes_actor.cylinder_radius = 0.01
-        axes.axes_actor.x_axis_shaft_properties.color = (1, 0, 0)
-        axes.axes_actor.x_axis_tip_properties.color = (1, 0, 0)
-        axes.axes_actor.y_axis_shaft_properties.color = (0, 1, 0)
-        axes.axes_actor.y_axis_tip_properties.color = (0, 1, 0)
-        axes.axes_actor.z_axis_shaft_properties.color = (0, 0, 1)
-        axes.axes_actor.z_axis_tip_properties.color = (0, 0, 1)
-        pl.add_actor(axes.axes_actor)
-        # pl.add_axes_at_origin()
+        pl.add_axes(line_width=5)
         pl.show()
 
     def apply_g4_command(self, command):

--- a/opengate/tests/src/test004_simple_visu_vrml.py
+++ b/opengate/tests/src/test004_simple_visu_vrml.py
@@ -14,7 +14,7 @@ ui = sim.user_info
 ui.g4_verbose = False
 ui.g4_verbose_level = 1
 ui.visu = True
-ui.visu_type = "vrml"
+ui.visu_type = "vrml_file_only"
 ui.visu_filename = "geant4VisuFile.wrl"
 ui.visu_verbose = True
 ui.number_of_threads = 1
@@ -65,3 +65,26 @@ stats_ref = gate.read_stat_file(paths.gate_output / "stat.txt")
 # is_ok = gate.assert_stats(stats, stats_ref, tolerance=0.03)
 
 # gate.test_ok(is_ok)
+
+try:
+    import pyvista
+except:
+    print(
+        "The module pyvista is not installed to be able to visualize vrml files. Execute:"
+    )
+    print("pip install pyvista")
+pl = pyvista.Plotter()
+pl.import_vrml(ui.visu_filename)
+axes = pyvista.Axes()
+axes.axes_actor.total_length = 1000  # mm
+axes.axes_actor.shaft_type = axes.axes_actor.ShaftType.CYLINDER
+axes.axes_actor.cylinder_radius = 0.01
+axes.axes_actor.x_axis_shaft_properties.color = (1, 0, 0)
+axes.axes_actor.x_axis_tip_properties.color = (1, 0, 0)
+axes.axes_actor.y_axis_shaft_properties.color = (0, 1, 0)
+axes.axes_actor.y_axis_tip_properties.color = (0, 1, 0)
+axes.axes_actor.z_axis_shaft_properties.color = (0, 0, 1)
+axes.axes_actor.z_axis_tip_properties.color = (0, 0, 1)
+pl.add_actor(axes.axes_actor)
+# pl.add_axes_at_origin()
+pl.show()


### PR DESCRIPTION
The axis in the origin could have the wrong size compare to the simulation Use the axis in the corner and let the user to use its own axis vizualisation with the example