### PR TITLE
Phsp source : avoid pybind copy

### DIFF
--- a/core/opengate_core/opengate_lib/GateHelpersPyBind.h
+++ b/core/opengate_core/opengate_lib/GateHelpersPyBind.h
@@ -1,0 +1,20 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#ifndef GateHelpersPyBind_h
+#define GateHelpersPyBind_h
+
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+template <class T> T *PyBindGetVector(const py::array_t<T> &values) {
+  py::buffer_info info = values.request();
+  return static_cast<T *>(info.ptr);
+}
+
+#endif // GateHelpersPyBind_h

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
@@ -41,7 +41,7 @@ void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
   fParticleTable = G4ParticleTable::GetParticleTable();
   // if particle left empty, the particle type will be read from the phsp file
   // check length of particle name
-  if (pname.length() == 0 or pname == "None")
+  if (pname.length() == 0 || pname == "None")
     fUseParticleTypeFromFile = true;
   else {
     fUseParticleTypeFromFile = false;

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
@@ -22,8 +22,8 @@ GatePhaseSpaceSource::~GatePhaseSpaceSource() {
   // It seems that this is required to prevent seg fault at the end
   // I don't understand why
   auto &l = fThreadLocalData.Get();
-  delete l.fEnergy;
-  delete l.fPDGCode;
+  // delete l.fEnergy;
+  // delete l.fPDGCode;
 }
 
 void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
@@ -9,28 +9,31 @@
 #include "G4ParticleTable.hh"
 #include "G4UnitsTable.hh"
 #include "GateHelpersDict.h"
+#include "GateHelpersPyBind.h"
 
 GatePhaseSpaceSource::GatePhaseSpaceSource() : GateVSource() {
-  fCurrentIndex = INT_MAX;
   fCharge = 0;
   fMass = 0;
-  fCurrentBatchSize = 0;
   fMaxN = 0;
   fGlobalFag = false;
 }
 
-GatePhaseSpaceSource::~GatePhaseSpaceSource() = default;
+GatePhaseSpaceSource::~GatePhaseSpaceSource() {
+  // It seems that this is required to prevent seg fault at the end
+  // I don't understand why
+  auto &l = fThreadLocalData.Get();
+  delete l.fEnergy;
+  delete l.fPDGCode;
+}
 
 void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
+  auto &l = fThreadLocalData.Get();
   // the following initialize all GenericSource options
   // and the SPS GateSingleParticleSource
   GateVSource::InitializeUserInfo(user_info);
 
   // Number of events to generate
   fMaxN = DictGetInt(user_info, "n");
-
-  // Batch size
-  fCurrentBatchSize = DictGetInt(user_info, "batch_size");
 
   // global (world) or local (mother volume) coordinate system
   fGlobalFag = DictGetBool(user_info, "global_flag");
@@ -40,7 +43,7 @@ void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
   fParticleTable = G4ParticleTable::GetParticleTable();
   // if particle left empty, the particle type will be read from the phsp file
   // check length of particle name
-  if (pname.length() == 0)
+  if (pname.length() == 0 or pname == "None")
     fUseParticleTypeFromFile = true;
   else {
     fUseParticleTypeFromFile = false;
@@ -50,8 +53,9 @@ void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
   }
 
   // Init
-  fNumberOfGeneratedEvents = 0;
-  fCurrentIndex = -1;
+  l.fNumberOfGeneratedEvents = 0;
+  l.fCurrentIndex = -1;
+  l.fCurrentBatchSize = 0;
 }
 
 void GatePhaseSpaceSource::PrepareNextRun() {
@@ -61,14 +65,17 @@ void GatePhaseSpaceSource::PrepareNextRun() {
 
 double GatePhaseSpaceSource::PrepareNextTime(double current_simulation_time) {
   // check according to t MaxN
-  if (fNumberOfGeneratedEvents >= fMaxN) {
+  auto &l = fThreadLocalData.Get();
+  if (l.fNumberOfGeneratedEvents >= fMaxN) {
     return -1;
   }
   return fStartTime; // FIXME timing ?
 }
 
-void GatePhaseSpaceSource::SetGeneratorFunction(ParticleGeneratorType &f) {
-  fGenerator = f;
+void GatePhaseSpaceSource::SetGeneratorFunction(
+    ParticleGeneratorType &f) const {
+  auto &l = fThreadLocalData.Get();
+  l.fGenerator = f;
 }
 
 void GatePhaseSpaceSource::GenerateBatchOfParticles() {
@@ -76,43 +83,46 @@ void GatePhaseSpaceSource::GenerateBatchOfParticles() {
   // (does not seem needed)
   // py::gil_scoped_acquire acquire;
 
-  // This function (fGenerator) is defined on Python side
+  // This function (l.fGenerator) is defined on Python side
   // It fills all values needed for the particles (position, dir, energy, etc)
   // Alternative: build vector of G4ThreeVector in GenerateBatchOfParticles ?
   // (unsure if it is faster)
-  fGenerator(this);
-  fCurrentIndex = 0;
-  fCurrentBatchSize = fPositionX.size();
+  auto &l = fThreadLocalData.Get();
+  l.fCurrentBatchSize = l.fGenerator(this);
+  l.fCurrentIndex = 0;
 }
 
 void GatePhaseSpaceSource::GeneratePrimaries(G4Event *event,
                                              double current_simulation_time) {
+  auto &l = fThreadLocalData.Get();
 
   // If batch is empty, we generate some particles
-  if (fCurrentIndex >= fCurrentBatchSize)
+  if (l.fCurrentIndex >= l.fCurrentBatchSize)
     GenerateBatchOfParticles();
 
   // Go
   GenerateOnePrimary(event, current_simulation_time);
 
   // update the index;
-  fCurrentIndex++;
+  l.fCurrentIndex++;
 
   // update the number of generated event
-  fNumberOfGeneratedEvents++;
+  l.fNumberOfGeneratedEvents++;
 }
 
 void GatePhaseSpaceSource::GenerateOnePrimary(G4Event *event,
                                               double current_simulation_time) {
-  auto position =
-      G4ThreeVector(fPositionX[fCurrentIndex], fPositionY[fCurrentIndex],
-                    fPositionZ[fCurrentIndex]);
-  auto direction =
-      G4ParticleMomentum(fDirectionX[fCurrentIndex], fDirectionY[fCurrentIndex],
-                         fDirectionZ[fCurrentIndex]);
-  auto energy = fEnergy[fCurrentIndex];
-  auto weight = fWeight[fCurrentIndex];
-  // FIXME auto time = fTime[fCurrentIndex];
+  auto &l = fThreadLocalData.Get();
+  auto position = G4ThreeVector(l.fPositionX[l.fCurrentIndex],
+                                l.fPositionY[l.fCurrentIndex],
+                                l.fPositionZ[l.fCurrentIndex]);
+  auto direction = G4ParticleMomentum(l.fDirectionX[l.fCurrentIndex],
+                                      l.fDirectionY[l.fCurrentIndex],
+                                      l.fDirectionZ[l.fCurrentIndex]);
+  auto energy = l.fEnergy[l.fCurrentIndex];
+  auto weight = l.fWeight[l.fCurrentIndex];
+
+  // FIXME auto time = fTime[l.fCurrentIndex];
 
   // transform according to mother
   if (!fGlobalFag) {
@@ -127,55 +137,22 @@ void GatePhaseSpaceSource::GenerateOnePrimary(G4Event *event,
                       current_simulation_time, weight);
 }
 
-// void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
-//                                                const G4ThreeVector &position,
-//                                                const G4ThreeVector
-//                                                &direction, double energy,
-//                                                double time, double w) const
 void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
                                                const G4ThreeVector &position,
                                                const G4ThreeVector &direction,
                                                double energy, double time,
                                                double w) {
-  // create primary particle
-  // SetPDGcode(G4int c);
-  // G4PrimaryParticle(const G4ParticleDefinition *Gcode, G4double px, G4double
-  // py, G4double pz); else
-  // {
-  //   fUseParticleTypeFromFile = false;
-  //   auto *particle_table = G4ParticleTable::GetParticleTable();
-  //   fParticleDefinition = particle_table->FindParticle(pname);
-  //   fCharge = fParticleDefinition->GetPDGCharge();
-  //   fMass = fParticleDefinition->GetPDGMass();
-  // }
-
   auto *particle = new G4PrimaryParticle();
-  // if we use the particle type from the file, there are two options
-  // 1) the PDGCodee is not defined in the file
-  // 2) the particle name is not defined in the file
-  if (fUseParticleTypeFromFile == true) {
+  auto &l = fThreadLocalData.Get();
+  if (fUseParticleTypeFromFile) {
     // if PDGCode exists in file
-    if (fPDGCode[fCurrentIndex] != 0) {
-      // auto *particle_table = G4ParticleTable::GetParticleTable();
+    if (l.fPDGCode[l.fCurrentIndex] != 0) {
       fParticleDefinition =
-          fParticleTable->FindParticle(fPDGCode[fCurrentIndex]);
-      particle->SetParticleDefinition(fParticleDefinition);
-    }
-    // if PDGCode does not exist in file, but particle name does and is not
-    // empty
-    else if (fParticleName[fCurrentIndex].length() != 0) {
-      // auto *particle_table = G4ParticleTable::GetParticleTable();
-      fParticleDefinition =
-          fParticleTable->FindParticle(fParticleName[fCurrentIndex]);
-      fCharge = fParticleDefinition->GetPDGCharge();
-      fMass = fParticleDefinition->GetPDGMass();
+          fParticleTable->FindParticle(l.fPDGCode[l.fCurrentIndex]);
       particle->SetParticleDefinition(fParticleDefinition);
     } else {
-      G4Exception("GatePhaseSpaceSource::AddOnePrimaryVertex", "Error",
-                  FatalException, "Particle type not defined in file");
-      std::cout << "ERROR: Particle name nor PDGCode defined in file. Aborting."
-                << std::endl;
-      exit(1);
+      Fatal(
+          "Error GatePhaseSpaceSource: PDGCode not defined in file. Aborting.");
     }
   } else {
     particle->SetParticleDefinition(fParticleDefinition);
@@ -192,4 +169,58 @@ void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
 
   // weights
   event->GetPrimaryVertex(0)->SetWeight(w);
+}
+
+void GatePhaseSpaceSource::SetPDGCodeBatch(
+    const py::array_t<int> &fPDGCode) const {
+  auto &l = fThreadLocalData.Get();
+  l.fPDGCode = PyBindGetVector(fPDGCode);
+}
+
+void GatePhaseSpaceSource::SetEnergyBatch(
+    const py::array_t<double> &fEnergy) const {
+  auto &l = fThreadLocalData.Get();
+  l.fEnergy = PyBindGetVector(fEnergy);
+}
+
+void GatePhaseSpaceSource::SetWeightBatch(
+    const py::array_t<double> &fWeight) const {
+  auto &l = fThreadLocalData.Get();
+  l.fWeight = PyBindGetVector(fWeight);
+}
+
+void GatePhaseSpaceSource::SetPositionXBatch(
+    const py::array_t<double> &fPositionX) const {
+  auto &l = fThreadLocalData.Get();
+  l.fPositionX = PyBindGetVector(fPositionX);
+}
+
+void GatePhaseSpaceSource::SetPositionYBatch(
+    const py::array_t<double> &fPositionY) const {
+  auto &l = fThreadLocalData.Get();
+  l.fPositionY = PyBindGetVector(fPositionY);
+}
+
+void GatePhaseSpaceSource::SetPositionZBatch(
+    const py::array_t<double> &fPositionZ) const {
+  auto &l = fThreadLocalData.Get();
+  l.fPositionZ = PyBindGetVector(fPositionZ);
+}
+
+void GatePhaseSpaceSource::SetDirectionXBatch(
+    const py::array_t<double> &fDirectionX) const {
+  auto &l = fThreadLocalData.Get();
+  l.fDirectionX = PyBindGetVector(fDirectionX);
+}
+
+void GatePhaseSpaceSource::SetDirectionYBatch(
+    const py::array_t<double> &fDirectionY) const {
+  auto &l = fThreadLocalData.Get();
+  l.fDirectionY = PyBindGetVector(fDirectionY);
+}
+
+void GatePhaseSpaceSource::SetDirectionZBatch(
+    const py::array_t<double> &fDirectionZ) const {
+  auto &l = fThreadLocalData.Get();
+  l.fDirectionZ = PyBindGetVector(fDirectionZ);
 }

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
@@ -21,11 +21,11 @@ GatePhaseSpaceSource::GatePhaseSpaceSource() : GateVSource() {
 GatePhaseSpaceSource::~GatePhaseSpaceSource() {
   // It seems that this is required to prevent seg fault at the end
   // I don't understand why
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
 }
 
 void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   // the following initialize all GenericSource options
   // and the SPS GateSingleParticleSource
   GateVSource::InitializeUserInfo(user_info);
@@ -63,7 +63,7 @@ void GatePhaseSpaceSource::PrepareNextRun() {
 
 double GatePhaseSpaceSource::PrepareNextTime(double current_simulation_time) {
   // check according to t MaxN
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   if (l.fNumberOfGeneratedEvents >= fMaxN) {
     return -1;
   }
@@ -72,7 +72,7 @@ double GatePhaseSpaceSource::PrepareNextTime(double current_simulation_time) {
 
 void GatePhaseSpaceSource::SetGeneratorFunction(
     ParticleGeneratorType &f) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fGenerator = f;
 }
 
@@ -85,14 +85,14 @@ void GatePhaseSpaceSource::GenerateBatchOfParticles() {
   // It fills all values needed for the particles (position, dir, energy, etc)
   // Alternative: build vector of G4ThreeVector in GenerateBatchOfParticles ?
   // (unsure if it is faster)
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fCurrentBatchSize = l.fGenerator(this);
   l.fCurrentIndex = 0;
 }
 
 void GatePhaseSpaceSource::GeneratePrimaries(G4Event *event,
                                              double current_simulation_time) {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
 
   // If batch is empty, we generate some particles
   if (l.fCurrentIndex >= l.fCurrentBatchSize)
@@ -110,7 +110,7 @@ void GatePhaseSpaceSource::GeneratePrimaries(G4Event *event,
 
 void GatePhaseSpaceSource::GenerateOnePrimary(G4Event *event,
                                               double current_simulation_time) {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
 
   auto position = G4ThreeVector(l.fPositionX[l.fCurrentIndex],
                                 l.fPositionY[l.fCurrentIndex],
@@ -125,10 +125,10 @@ void GatePhaseSpaceSource::GenerateOnePrimary(G4Event *event,
 
   // transform according to mother
   if (!fGlobalFag) {
-    auto &l = fThreadLocalData.Get();
-    position = l.fGlobalRotation * position + l.fGlobalTranslation;
+    auto &ls = fThreadLocalData.Get();
+    position = ls.fGlobalRotation * position + ls.fGlobalTranslation;
     direction = direction / direction.mag();
-    direction = l.fGlobalRotation * direction;
+    direction = ls.fGlobalRotation * direction;
   }
 
   // Create the final vertex
@@ -142,7 +142,7 @@ void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
                                                double energy, double time,
                                                double w) {
   auto *particle = new G4PrimaryParticle();
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   if (fUseParticleTypeFromFile) {
     if (l.fPDGCode[l.fCurrentIndex] != 0) {
       fParticleDefinition =
@@ -170,54 +170,54 @@ void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
 
 void GatePhaseSpaceSource::SetPDGCodeBatch(
     const py::array_t<std::int32_t> &fPDGCode) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fPDGCode = PyBindGetVector<std::int32_t>(fPDGCode);
 }
 
 void GatePhaseSpaceSource::SetEnergyBatch(
     const py::array_t<double> &fEnergy) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fEnergy = PyBindGetVector(fEnergy);
 }
 
 void GatePhaseSpaceSource::SetWeightBatch(
     const py::array_t<double> &fWeight) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fWeight = PyBindGetVector(fWeight);
 }
 
 void GatePhaseSpaceSource::SetPositionXBatch(
     const py::array_t<double> &fPositionX) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fPositionX = PyBindGetVector(fPositionX);
 }
 
 void GatePhaseSpaceSource::SetPositionYBatch(
     const py::array_t<double> &fPositionY) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fPositionY = PyBindGetVector(fPositionY);
 }
 
 void GatePhaseSpaceSource::SetPositionZBatch(
     const py::array_t<double> &fPositionZ) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fPositionZ = PyBindGetVector(fPositionZ);
 }
 
 void GatePhaseSpaceSource::SetDirectionXBatch(
     const py::array_t<double> &fDirectionX) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fDirectionX = PyBindGetVector(fDirectionX);
 }
 
 void GatePhaseSpaceSource::SetDirectionYBatch(
     const py::array_t<double> &fDirectionY) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fDirectionY = PyBindGetVector(fDirectionY);
 }
 
 void GatePhaseSpaceSource::SetDirectionZBatch(
     const py::array_t<double> &fDirectionZ) const {
-  auto &l = fThreadLocalData.Get();
+  auto &l = fThreadLocalDataPhsp.Get();
   l.fDirectionZ = PyBindGetVector(fDirectionZ);
 }

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.cpp
@@ -22,8 +22,6 @@ GatePhaseSpaceSource::~GatePhaseSpaceSource() {
   // It seems that this is required to prevent seg fault at the end
   // I don't understand why
   auto &l = fThreadLocalData.Get();
-  // delete l.fEnergy;
-  // delete l.fPDGCode;
 }
 
 void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
@@ -54,7 +52,7 @@ void GatePhaseSpaceSource::InitializeUserInfo(py::dict &user_info) {
 
   // Init
   l.fNumberOfGeneratedEvents = 0;
-  l.fCurrentIndex = -1;
+  l.fCurrentIndex = 0;
   l.fCurrentBatchSize = 0;
 }
 
@@ -113,6 +111,7 @@ void GatePhaseSpaceSource::GeneratePrimaries(G4Event *event,
 void GatePhaseSpaceSource::GenerateOnePrimary(G4Event *event,
                                               double current_simulation_time) {
   auto &l = fThreadLocalData.Get();
+
   auto position = G4ThreeVector(l.fPositionX[l.fCurrentIndex],
                                 l.fPositionY[l.fCurrentIndex],
                                 l.fPositionZ[l.fCurrentIndex]);
@@ -145,14 +144,12 @@ void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
   auto *particle = new G4PrimaryParticle();
   auto &l = fThreadLocalData.Get();
   if (fUseParticleTypeFromFile) {
-    // if PDGCode exists in file
     if (l.fPDGCode[l.fCurrentIndex] != 0) {
       fParticleDefinition =
           fParticleTable->FindParticle(l.fPDGCode[l.fCurrentIndex]);
       particle->SetParticleDefinition(fParticleDefinition);
     } else {
-      Fatal(
-          "Error GatePhaseSpaceSource: PDGCode not defined in file. Aborting.");
+      Fatal("GatePhaseSpaceSource: PDGCode not available. Aborting.");
     }
   } else {
     particle->SetParticleDefinition(fParticleDefinition);
@@ -172,9 +169,9 @@ void GatePhaseSpaceSource::AddOnePrimaryVertex(G4Event *event,
 }
 
 void GatePhaseSpaceSource::SetPDGCodeBatch(
-    const py::array_t<int> &fPDGCode) const {
+    const py::array_t<std::int32_t> &fPDGCode) const {
   auto &l = fThreadLocalData.Get();
-  l.fPDGCode = PyBindGetVector(fPDGCode);
+  l.fPDGCode = PyBindGetVector<std::int32_t>(fPDGCode);
 }
 
 void GatePhaseSpaceSource::SetEnergyBatch(

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
@@ -11,6 +11,8 @@
 #include "GateSPSVoxelsPosDistribution.h"
 #include "GateSingleParticleSource.h"
 #include "GateVSource.h"
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
@@ -20,7 +22,7 @@ class GatePhaseSpaceSource : public GateVSource {
 public:
   // signature of the callback function in Python
   // that will generate particles (from phsp file)
-  using ParticleGeneratorType = std::function<void(GatePhaseSpaceSource *)>;
+  using ParticleGeneratorType = std::function<int(GatePhaseSpaceSource *)>;
 
   GatePhaseSpaceSource();
 
@@ -37,17 +39,11 @@ public:
 
   void GenerateOnePrimary(G4Event *event, double current_simulation_time);
 
-  // void AddOnePrimaryVertex(G4Event *event, const G4ThreeVector &position,
-  //                          const G4ThreeVector &momentum_direction,
-  //                          double energy, double time, double w) const;
-
   void AddOnePrimaryVertex(G4Event *event, const G4ThreeVector &position,
                            const G4ThreeVector &momentum_direction,
                            double energy, double time, double w);
 
-  void SetGeneratorFunction(ParticleGeneratorType &f);
-
-  // virtual void SetGeneratorInfo(py::dict &user_info);
+  void SetGeneratorFunction(ParticleGeneratorType &f) const;
 
   void GenerateBatchOfParticles();
 
@@ -59,26 +55,48 @@ public:
   bool fUseParticleTypeFromFile;
 
   unsigned long fMaxN;
-  long fNumberOfGeneratedEvents;
-  size_t fCurrentBatchSize;
 
-  std::vector<int> fPDGCode;
-  std::vector<string> fParticleName;
+  void SetPDGCodeBatch(const py::array_t<int> &fPDGCode) const;
 
-  std::vector<double> fPositionX;
-  std::vector<double> fPositionY;
-  std::vector<double> fPositionZ;
+  void SetEnergyBatch(const py::array_t<double> &fEnergy) const;
 
-  std::vector<double> fDirectionX;
-  std::vector<double> fDirectionY;
-  std::vector<double> fDirectionZ;
+  void SetWeightBatch(const py::array_t<double> &fWeight) const;
 
-  std::vector<double> fEnergy;
-  std::vector<double> fWeight;
-  // std::vector<double> fTime;
+  void SetPositionXBatch(const py::array_t<double> &fPositionX) const;
 
-  ParticleGeneratorType fGenerator;
-  size_t fCurrentIndex;
+  void SetPositionYBatch(const py::array_t<double> &fPositionY) const;
+
+  void SetPositionZBatch(const py::array_t<double> &fPositionZ) const;
+
+  void SetDirectionXBatch(const py::array_t<double> &fDirectionX) const;
+
+  void SetDirectionYBatch(const py::array_t<double> &fDirectionY) const;
+
+  void SetDirectionZBatch(const py::array_t<double> &fDirectionZ) const;
+
+  // For MT, all threads local variables are gathered here
+  struct threadLocalT {
+
+    ParticleGeneratorType fGenerator;
+    long fNumberOfGeneratedEvents;
+    size_t fCurrentIndex;
+    size_t fCurrentBatchSize;
+
+    int *fPDGCode;
+
+    double *fPositionX;
+    double *fPositionY;
+    double *fPositionZ;
+
+    double *fDirectionX;
+    double *fDirectionY;
+    double *fDirectionZ;
+
+    double *fEnergy;
+    double *fWeight;
+    // double * fTime;
+  };
+  G4Cache<threadLocalT> fThreadLocalData;
 };
 
 #endif // GatePhaseSpaceSource_h

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
@@ -56,7 +56,7 @@ public:
 
   unsigned long fMaxN;
 
-  void SetPDGCodeBatch(const py::array_t<int> &fPDGCode) const;
+  void SetPDGCodeBatch(const py::array_t<std::int32_t> &fPDGCode) const;
 
   void SetEnergyBatch(const py::array_t<double> &fEnergy) const;
 

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
@@ -78,7 +78,7 @@ public:
   struct threadLocalT {
 
     ParticleGeneratorType fGenerator;
-    long fNumberOfGeneratedEvents;
+    unsigned long fNumberOfGeneratedEvents;
     size_t fCurrentIndex;
     size_t fCurrentBatchSize;
 

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceSource.h
@@ -75,7 +75,7 @@ public:
   void SetDirectionZBatch(const py::array_t<double> &fDirectionZ) const;
 
   // For MT, all threads local variables are gathered here
-  struct threadLocalT {
+  struct threadLocalTPhsp {
 
     ParticleGeneratorType fGenerator;
     unsigned long fNumberOfGeneratedEvents;
@@ -96,7 +96,7 @@ public:
     double *fWeight;
     // double * fTime;
   };
-  G4Cache<threadLocalT> fThreadLocalData;
+  G4Cache<threadLocalTPhsp> fThreadLocalDataPhsp;
 };
 
 #endif // GatePhaseSpaceSource_h

--- a/core/opengate_core/opengate_lib/pyGatePhaseSpaceSource.cpp
+++ b/core/opengate_core/opengate_lib/pyGatePhaseSpaceSource.cpp
@@ -7,7 +7,6 @@
 
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -19,23 +18,16 @@ void init_GatePhaseSpaceSource(py::module &m) {
       .def(py::init())
       .def("InitializeUserInfo", &GatePhaseSpaceSource::InitializeUserInfo)
       .def("SetGeneratorFunction", &GatePhaseSpaceSource::SetGeneratorFunction)
-      //.def("SetGeneratorInfo", &GatePhaseSpaceSource::SetGeneratorInfo)
 
-      .def_readwrite("fPDGCode", &GatePhaseSpaceSource::fPDGCode)
-      .def_readwrite("fParticleName", &GatePhaseSpaceSource::fParticleName)
+      .def("SetEnergyBatch", &GatePhaseSpaceSource::SetEnergyBatch)
+      .def("SetWeightBatch", &GatePhaseSpaceSource::SetWeightBatch)
+      .def("SetPDGCodeBatch", &GatePhaseSpaceSource::SetPDGCodeBatch)
 
-      .def_readwrite("fPositionX", &GatePhaseSpaceSource::fPositionX)
-      .def_readwrite("fPositionY", &GatePhaseSpaceSource::fPositionY)
-      .def_readwrite("fPositionZ", &GatePhaseSpaceSource::fPositionZ)
+      .def("SetPositionXBatch", &GatePhaseSpaceSource::SetPositionXBatch)
+      .def("SetPositionYBatch", &GatePhaseSpaceSource::SetPositionYBatch)
+      .def("SetPositionZBatch", &GatePhaseSpaceSource::SetPositionZBatch)
 
-      .def_readwrite("fDirectionX", &GatePhaseSpaceSource::fDirectionX)
-      .def_readwrite("fDirectionY", &GatePhaseSpaceSource::fDirectionY)
-      .def_readwrite("fDirectionZ", &GatePhaseSpaceSource::fDirectionZ)
-
-      .def_readwrite("fEnergy", &GatePhaseSpaceSource::fEnergy)
-      .def_readwrite("fWeight", &GatePhaseSpaceSource::fWeight)
-
-      //.def("GetThreadId", &GateVSource::GetThreadId)
-      // .def_readwrite("fTime", &GatePhaseSpaceSource::fTime)
-      ;
+      .def("SetDirectionXBatch", &GatePhaseSpaceSource::SetDirectionXBatch)
+      .def("SetDirectionYBatch", &GatePhaseSpaceSource::SetDirectionYBatch)
+      .def("SetDirectionZBatch", &GatePhaseSpaceSource::SetDirectionZBatch);
 }

--- a/opengate/source/PhaseSpaceSource.py
+++ b/opengate/source/PhaseSpaceSource.py
@@ -52,7 +52,6 @@ class PhaseSpaceSource(SourceBase):
         user_info.direction_key_z = None
         user_info.energy_key = "KineticEnergy"
         user_info.weight_key = "Weight"
-        user_info.particle_name_key = "ParticleName"
         user_info.PDGCode_key = "PDGCode"
         # change position and direction of the source
         # position is relative to the stored coordinates
@@ -62,7 +61,7 @@ class PhaseSpaceSource(SourceBase):
         user_info.position = Box()
         user_info.position.translation = [0, 0, 0]
         user_info.position.rotation = Rotation.identity().as_matrix()
-        # user_info.time_key = None # FIXME later
+        # user_info.time_key = None # FIXME TODO later
 
     def __del__(self):
         pass

--- a/opengate/source/PhaseSpaceSource.py
+++ b/opengate/source/PhaseSpaceSource.py
@@ -62,6 +62,8 @@ class PhaseSpaceSource(SourceBase):
         user_info.position.translation = [0, 0, 0]
         user_info.position.rotation = Rotation.identity().as_matrix()
         # user_info.time_key = None # FIXME TODO later
+        # for debug
+        user_info.verbose_batch = False
 
     def __del__(self):
         pass

--- a/opengate/source/PhaseSpaceSourceGenerator.py
+++ b/opengate/source/PhaseSpaceSourceGenerator.py
@@ -15,8 +15,6 @@ class PhaseSpaceSourceGenerator:
 
     def __init__(self):
         self.current_index = None
-        self.lock = threading.Lock()
-        self.initialize_is_done = False
         self.user_info = None
         self.root_file = None
         self.num_entries = 0
@@ -31,11 +29,8 @@ class PhaseSpaceSourceGenerator:
         return self.__dict__
 
     def initialize(self, user_info):
-        with self.lock:
-            if not self.initialize_is_done:
-                self.user_info = user_info
-                self.read_phsp_and_keys()
-                self.initialize_is_done = True
+        self.user_info = user_info
+        self.read_phsp_and_keys()
 
     def read_phsp_and_keys(self):
         # convert str like 1e5 to int

--- a/opengate/source/PhaseSpaceSourceGenerator.py
+++ b/opengate/source/PhaseSpaceSourceGenerator.py
@@ -131,26 +131,22 @@ class PhaseSpaceSourceGenerator:
         if ui.particle == "" or ui.particle is None:
             # check if the keys for PDGCode are in the root file
             if ui.PDGCode_key in batch:
-                a = batch[ui.PDGCode_key]
                 source.SetPDGCodeBatch(batch[ui.PDGCode_key])
             else:
                 gate.fatal(
-                    f"PhaseSpaceSource: no PDGCode key ({ui.PDGCode_key}) in the phsp file and no source.particle"
+                    f"PhaseSpaceSource: no PDGCode key ({ui.PDGCode_key}) "
+                    f"in the phsp file and no source.particle"
                 )
 
         # if override_position is set to True, the position
         # supplied will be added to the phsp file position
-        a = batch[ui.position_key_x]
         if ui.override_position:
-            source.SetPositionXBatch(
-                batch[ui.position_key_x] + ui.position.translation[0]
-            )
-            source.SetPositionYBatch(
-                batch[ui.position_key_y] + ui.position.translation[1]
-            )
-            source.SetPositionZBatch(
-                batch[ui.position_key_z] + ui.position.translation[2]
-            )
+            x = batch[ui.position_key_x] + ui.position.translation[0]
+            y = batch[ui.position_key_y] + ui.position.translation[1]
+            z = batch[ui.position_key_z] + ui.position.translation[2]
+            source.SetPositionXBatch(x)
+            source.SetPositionYBatch(y)
+            source.SetPositionZBatch(z)
         else:
             source.SetPositionXBatch(batch[ui.position_key_x])
             source.SetPositionYBatch(batch[ui.position_key_y])
@@ -173,9 +169,9 @@ class PhaseSpaceSourceGenerator:
             # rotate vector with rotation matrix
             points = r.apply(self.points)
             # source.fDirectionX, source.fDirectionY, source.fDirectionZ = points.T
-            source.SetDirectionXBatch(points[0])
-            source.SetDirectionYBatch(points[1])
-            source.SetDirectionZBatch(points[2])
+            source.SetDirectionXBatch(points[:, 0])
+            source.SetDirectionYBatch(points[:, 1])
+            source.SetDirectionZBatch(points[:, 2])
         else:
             source.SetDirectionXBatch(batch[ui.direction_key_x])
             source.SetDirectionYBatch(batch[ui.direction_key_y])

--- a/opengate/tests/src/test019_linac_phsp_helpers.py
+++ b/opengate/tests/src/test019_linac_phsp_helpers.py
@@ -218,6 +218,8 @@ def create_simu_test019_phsp_source(sim):
     source.direction_key = "PreDirectionLocal"
     source.global_flag = False
     source.particle = "gamma"
+    source.particle = ""
+    source.PDGCode_key = "PDGCode"
     source.n = 20000 / ui.number_of_threads
     source.batch_size = source.n
 
@@ -232,6 +234,7 @@ def create_simu_test019_phsp_source(sim):
     source.PDGCode_key = "PDGCode"
     source.n = 20000 / ui.number_of_threads
     source.batch_size = source.n
+    source.verbose_batch = True
 
     # add stat actor
     s = sim.add_actor("SimulationStatisticsActor", "Stats")

--- a/opengate/tests/src/test019_linac_phsp_helpers.py
+++ b/opengate/tests/src/test019_linac_phsp_helpers.py
@@ -228,7 +228,8 @@ def create_simu_test019_phsp_source(sim):
     source.position_key = "PrePosition"
     source.direction_key = "PreDirection"
     source.global_flag = True
-    source.particle = "gamma"
+    source.particle = None
+    source.PDGCode_key = "PDGCode"
     source.n = 20000 / ui.number_of_threads
     source.batch_size = source.n
 

--- a/opengate/tests/src/test060_PhsSource_ParticleName_direct.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_direct.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import test060_PhsSource_helpers as t
 import opengate as gate
 

--- a/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_PDGCode.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_PDGCode.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import test060_PhsSource_helpers as t
 import opengate as gate
 

--- a/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_ParticleName_WIP.py
+++ b/opengate/tests/src/test060_PhsSource_ParticleName_fromPHS_ParticleName_WIP.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import test060_PhsSource_helpers as t
 import opengate as gate
 

--- a/opengate/tests/src/test060_PhsSource_helpers.py
+++ b/opengate/tests/src/test060_PhsSource_helpers.py
@@ -34,10 +34,8 @@ def create_test_Phs(
 
     # units
     m = gate.g4_units("m")
-    mm = gate.g4_units("mm")
     cm = gate.g4_units("cm")
     nm = gate.g4_units("nm")
-    Bq = gate.g4_units("Bq")
     MeV = gate.g4_units("MeV")
 
     ##########################################################################################
@@ -188,9 +186,6 @@ def create_PhS_withoutSource(
     mm = gate.g4_units("mm")
     cm = gate.g4_units("cm")
     nm = gate.g4_units("nm")
-    Bq = gate.g4_units("Bq")
-    MeV = gate.g4_units("MeV")
-    deg: float = gate.g4_units("deg")
 
     ##########################################################################################
     # geometry
@@ -232,7 +227,7 @@ def create_PhS_withoutSource(
         "PDGCode",
     ]
     ta1.output = phs_name
-    ta1.debug = False
+    ta1.debug = True
 
     # ~ phys.physics_list_name = "FTFP_BERT"
     sim.physics_manager.physics_list_name = "QGSP_BIC_EMZ"
@@ -329,7 +324,7 @@ def test_source_translation(
     source.position_key = "PrePosition"
     source.direction_key = "PreDirection"
     source.global_flag = True
-    source.particle = ""
+    source.particle = "proton"
     source.batch_size = 3000
     source.n = number_of_particles
     source.override_position = True
@@ -357,7 +352,7 @@ def test_source_rotation(
     source.position_key = "PrePosition"
     source.direction_key = "PreDirection"
     source.global_flag = True
-    source.particle = ""
+    source.particle = "proton"
     source.batch_size = 3000
     source.n = number_of_particles
     # source.override_position = True

--- a/opengate/tests/src/test060_PhsSource_rotation.py
+++ b/opengate/tests/src/test060_PhsSource_rotation.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import test060_PhsSource_helpers as t
 import opengate as gate
 
@@ -24,7 +27,7 @@ def main():
         number_of_particles=1,
         translation=[10 * cm, 5 * cm, 0 * mm],
     )
-    print("testing translation")
+    print("testing rotation")
     t.test_source_rotation(
         source_file_name=paths.output / "test_proton_offset.root",
         phs_file_name_out=paths.output / "test_source_rotation.root",

--- a/opengate/tests/src/test060_PhsSource_translation.py
+++ b/opengate/tests/src/test060_PhsSource_translation.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import test060_PhsSource_helpers as t
 import opengate as gate
 


### PR DESCRIPTION
In phsp source, the particles are generated from python. Now, we avoid copying the data from python to cpp, it should be faster. 
We also change the default uproot awkward to numpy because it was not working on linux (but was fine on MacOS, dont know why). 
Still the MT version is not really faster. Maybe with simulation where the tracking is larger ? 