### PR TITLE
Randomize tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,7 +272,11 @@ jobs:
               path=`opengate_tests_utils -p libG4geometry`
               export LD_PRELOAD=${path}:${LD_PRELOAD}
           fi
-          OutputTest=$(opengate_tests)
+          if [ $Pr_Number == "" ]; then
+              OutputTest=$(opengate_tests)
+          else
+              OutputTest=$(opengate_tests -r)
+          fi
           echo "$OutputTest"
           OutputTest=$(echo "$OutputTest" | tail -1)
           if [ "$OutputTest" != "True" ]; then
@@ -280,3 +284,5 @@ jobs:
           else
               exit 0
           fi
+      env:
+        Pr_Number: ${{ github.event.number }}

--- a/opengate/bin/opengate_tests
+++ b/opengate/bin/opengate_tests
@@ -9,13 +9,21 @@ from opengate_core.testsDataSetup import *
 import pathlib
 import click
 import hashlib
+import random
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option("--test_id", "-i", default="all", help="Start test from this number")
-def go(test_id):
+@click.option(
+    "--random_tests",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Start the last 10 tests and 1/4 of the others randomly",
+)
+def go(test_id, random_tests):
     pathFile = pathlib.Path(__file__).parent.resolve()
     if "src" in os.listdir(pathFile):
         mypath = os.path.join(pathFile, "../tests/src")
@@ -88,6 +96,11 @@ def go(test_id):
             else:
                 print(f"Ignoring: {f:<40} (< {test_id}) ")
         files = files_new
+    elif random_tests:
+        files_new = files[-10:]
+        prob = 0.25
+        files = files_new + random.sample(files[:-10], int(prob * (len(files) - 10)))
+        files = sorted(files)
 
     print(f"Running {len(files)} tests")
     print(f"-" * 70)

--- a/opengate/tests/src/test015_iec_phantom_2.py
+++ b/opengate/tests/src/test015_iec_phantom_2.py
@@ -5,8 +5,16 @@ import opengate as gate
 import opengate.contrib.phantom_nema_iec_body as gate_iec
 import pathlib
 import os
+import subprocess
 
 pathFile = pathlib.Path(__file__).parent.resolve()
+
+# To compare output this takes the output of test015_iec_phantom_1.py
+# If the output of test015_iec_phantom_1.py does not exist (eg: random test), create it
+if not os.path.isfile(pathFile / ".." / "output" / "stats_test015_iec_phantom_1.txt"):
+    print("---------- Begin of test015_iec_phantom_1.py ----------")
+    subprocess.call(["python", pathFile / "test015_iec_phantom_1.py"])
+    print("----------- End of test015_iec_phantom_1.py -----------")
 
 # global log level
 # create the simulation

--- a/opengate/tests/src/test019_linac_phsp_source.py
+++ b/opengate/tests/src/test019_linac_phsp_source.py
@@ -5,10 +5,19 @@ import opengate as gate
 from scipy.spatial.transform import Rotation
 import gatetools.phsp as phsp
 import matplotlib.pyplot as plt
+import os
+import subprocess
 
 paths = gate.get_default_test_paths(
     __file__, "gate_test019_linac_phsp", output_folder="test019"
 )
+
+# This test need the output of test019_linac_phsp.py
+# If the output of test019_linac_phsp.py does not exist (eg: random test), create it
+if not os.path.isfile(paths.output / "test019_hits.root"):
+    print("---------- Begin of test019_linac_phsp.py ----------")
+    subprocess.call(["python", paths.current / "test019_linac_phsp.py"])
+    print("----------- End of test019_linac_phsp.py -----------")
 
 # create the simulation
 sim = gate.Simulation()

--- a/opengate/tests/src/test040_gan_phsp_pet_gan.py
+++ b/opengate/tests/src/test040_gan_phsp_pet_gan.py
@@ -8,9 +8,18 @@ import uproot
 import numpy as np
 import matplotlib.pyplot as plt
 import os
+import subprocess
 
 paths = gate.get_default_test_paths(__file__, "")
 paths.output_ref = paths.output_ref / "test040_ref"
+
+# The test needs the output of test040_gan_phsp_pet_aref.py
+# If the output of test040_gan_phsp_pet_aref.py does not exist (eg: random test), create it
+if not os.path.isfile(paths.output / "test040_gan_phsp.root"):
+    print("---------- Begin of test040_gan_phsp_pet_aref.py ----------")
+    subprocess.call(["python", paths.current / "test040_gan_phsp_pet_aref.py"])
+    print("----------- End of test040_gan_phsp_pet_aref.py -----------")
+
 
 # create the simulation
 sim = gate.Simulation()


### PR DESCRIPTION
For PR, run the lasts 10 examples and 30% of the others tests randomly to reduce waiting time
Not applicable for tag CI and for schedule CI to be sure all tests are run