### PR TITLE
Upgraded phs source

### DIFF
--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
@@ -15,7 +15,8 @@
 
 namespace py = pybind11;
 
-class GatePhaseSpaceSource : public GateVSource {
+class GatePhaseSpaceSource : public GateVSource
+{
 
 public:
   // signature of the callback function in Python
@@ -37,9 +38,13 @@ public:
 
   void GenerateOnePrimary(G4Event *event, double current_simulation_time);
 
+  // void AddOnePrimaryVertex(G4Event *event, const G4ThreeVector &position,
+  //                          const G4ThreeVector &momentum_direction,
+  //                          double energy, double time, double w) const;
+
   void AddOnePrimaryVertex(G4Event *event, const G4ThreeVector &position,
                            const G4ThreeVector &momentum_direction,
-                           double energy, double time, double w) const;
+                           double energy, double time, double w);
 
   void SetGeneratorFunction(ParticleGeneratorType &f);
 
@@ -48,13 +53,18 @@ public:
   void GenerateBatchOfParticles();
 
   G4ParticleDefinition *fParticleDefinition;
+  G4ParticleTable *fParticleTable;
   double fCharge;
   double fMass;
   bool fGlobalFag;
+  bool fUseParticleTypeFromFile;
 
   unsigned long fMaxN;
   long fNumberOfGeneratedEvents;
   size_t fCurrentBatchSize;
+
+  std::vector<int> fPDGCode;
+  std::vector<string> fParticleName;
 
   std::vector<double> fPositionX;
   std::vector<double> fPositionY;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeList.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeList.cpp
@@ -23,7 +23,8 @@
 #define FILLF [=](GateVDigiAttribute * att, G4Step * step)
 #define FILLFS [=](GateVDigiAttribute * att, G4Step *)
 
-void GateDigiAttributeManager::InitializeAllDigiAttributes() {
+void GateDigiAttributeManager::InitializeAllDigiAttributes()
+{
 
   // -----------------------------------------------------
   // Energy
@@ -160,6 +161,12 @@ void GateDigiAttributeManager::InitializeAllDigiAttributes() {
         att->FillUValue(uid);
       });
   DefineDigiAttribute(
+      "PDGCode", 'I', FILLF {
+        att->FillIValue(
+            step->GetTrack()->GetParticleDefinition()->GetPDGEncoding());
+      });
+
+  DefineDigiAttribute(
       "HitUniqueVolumeID", 'U', FILLF {
         /*
           Like in old GATE (see GateCrystalSD.cc).
@@ -169,10 +176,13 @@ void GateDigiAttributeManager::InitializeAllDigiAttributes() {
         auto *m = GateUniqueVolumeIDManager::GetInstance();
         if (step->GetPostStepPoint()
                 ->GetProcessDefinedStep()
-                ->GetProcessName() == "Transportation") {
+                ->GetProcessName() == "Transportation")
+        {
           auto uid = m->GetVolumeID(step->GetPreStepPoint()->GetTouchable());
           att->FillUValue(uid);
-        } else {
+        }
+        else
+        {
           auto uid = m->GetVolumeID(step->GetPostStepPoint()->GetTouchable());
           att->FillUValue(uid);
         }

--- a/core/opengate_core/opengate_lib/pyGatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/pyGatePhaseSpaceSource.cpp
@@ -13,24 +13,28 @@ namespace py = pybind11;
 
 #include "GatePhaseSpaceSource.h"
 
-void init_GatePhaseSpaceSource(py::module &m) {
+void init_GatePhaseSpaceSource(py::module &m)
+{
 
-  py::class_<GatePhaseSpaceSource, GateVSource>(m, "GatePhaseSpaceSource")
-      .def(py::init())
-      .def("InitializeUserInfo", &GatePhaseSpaceSource::InitializeUserInfo)
-      .def("SetGeneratorFunction", &GatePhaseSpaceSource::SetGeneratorFunction)
-      //.def("SetGeneratorInfo", &GatePhaseSpaceSource::SetGeneratorInfo)
+   py::class_<GatePhaseSpaceSource, GateVSource>(m, "GatePhaseSpaceSource")
+       .def(py::init())
+       .def("InitializeUserInfo", &GatePhaseSpaceSource::InitializeUserInfo)
+       .def("SetGeneratorFunction", &GatePhaseSpaceSource::SetGeneratorFunction)
+       //.def("SetGeneratorInfo", &GatePhaseSpaceSource::SetGeneratorInfo)
 
-      .def_readwrite("fPositionX", &GatePhaseSpaceSource::fPositionX)
-      .def_readwrite("fPositionY", &GatePhaseSpaceSource::fPositionY)
-      .def_readwrite("fPositionZ", &GatePhaseSpaceSource::fPositionZ)
+       .def_readwrite("fPDGCode", &GatePhaseSpaceSource::fPDGCode)
+       .def_readwrite("fParticleName", &GatePhaseSpaceSource::fParticleName)
 
-      .def_readwrite("fDirectionX", &GatePhaseSpaceSource::fDirectionX)
-      .def_readwrite("fDirectionY", &GatePhaseSpaceSource::fDirectionY)
-      .def_readwrite("fDirectionZ", &GatePhaseSpaceSource::fDirectionZ)
+       .def_readwrite("fPositionX", &GatePhaseSpaceSource::fPositionX)
+       .def_readwrite("fPositionY", &GatePhaseSpaceSource::fPositionY)
+       .def_readwrite("fPositionZ", &GatePhaseSpaceSource::fPositionZ)
 
-      .def_readwrite("fEnergy", &GatePhaseSpaceSource::fEnergy)
-      .def_readwrite("fWeight", &GatePhaseSpaceSource::fWeight)
-      // .def_readwrite("fTime", &GatePhaseSpaceSource::fTime)
-      ;
+       .def_readwrite("fDirectionX", &GatePhaseSpaceSource::fDirectionX)
+       .def_readwrite("fDirectionY", &GatePhaseSpaceSource::fDirectionY)
+       .def_readwrite("fDirectionZ", &GatePhaseSpaceSource::fDirectionZ)
+
+       .def_readwrite("fEnergy", &GatePhaseSpaceSource::fEnergy)
+       .def_readwrite("fWeight", &GatePhaseSpaceSource::fWeight)
+       // .def_readwrite("fTime", &GatePhaseSpaceSource::fTime)
+       ;
 }

--- a/opengate/source/PhaseSpaceSource.py
+++ b/opengate/source/PhaseSpaceSource.py
@@ -1,6 +1,8 @@
 from .SourceBase import *
 import opengate_core as g4
 from .PhaseSpaceSourceGenerator import *
+from scipy.spatial.transform import Rotation
+from box import Box
 
 
 class PhaseSpaceSource(SourceBase):
@@ -27,7 +29,10 @@ class PhaseSpaceSource(SourceBase):
         # initial user info
         user_info.phsp_file = None
         user_info.n = 1
-        user_info.particle = None  # FIXME later as key
+        user_info.particle = ""  # FIXME later as key
+        # if a particle name is supplied, the particle type is set to it
+        # otherwise, information from the phase space is used
+
         # if global flag is True, the position/direction are global, not
         # in the coordinate system of the mother volume.
         # if the global flag is False, the position/direction are relative
@@ -45,6 +50,16 @@ class PhaseSpaceSource(SourceBase):
         user_info.direction_key_z = None
         user_info.energy_key = "KineticEnergy"
         user_info.weight_key = "Weight"
+        user_info.particle_name_key = "ParticleName"
+        user_info.PDGCode_key = "PDGCode"
+        # change position and direction of the source
+        # position is relative to the stored coordinates
+        # direction is a rotation of the stored direction
+        user_info.override_position = False
+        user_info.override_direction = False
+        user_info.position = Box()
+        user_info.position.translation = [0, 0, 0]
+        user_info.position.rotation = Rotation.identity().as_matrix()
         # user_info.time_key = None # FIXME later
 
     def __del__(self):
@@ -59,8 +74,8 @@ class PhaseSpaceSource(SourceBase):
 
     def initialize(self, run_timing_intervals):
         # initialize the mother class generic source
-        gate.SourceBase.initialize(self, run_timing_intervals)
 
+        gate.SourceBase.initialize(self, run_timing_intervals)
         if self.simulation.use_multithread:
             gate.fatal(
                 f"Cannot use phsp source in MT mode for the moment"

--- a/opengate/source/PhaseSpaceSource.py
+++ b/opengate/source/PhaseSpaceSource.py
@@ -27,7 +27,7 @@ class PhaseSpaceSource(SourceBase):
         # initial user info
         user_info.phsp_file = None
         user_info.n = 1
-        user_info.particle = "gamma"  # FIXME later as key
+        user_info.particle = None  # FIXME later as key
         # if global flag is True, the position/direction are global, not
         # in the coordinate system of the mother volume.
         # if the global flag is False, the position/direction are relative

--- a/opengate/source/PhaseSpaceSourceGenerator.py
+++ b/opengate/source/PhaseSpaceSourceGenerator.py
@@ -75,5 +75,9 @@ class PhaseSpaceSourceGenerator:
         source.fDirectionY = batch[ui.direction_key_y]
         source.fDirectionZ = batch[ui.direction_key_z]
 
+        # source.fParticleName = batch[ui.particle]
+        # PDGCode = gate.ParticleInfo.instance().get_pdg_code(source.fParticleName)
+        # source.fPDGCode = batch[ui.PDGCode]
+
         source.fEnergy = batch[ui.energy_key]
         source.fWeight = batch[ui.weight_key]

--- a/opengate/source/PhaseSpaceSourceGenerator.py
+++ b/opengate/source/PhaseSpaceSourceGenerator.py
@@ -1,6 +1,8 @@
 import threading
 import uproot
 import opengate as gate
+from scipy.spatial.transform import Rotation
+import numpy as np
 
 
 class PhaseSpaceSourceGenerator:
@@ -64,20 +66,84 @@ class PhaseSpaceSourceGenerator:
             )
             self.iter = self.root_file.iterate(step_size=self.user_info.batch_size)
             batch = next(self.iter)
+        # print("batch", batch)
+        # print("type of batch", type(batch))
+        # print("type of batch[0]", type(batch[0]))
+        # print("batch fields", batch.fields)
 
         # copy to cpp
         ui = self.user_info
-        source.fPositionX = batch[ui.position_key_x]
-        source.fPositionY = batch[ui.position_key_y]
-        source.fPositionZ = batch[ui.position_key_z]
 
-        source.fDirectionX = batch[ui.direction_key_x]
-        source.fDirectionY = batch[ui.direction_key_y]
-        source.fDirectionZ = batch[ui.direction_key_z]
+        # # check if the keys for particle name or PDGCode are in the root file
 
-        # source.fParticleName = batch[ui.particle]
-        # PDGCode = gate.ParticleInfo.instance().get_pdg_code(source.fParticleName)
-        # source.fPDGCode = batch[ui.PDGCode]
+        if ui.PDGCode_key in batch.fields:
+            source.fPDGCode = batch[ui.PDGCode_key]
+            # print("source.fPDGCode", source.fPDGCode)
+            # print("type of source.fPDGCode", type(source.fPDGCode))
+            # print("source.fPDGCode in there")
+        else:
+            source.fPDGCode = np.zeros(len(batch), dtype=int)
+            # print("type of source.fPDGCode", type(source.fPDGCode))
+            # print("source.fPDGCode", source.fPDGCode)
+        if ui.particle_name_key in batch.fields:
+            # print("source.fParticleName in there")
+            source.fParticleName = batch[ui.particle_name_key]
+        else:
+            source.fParticleName = [""] * len(batch)
 
+        # if neither particle name, nor PDGCode are in the root file,
+        # nor the particle type was set, raise an error
+        if (
+            ui.particle == ""
+            and ui.PDGCode_key not in batch.fields
+            and ui.particle_name_key not in batch.fields
+        ):
+            print(
+                "ERROR: PhaseSpaceSource: No particle name or PDGCode key in the root file, "
+                "and no particle type was set. "
+                "Please set the particle type or add the particle name or PDGCode key in the root file. Aborting."
+            )
+            exit(-1)
+
+        # change position and direction of the source
+
+        # if override_position is set to True, the position
+        # supplied will be added to the root file position
+        if ui.override_position:
+            source.fPositionX = batch[ui.position_key_x] + ui.position.translation[0]
+            source.fPositionY = batch[ui.position_key_y] + ui.position.translation[1]
+            source.fPositionZ = batch[ui.position_key_z] + ui.position.translation[2]
+        else:
+            source.fPositionX = batch[ui.position_key_x]
+            source.fPositionY = batch[ui.position_key_y]
+            source.fPositionZ = batch[ui.position_key_z]
+
+        # direction is a rotation of the stored direction
+        # if override_direction is set to True, the direction
+        # in the root file will be rotated based on the supplied rotation matrix
+        if ui.override_direction:
+            # create point vectors
+            points = np.column_stack(
+                (
+                    batch[ui.direction_key_x],
+                    batch[ui.direction_key_y],
+                    batch[ui.direction_key_z],
+                )
+            )
+            # create rotation matrix
+            r = Rotation.from_matrix(ui.position.rotation)
+            # rotate vector with rotation matrix
+            points = r.apply(points)
+            # assign rotated vector to direction
+            # source.fDirectionX = points[:, 0]
+            # source.fDirectionY = points[:, 1]
+            # source.fDirectionZ = points[:, 2]
+            source.fDirectionX, source.fDirectionY, source.fDirectionZ = points.T
+        else:
+            source.fDirectionX = batch[ui.direction_key_x]
+            source.fDirectionY = batch[ui.direction_key_y]
+            source.fDirectionZ = batch[ui.direction_key_z]
+
+        # pass energy and weight
         source.fEnergy = batch[ui.energy_key]
         source.fWeight = batch[ui.weight_key]

--- a/opengate/tests/src/test019_linac_phsp_PDGCode.py
+++ b/opengate/tests/src/test019_linac_phsp_PDGCode.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# ~ import test019_linac_phsp_helpers as t
+from test019_linac_phsp_helpers import *
+
+
+sim = init_test019(1)
+
+
+# start simulation
+sim.run()
+
+# print results
+stats = sim.output.get_actor("Stats")
+print(stats)
+
+h = sim.output.get_actor("PhaseSpace")
+print(h)
+
+# check the phsp tree if PDGCode is in there
+# PDGCode of gamma is 22
+print()
+fn2 = paths.output / "test019_hits.root"
+print("Checked Tree : ", fn2)
+data, keys, m = phsp.load(fn2)
+print(data, keys)
+# find PDGCode
+if "PDGCode" in keys:
+    print("PDGCode key found")
+    # all particles should be gamma, we check only first one
+    # PDGCode of gamma is 22
+    if data[0,keys.index("PDGCode")] == 22:
+        is_ok = True
+        # ~ print("index: ",keys.index("PDGCode"))
+    else:
+        is_ok = False
+    
+else:
+    is_ok = False
+    
+
+# this is the end, my friend
+gate.test_ok(is_ok)

--- a/opengate/tests/src/test019_linac_phsp_PDGCode.py
+++ b/opengate/tests/src/test019_linac_phsp_PDGCode.py
@@ -4,7 +4,6 @@
 # ~ import test019_linac_phsp_helpers as t
 from test019_linac_phsp_helpers import *
 
-
 sim = init_test019(1)
 
 
@@ -30,15 +29,15 @@ if "PDGCode" in keys:
     print("PDGCode key found")
     # all particles should be gamma, we check only first one
     # PDGCode of gamma is 22
-    if data[0,keys.index("PDGCode")] == 22:
+    if data[0, keys.index("PDGCode")] == 22:
         is_ok = True
         # ~ print("index: ",keys.index("PDGCode"))
     else:
         is_ok = False
-    
+
 else:
     is_ok = False
-    
+
 
 # this is the end, my friend
 gate.test_ok(is_ok)

--- a/opengate/tests/src/test019_linac_phsp_helpers.py
+++ b/opengate/tests/src/test019_linac_phsp_helpers.py
@@ -85,6 +85,7 @@ def init_test019(nt):
         "GlobalTime",
         "LocalTime",
         "EventPosition",
+        "PDGCode",
     ]
     ta2.output = paths.output / "test019_hits.root"
     ta2.debug = False

--- a/opengate/tests/src/test037_digi_attributes_list.py
+++ b/opengate/tests/src/test037_digi_attributes_list.py
@@ -19,7 +19,7 @@ for a in nlist:
     att = am.GetDigiAttributeByName(a)
     print(att.GetDigiAttributeName(), att.GetDigiAttributeType())
 
-n = 39
+n = 40
 is_ok = len(nlist) == n
 
 gate.print_test(is_ok, f"Done for {n} attributes.")

--- a/opengate/tests/src/test060_PhsSource_ParticleName_direct.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_direct.py
@@ -1,0 +1,42 @@
+import test060_PhsSource_helpers as t
+import opengate as gate
+
+
+paths = gate.get_default_test_paths(
+    __file__, "test060_PhsSource_ParticleName_direct", output_folder="test060"
+)
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def main():
+    print("create reference PhS file")
+    t.create_test_Phs(
+        particle="proton",
+        phs_name=paths.output / "test_proton_offset",
+        number_of_particles=1,
+        translation=[10 * cm, 5 * cm, 0 * mm],
+    )
+    print("Testing PhS source particle name")
+    t.test_source_name(
+        source_file_name=paths.output / "test_proton_offset.root",
+        phs_file_name_out=paths.output / "test_source_electron.root",
+    )
+    is_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_electron.root",
+        key="ParticleName",
+        ref_value="e-",
+    )
+    # this is the end, my friend
+    gate.test_ok(is_ok)
+
+
+if __name__ == "__main__":
+    main()

--- a/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_PDGCode.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_PDGCode.py
@@ -1,0 +1,43 @@
+import test060_PhsSource_helpers as t
+import opengate as gate
+
+
+paths = gate.get_default_test_paths(
+    __file__, "test060_PhsSource_ParticleName_direct", output_folder="test060"
+)
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def main():
+    print("create reference PhS file")
+    t.create_test_Phs(
+        particle="proton",
+        phs_name=paths.output / "test_proton_offset",
+        number_of_particles=1,
+        translation=[10 * cm, 5 * cm, 0 * mm],
+    )
+    print("Testing PhS source particle name")
+    t.test_source_particleInfo_from_Phs(
+        source_file_name=paths.output / "test_proton_offset.root",
+        phs_file_name_out=paths.output / "test_source_PDG_proton.root",
+    )
+    is_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_PDG_proton.root",
+        key="ParticleName",
+        ref_value="proton",
+    )
+
+    # this is the end, my friend
+    gate.test_ok(is_ok)
+
+
+if __name__ == "__main__":
+    main()

--- a/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_ParticleName.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_ParticleName.py
@@ -1,0 +1,43 @@
+import test060_PhsSource_helpers as t
+import opengate as gate
+
+
+paths = gate.get_default_test_paths(
+    __file__, "test060_PhsSource_ParticleName_direct", output_folder="test060"
+)
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def main():
+    print("create reference PhS file")
+    t.create_test_Phs(
+        particle="proton",
+        phs_name=paths.output / "test_proton_offset",
+        number_of_particles=1,
+        translation=[10 * cm, 5 * cm, 0 * mm],
+    )
+    print("Testing PhS source particle name")
+    t.test_source_particleInfo_from_Phs(
+        source_file_name=paths.output / "test_proton_offset_ParticleName.root",
+        phs_file_name_out=paths.output / "test_source_PDG_proton.root",
+    )
+    is_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_PDG_proton.root",
+        key="ParticleName",
+        ref_value="proton",
+    )
+
+    # this is the end, my friend
+    gate.test_ok(is_ok)
+
+
+if __name__ == "__main__":
+    main()

--- a/opengate/tests/src/test060_PhsSource_helpers.py
+++ b/opengate/tests/src/test060_PhsSource_helpers.py
@@ -1,0 +1,420 @@
+import opengate as gate
+
+# import numpy as np
+# import matplotlib.pyplot as plot
+from scipy.spatial.transform import Rotation
+import gatetools.phsp as phsp
+import os
+
+
+# paths = gate.get_default_test_paths(
+#     __file__, "gate_test019_linac_phsp", output_folder="test019"
+# )
+# paths = {output: "output"}
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def create_test_Phs(
+    particle="proton",
+    phs_name="output/test_proton.root",
+    number_of_particles=1,
+    translation=[0 * mm, 0 * mm, 0 * mm],
+):
+    # create the simulation
+    sim = gate.Simulation()
+
+    # main options
+    ui = sim.user_info
+    ui.g4_verbose = False
+    # ui.visu = True
+    ui.visu_type = "vrml"
+    ui.check_volumes_overlap = False
+    # ui.running_verbose_level = gate.EVENT
+    ui.number_of_threads = 1
+    ui.random_seed = "auto"
+
+    # units
+    m = gate.g4_units("m")
+    mm = gate.g4_units("mm")
+    cm = gate.g4_units("cm")
+    nm = gate.g4_units("nm")
+    Bq = gate.g4_units("Bq")
+    MeV = gate.g4_units("MeV")
+
+    ##########################################################################################
+    # geometry
+    ##########################################################################################
+    #  adapt world size
+    world = sim.world
+    world.size = [1 * m, 1 * m, 1 * m]
+    world.material = "G4_Galactic"
+
+    # virtual plane for phase space
+    plane = sim.add_volume("Tubs", "phase_space_plane")
+    # plane.material = "G4_AIR"
+    plane.material = "G4_Galactic"
+    plane.rmin = 0
+    plane.rmax = 30 * cm
+    plane.dz = 1 * nm  # half height
+    # plane.rotation = Rotation.from_euler("xy", [180, 30], degrees=True).as_matrix()
+    # plane.translation = [0 * mm, 0 * mm, 0 * mm]
+    plane.translation = translation
+
+    plane.color = [1, 0, 0, 1]  # red
+
+    ##########################################################################################
+    # Actors
+    ##########################################################################################
+    # Split the joined path into the directory path and filename
+    directory_path, filename = os.path.split(phs_name)
+    # Extract the base filename and extension
+    base_filename, extension = os.path.splitext(filename)
+    new_extension = ".root"
+
+    # PhaseSpace Actor
+    ta1 = sim.add_actor("PhaseSpaceActor", "PhaseSpace1")
+    ta1.mother = plane.name
+    ta1.attributes = [
+        "KineticEnergy",
+        "Weight",
+        "PrePosition",
+        "PrePositionLocal",
+        "ParticleName",
+        "PreDirection",
+        "PreDirectionLocal",
+        "PDGCode",
+    ]
+    new_joined_path = os.path.join(directory_path, base_filename + new_extension)
+    ta1.output = new_joined_path
+    ta1.debug = False
+    f = sim.add_filter("ParticleFilter", "f")
+    f.particle = particle
+    ta1.filters.append(f)
+
+    # PhaseSpace Actor
+    ta2 = sim.add_actor("PhaseSpaceActor", "PhaseSpace2")
+    ta2.mother = plane.name
+    ta2.attributes = [
+        "KineticEnergy",
+        "Weight",
+        "PrePosition",
+        "PrePositionLocal",
+        "PreDirection",
+        "PreDirectionLocal",
+    ]
+    new_joined_path = os.path.join(
+        directory_path, base_filename + "_noParticleInfo" + new_extension
+    )
+    ta2.output = new_joined_path
+    ta2.debug = False
+    ta2.filters.append(f)
+
+    # PhaseSpace Actor
+    ta3 = sim.add_actor("PhaseSpaceActor", "PhaseSpace3")
+    ta3.mother = plane.name
+    ta3.attributes = [
+        "KineticEnergy",
+        "Weight",
+        "PrePosition",
+        "PrePositionLocal",
+        "PreDirection",
+        "PreDirectionLocal",
+        "PDGCode",
+    ]
+    new_joined_path = os.path.join(
+        directory_path, base_filename + "_PDGCode" + new_extension
+    )
+    ta3.output = new_joined_path
+    ta3.debug = False
+    ta3.filters.append(f)
+
+    # PhaseSpace Actor
+    ta4 = sim.add_actor("PhaseSpaceActor", "PhaseSpace4")
+    ta4.mother = plane.name
+    ta4.attributes = [
+        "KineticEnergy",
+        "Weight",
+        "PrePosition",
+        "PrePositionLocal",
+        "PreDirection",
+        "PreDirectionLocal",
+        "ParticleName",
+    ]
+    new_joined_path = os.path.join(
+        directory_path, base_filename + "_ParticleName" + new_extension
+    )
+    ta4.output = new_joined_path
+    ta4.debug = False
+    ta4.filters.append(f)
+
+    phys = sim.get_physics_user_info()
+    # ~ phys.physics_list_name = "FTFP_BERT"
+    phys.physics_list_name = "QGSP_BIC_EMZ"
+
+    ##########################################################################################
+    #  Source
+    ##########################################################################################
+    source = sim.add_source("GenericSource", "particle_source")
+    source.mother = "world"
+    # source.particle = "ion 6 12"  # Carbon ions
+    source.particle = "proton"
+    source.position.type = "point"
+    source.direction.type = "momentum"
+    source.direction.momentum = [0, 0, 1]
+    source.position.translation = [0 * cm, 0 * cm, -0.1 * cm]
+    source.energy.type = "mono"
+    source.energy.mono = 150 * MeV
+    source.n = number_of_particles
+
+    # output = sim.run()
+    output = sim.start(start_new_process=True)
+
+
+def create_PhS_withoutSource(
+    phs_name="output/test_proton.root",
+):
+    # create the simulation
+    sim = gate.Simulation()
+
+    # main options
+    ui = sim.user_info
+    ui.g4_verbose = False
+    # ui.visu = True
+    ui.visu_type = "vrml"
+    ui.check_volumes_overlap = False
+    # ui.running_verbose_level = gate.EVENT
+    ui.number_of_threads = 1
+    ui.random_seed = "auto"
+
+    # units
+    m = gate.g4_units("m")
+    mm = gate.g4_units("mm")
+    cm = gate.g4_units("cm")
+    nm = gate.g4_units("nm")
+    Bq = gate.g4_units("Bq")
+    MeV = gate.g4_units("MeV")
+    deg: float = gate.g4_units("deg")
+
+    ##########################################################################################
+    # geometry
+    ##########################################################################################
+    #  adapt world size
+    world = sim.world
+    world.size = [1 * m, 1 * m, 1 * m]
+    world.material = "G4_Galactic"
+    print(world.name)
+
+    # virtual plane for phase space
+    plane = sim.add_volume("Tubs", "phase_space_plane")
+    # plane.material = "G4_AIR"
+    plane.material = "G4_Galactic"
+    plane.rmin = 0
+    plane.rmax = 30 * cm
+    plane.dz = 1 * nm  # half height
+    # plane.rotation = Rotation.from_euler("xy", [180, 30], degrees=True).as_matrix()
+    plane.translation = [0 * mm, 0 * mm, 0 * mm]
+    # plane.translation = translation
+
+    plane.color = [1, 0, 0, 1]  # red
+
+    ##########################################################################################
+    # Actors
+    ##########################################################################################
+
+    # PhaseSpace Actor
+    ta1 = sim.add_actor("PhaseSpaceActor", "PhaseSpace")
+    ta1.mother = plane.name
+    ta1.attributes = [
+        "KineticEnergy",
+        "Weight",
+        "PrePosition",
+        "PrePositionLocal",
+        "ParticleName",
+        "PreDirection",
+        "PreDirectionLocal",
+        "PDGCode",
+    ]
+    ta1.output = phs_name
+    ta1.debug = False
+
+    phys = sim.get_physics_user_info()
+    # ~ phys.physics_list_name = "FTFP_BERT"
+    phys.physics_list_name = "QGSP_BIC_EMZ"
+
+    # ##########################################################################################
+    # #  Source
+    # ##########################################################################################
+    # # phsp source
+    # source = sim.add_source("PhaseSpaceSource", "phsp_source_global")
+    # source.mother = world.name
+    # source.phsp_file = source_name
+    # source.position_key = "PrePosition"
+    # source.direction_key = "PreDirection"
+    # source.global_flag = True
+    # source.particle = particle
+    # source.batch_size = 3000
+    # source.n = number_of_particles / ui.number_of_threads
+    # # source.position.translation = [0 * cm, 0 * cm, -35 * cm]
+
+    # output = sim.run()
+    # output = sim.start()
+    # output = sim.start(start_new_process=True)
+    return sim
+
+
+def test_source_name(
+    source_file_name="output/test_proton_offset.root",
+    phs_file_name_out="output/output/test_source_electron.root",
+) -> None:
+    sim = create_PhS_withoutSource(
+        phs_name=phs_file_name_out,
+    )
+    particle = "e-"
+    number_of_particles = 1
+    ##########################################################################################
+    #  Source
+    ##########################################################################################
+    # phsp source
+    source = sim.add_source("PhaseSpaceSource", "phsp_source_global")
+    source.mother = "world"
+    source.phsp_file = source_file_name
+    source.position_key = "PrePositionLocal"
+    source.direction_key = "PreDirectionLocal"
+    source.global_flag = True
+    source.particle = particle
+    source.batch_size = 3000
+    source.n = number_of_particles
+    # source.position.translation = [0 * cm, 0 * cm, -35 * cm]
+
+    output = sim.start()
+
+
+def test_source_particleInfo_from_Phs(
+    source_file_name="output/test_proton_offset.root",
+    phs_file_name_out="output/test_source_PDG_proton.root",
+) -> None:
+    sim = create_PhS_withoutSource(
+        phs_name=phs_file_name_out,
+    )
+    number_of_particles = 1
+    ##########################################################################################
+    #  Source
+    ##########################################################################################
+    # phsp source
+    source = sim.add_source("PhaseSpaceSource", "phsp_source_global")
+    source.mother = "world"
+    source.phsp_file = source_file_name
+    source.particle = ""
+    source.position_key = "PrePositionLocal"
+    source.direction_key = "PreDirectionLocal"
+    source.global_flag = True
+    source.batch_size = 3000
+    source.n = number_of_particles
+    # source.position.translation = [0 * cm, 0 * cm, -35 * cm]
+
+    output = sim.start()
+
+
+def test_source_translation(
+    source_file_name="output/test_proton_offset.root",
+    phs_file_name_out="output/output/test_source_electron.root",
+) -> None:
+    sim = create_PhS_withoutSource(
+        phs_name=phs_file_name_out,
+    )
+    number_of_particles = 1
+    ##########################################################################################
+    #  Source
+    ##########################################################################################
+    # phsp source
+    source = sim.add_source("PhaseSpaceSource", "phsp_source_global")
+    source.mother = "world"
+    source.phsp_file = source_file_name
+    source.position_key = "PrePosition"
+    source.direction_key = "PreDirection"
+    source.global_flag = True
+    source.particle = ""
+    source.batch_size = 3000
+    source.n = number_of_particles
+    source.override_position = True
+    source.position.translation = [3 * cm, 0 * cm, 0 * cm]
+    print(source)
+
+    output = sim.start()
+
+
+def test_source_rotation(
+    source_file_name="output/test_proton_offset.root",
+    phs_file_name_out="output/output/test_source_electron.root",
+) -> None:
+    sim = create_PhS_withoutSource(
+        phs_name=phs_file_name_out,
+    )
+    number_of_particles = 1
+    ##########################################################################################
+    #  Source
+    ##########################################################################################
+    # phsp source
+    source = sim.add_source("PhaseSpaceSource", "phsp_source_global")
+    source.mother = "world"
+    source.phsp_file = source_file_name
+    source.position_key = "PrePosition"
+    source.direction_key = "PreDirection"
+    source.global_flag = True
+    source.particle = ""
+    source.batch_size = 3000
+    source.n = number_of_particles
+    # source.override_position = True
+    # source.position.translation = [3 * cm, 1 * cm, 0 * cm]
+    source.override_direction = True
+    # rotation = Rotation.from_euler("zyx", [30, 20, 10], degrees=True)
+    rotation = Rotation.from_euler("x", [30], degrees=True)
+    source.position.rotation = rotation.as_matrix()
+    print(source)
+
+    output = sim.start()
+
+
+def get_first_entry_of_key(
+    file_name_root="output/test_source_electron.root", key="ParticleName"
+) -> None:
+    # read root file
+    data_ref, keys_ref, m_ref = phsp.load(file_name_root)
+    # print(data_ref)
+    # print(keys_ref)
+    index = keys_ref.index(key)
+    # print(index)
+    # print(data_ref[index][0])
+    return data_ref[0][index]
+
+
+def check_value_from_root_file(
+    file_name_root="output/test_source_electron.root",
+    key="ParticleName",
+    ref_value="e-",
+):
+    # read root file
+    value = get_first_entry_of_key(file_name_root=file_name_root, key=key)
+    if (type(ref_value) != str) and (type(value) != str):
+        is_ok = gate.check_diff_abs(
+            float(value), float(ref_value), tolerance=1e-6, txt=key
+        )
+    # gate.check_diff_abs(float(value), float(ref_value), tolerance=1e-6, txt=key)
+    else:
+        if value == ref_value:
+            # print("Is correct")
+            is_ok = True
+        else:
+            # print("Is not correct")
+            is_ok = False
+    # print("ref_value: ", ref_value)
+    # print("value: ", value)
+    return is_ok

--- a/opengate/tests/src/test060_PhsSource_rotation.py
+++ b/opengate/tests/src/test060_PhsSource_rotation.py
@@ -1,0 +1,59 @@
+import test060_PhsSource_helpers as t
+import opengate as gate
+
+
+paths = gate.get_default_test_paths(
+    __file__, "test060_PhsSource_ParticleName_direct", output_folder="test060"
+)
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def main():
+    print("create reference PhS file")
+    t.create_test_Phs(
+        particle="proton",
+        phs_name=paths.output / "test_proton_offset",
+        number_of_particles=1,
+        translation=[10 * cm, 5 * cm, 0 * mm],
+    )
+    print("testing translation")
+    t.test_source_rotation(
+        source_file_name=paths.output / "test_proton_offset.root",
+        phs_file_name_out=paths.output / "test_source_rotation.root",
+    )
+
+    dirX_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_rotation.root",
+        key="PreDirection_X",
+        ref_value=0,
+    )
+    print("PhS source rotation dirX_ok is correct: ", dirX_ok)
+
+    dirY_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_rotation.root",
+        key="PreDirection_Y",
+        ref_value=-0.5,
+    )
+    print("PhS source rotation dirY_ok is correct: ", dirY_ok)
+
+    dirZ_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_rotation.root",
+        key="PreDirection_Z",
+        ref_value=(1.0 - 0.5**2) ** 0.5,
+    )
+    print("PhS source rotation dirZ_ok is correct: ", dirZ_ok)
+
+    # this is the end, my friend
+    gate.test_ok(dirX_ok and dirY_ok and dirZ_ok)
+
+
+if __name__ == "__main__":
+    main()

--- a/opengate/tests/src/test060_PhsSource_translation.py
+++ b/opengate/tests/src/test060_PhsSource_translation.py
@@ -1,0 +1,43 @@
+import test060_PhsSource_helpers as t
+import opengate as gate
+
+
+paths = gate.get_default_test_paths(
+    __file__, "test060_PhsSource_ParticleName_direct", output_folder="test060"
+)
+
+# units
+m = gate.g4_units("m")
+mm = gate.g4_units("mm")
+cm = gate.g4_units("cm")
+nm = gate.g4_units("nm")
+Bq = gate.g4_units("Bq")
+MeV = gate.g4_units("MeV")
+deg: float = gate.g4_units("deg")
+
+
+def main():
+    print("create reference PhS file")
+    t.create_test_Phs(
+        particle="proton",
+        phs_name=paths.output / "test_proton_offset",
+        number_of_particles=1,
+        translation=[10 * cm, 5 * cm, 0 * mm],
+    )
+    print("testing translation")
+    t.test_source_translation(
+        source_file_name=paths.output / "test_proton_offset.root",
+        phs_file_name_out=paths.output / "test_source_translation.root",
+    )
+    is_ok = t.check_value_from_root_file(
+        file_name_root=paths.output / "test_source_translation.root",
+        key="PrePositionLocal_X",
+        ref_value=30 * mm,
+    )
+
+    # this is the end, my friend
+    gate.test_ok(is_ok)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The phase space actor was extended to also store the PDGCode in the root file. 
This makes evaluations potentially much more efficient.

The phase space source was extended to be able to translate and rotate the source.
Furthermore, it can now use the particle name or PDGCode from the phase space. This way also secondary particles can be simulated.

Tests were created.
test060 for the phase space source
testtest019_linac_phsp_PDGCode for the phase space actor