### PR TITLE
Change gpu_mode setting for GANSource

### DIFF
--- a/opengate/sources/gansources.py
+++ b/opengate/sources/gansources.py
@@ -379,7 +379,7 @@ class GANSourceDefaultGenerator:
         self.initialize_is_done = False
         self.keys_output = None
         self.gan_info = None
-        self.gpu_mode = user_info.gpu_mode
+        self.gpu_mode = None
 
     def __getstate__(self):
         self.lock = None
@@ -395,6 +395,7 @@ class GANSourceDefaultGenerator:
             if self.gaga is None:
                 print("Cannot run GANSource, gaga_phsp not installed?")
                 sys.exit()
+            self.gpu_mode = self.user_info.gpu_mode
             if not self.initialize_is_done:
                 self.read_gan_and_keys()
                 self.initialize_is_done = True

--- a/opengate/tests/src/test040_gan_phsp_pet_gan.py
+++ b/opengate/tests/src/test040_gan_phsp_pet_gan.py
@@ -158,13 +158,13 @@ if __name__ == "__main__":
     gsource.skip_policy = "ZeroEnergy"
     gsource.batch_size = 1e5
     gsource.verbose_generator = True
-    gsource.gpu_mode = (
-        utility.get_gpu_mode()
-    )  # should be "auto" but "cpu" for macOS github actions to avoid mps errors
     # set the generator and the condition generator
     gsource.generator = gate.sources.gansources.GANSourceConditionalPairsGenerator(
         gsource, 210 * mm, gen_cond
     )
+    gsource.gpu_mode = (
+        utility.get_gpu_mode()
+    )  # should be "auto" but "cpu" for macOS github actions to avoid mps errors
 
     # add stat actor
     stat = sim.add_actor("SimulationStatisticsActor", "Stats")


### PR DESCRIPTION
The gpu_mode was set during __init__ but if we change it after setting the generator (like in the test40) it was not changed. git diff master_mode is correct