### PR TITLE
ResetStackAndState the Navigator

### DIFF
--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerReadoutActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerReadoutActor.cpp
@@ -46,6 +46,9 @@ void GateDigitizerReadoutActor::BeginOfRunAction(const G4Run *run) {
     lr.fNavigator = new G4Navigator();
     lr.fNavigator->SetWorldVolume(world);
     lr.fIgnoredHitsCount = 0;
+  } else {
+    auto &lr = fThreadLocalReadoutData.Get();
+    lr.fNavigator->ResetStackAndState();
   }
 }
 

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerSpatialBlurringActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerSpatialBlurringActor.cpp
@@ -69,6 +69,9 @@ void GateDigitizerSpatialBlurringActor::BeginOfRunAction(const G4Run *run) {
     auto &l = fThreadLocalData.Get();
     l.fNavigator = new G4Navigator();
     l.fNavigator->SetWorldVolume(world);
+  } else {
+    auto &l = fThreadLocalData.Get();
+    l.fNavigator->ResetStackAndState();
   }
 }
 


### PR DESCRIPTION
With a motion actor, the second run is not correct in the Navigator. You can see the problem in GateUniqueVolumeId, printing the VolumeDepthID parameters

But for the moment, I cannot provide a test:
The problem was found using a proprietary model of spect. I wanted to reproduce with available ge model in contrib folder whithout success