### PR TITLE
Reduce import time of opengate

### DIFF
--- a/opengate/actors/arfactors.py
+++ b/opengate/actors/arfactors.py
@@ -1,9 +1,7 @@
 import sys
 from box import Box
 import numpy as np
-from itk import image_from_array, Image, CastImageFilter, imwrite
-from itk import F as itkF
-from itk import D as itkD
+import itk
 import threading
 import opengate_core as g4
 from ..utility import g4_units, check_filename_type
@@ -272,7 +270,7 @@ class ARFActor(g4.GateARFActor, ActorBase):
             self.param.image_size[1] = self.param.image_size[1] - 1
 
         # convert to itk image
-        self.output_image = image_from_array(self.output_image)
+        self.output_image = itk.image_from_array(self.output_image)
 
         # set spacing and origin like DigitizerProjectionActor
         spacing = self.user_info.image_spacing
@@ -286,13 +284,13 @@ class ARFActor(g4.GateARFActor, ActorBase):
         self.output_image.SetOrigin(origin)
 
         # convert double to float
-        InputImageType = Image[itkD, 3]
-        OutputImageType = Image[itkF, 3]
-        castImageFilter = CastImageFilter[InputImageType, OutputImageType].New()
+        InputImageType = itk.Image[itk.D, 3]
+        OutputImageType = itk.Image[itk.F, 3]
+        castImageFilter = itk.CastImageFilter[InputImageType, OutputImageType].New()
         castImageFilter.SetInput(self.output_image)
         castImageFilter.Update()
         self.output_image = castImageFilter.GetOutput()
 
         # write ?
         if self.user_info.output:
-            imwrite(self.output_image, check_filename_type(self.user_info.output))
+            itk.imwrite(self.output_image, check_filename_type(self.user_info.output))

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from itk import imwrite
+import itk
 from scipy.spatial.transform import Rotation
 
 import opengate_core as g4
@@ -669,7 +669,7 @@ class DigitizerProjectionActor(g4.GateDigitizerProjectionActor, ActorBase):
         self.output_image.SetSpacing(spacing)
         self.output_image.SetOrigin(origin)
         if self.user_info.output:
-            imwrite(self.output_image, check_filename_type(self.user_info.output))
+            itk.imwrite(self.output_image, check_filename_type(self.user_info.output))
 
 
 class DigitizerReadoutActor(g4.GateDigitizerReadoutActor, ActorBase):

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -1,4 +1,4 @@
-from itk import imwrite, array_view_from_image
+import itk
 import numpy as np
 import opengate_core as g4
 from .base import ActorBase
@@ -208,7 +208,7 @@ class DoseActor(g4.GateDoseActor, ActorBase):
             n = check_filename_type(self.user_info.output).replace(
                 ".mhd", "_uncertainty.mhd"
             )
-            imwrite(self.uncertainty_image, n)
+            itk.imwrite(self.uncertainty_image, n)
 
         # Write square image too
         if self.user_info.square:
@@ -216,19 +216,19 @@ class DoseActor(g4.GateDoseActor, ActorBase):
             n = check_filename_type(self.user_info.output).replace(
                 ".mhd", "-Squared.mhd"
             )
-            imwrite(self.py_square_image, n)
+            itk.imwrite(self.py_square_image, n)
 
         # dose in gray
         if self.user_info.gray:
             self.py_dose_image = get_cpp_image(self.cpp_dose_image)
             self.py_dose_image.SetOrigin(self.output_origin)
             n = check_filename_type(self.user_info.output).replace(".mhd", "_dose.mhd")
-            imwrite(self.py_dose_image, n)
+            itk.imwrite(self.py_dose_image, n)
 
         # write the image at the end of the run
         # FIXME : maybe different for several runs
         if self.user_info.output:
-            imwrite(self.py_edep_image, check_filename_type(self.user_info.output))
+            itk.imwrite(self.py_edep_image, check_filename_type(self.user_info.output))
 
     def compute_square(self):
         if self.py_square_image == None:
@@ -240,8 +240,8 @@ class DoseActor(g4.GateDoseActor, ActorBase):
         NbOfEvent = self.NbOfEvent
         self.compute_square()
 
-        edep = array_view_from_image(self.py_edep_image)
-        square = array_view_from_image(self.py_square_image)
+        edep = itk.array_view_from_image(self.py_edep_image)
+        square = itk.array_view_from_image(self.py_square_image)
 
         self.py_edep_image_tmp = itk_image_view_from_array(edep)
         self.py_edep_image_tmp.CopyInformation(self.py_edep_image)
@@ -250,7 +250,7 @@ class DoseActor(g4.GateDoseActor, ActorBase):
 
         # uncertainty image
         self.uncertainty_image = create_image_like(self.py_edep_image)
-        unc = array_view_from_image(self.uncertainty_image)
+        unc = itk.array_view_from_image(self.uncertainty_image)
         N = NbOfEvent
         if N != 1:
             # unc = np.sqrt(1 / (N - 1) * (square / N - np.power(edep / N, 2)))
@@ -268,10 +268,10 @@ class DoseActor(g4.GateDoseActor, ActorBase):
         self.uncertainty_image.CopyInformation(self.py_edep_image)
         self.uncertainty_image.SetOrigin(self.output_origin)
         # debug
-        """imwrite(self.py_square_image, "square.mhd")
-        imwrite(self.py_temp_image, "temp.mhd")
-        imwrite(self.py_last_id_image, "lastid.mhd")
-        imwrite(self.uncertainty_image, "uncer.mhd")"""
+        """itk.imwrite(self.py_square_image, "square.mhd")
+        itk.imwrite(self.py_temp_image, "temp.mhd")
+        itk.imwrite(self.py_last_id_image, "lastid.mhd")
+        itk.imwrite(self.uncertainty_image, "uncer.mhd")"""
 
 
 class LETActor(g4.GateLETActor, ActorBase):
@@ -497,11 +497,11 @@ class LETActor(g4.GateLETActor, ActorBase):
                 filterVal=0,
                 replaceFilteredVal=0,
             )
-            imwrite(self.py_LETd_image, check_filename_type(fPath))
+            itk.imwrite(self.py_LETd_image, check_filename_type(fPath))
 
             # for parrallel computation we need to provide both outputs
             if self.user_info.separate_output:
                 fPath = fPath.replace(".mhd", "_numerator.mhd")
-                imwrite(self.py_numerator_image, check_filename_type(fPath))
+                itk.imwrite(self.py_numerator_image, check_filename_type(fPath))
                 fPath = fPath.replace("_numerator", "_denominator")
-                imwrite(self.py_denominator_image, check_filename_type(fPath))
+                itk.imwrite(self.py_denominator_image, check_filename_type(fPath))

--- a/opengate/geometry/ImageVolume.py
+++ b/opengate/geometry/ImageVolume.py
@@ -1,4 +1,4 @@
-from itk import imread, imwrite, array_view_from_image, size
+import itk
 import numpy as np
 import opengate_core as g4
 from .VolumeBase import VolumeBase
@@ -44,8 +44,8 @@ class ImageVolume(VolumeBase):
     def construct(self, volume_engine, g4_world_log_vol):
         self.volume_engine = volume_engine
         # read image
-        self.image = imread(check_filename_type(self.user_info.image))
-        size_pix = np.array(size(self.image)).astype(int)
+        self.image = itk.imread(check_filename_type(self.user_info.image))
+        size_pix = np.array(itk.size(self.image)).astype(int)
         spacing = np.array(self.image.GetSpacing())
         size_mm = size_pix * spacing
 
@@ -170,8 +170,8 @@ class ImageVolume(VolumeBase):
         self.final_materials.append(self.user_info.material)
 
         # convert interval to material id
-        input = array_view_from_image(self.image)
-        output = array_view_from_image(self.py_image)
+        input = itk.array_view_from_image(self.image)
+        output = itk.array_view_from_image(self.py_image)
         # the final list of materials is packed (same label even if
         # there are several intervals with the same material)
         self.final_materials = []
@@ -188,10 +188,10 @@ class ImageVolume(VolumeBase):
         # dump label image ?
         if self.user_info.dump_label_image:
             self.py_image.SetOrigin(info.origin)
-            imwrite(self.py_image, str(self.user_info.dump_label_image))
+            itk.imwrite(self.py_image, str(self.user_info.dump_label_image))
 
         # compute image origin
-        size_pix = np.array(size(self.py_image))
+        size_pix = np.array(itk.size(self.py_image))
         spacing = np.array(self.py_image.GetSpacing())
         orig = -(size_pix * spacing) / 2.0 + spacing / 2.0
         self.py_image.SetOrigin(orig)

--- a/opengate/sources/gansources.py
+++ b/opengate/sources/gansources.py
@@ -4,7 +4,7 @@ import scipy
 import numpy as np
 import threading
 from box import Box
-from itk import array_view_from_image, imread
+import itk
 import bisect
 import opengate_core
 from ..exception import fatal
@@ -57,7 +57,7 @@ class VoxelizedSourcePDFSampler:
         self.image = itk_image
         self.version = version
         # get image in np array
-        self.imga = array_view_from_image(itk_image)
+        self.imga = itk.array_view_from_image(itk_image)
         imga = self.imga
 
         # image sizes
@@ -199,7 +199,7 @@ class VoxelizedSourceConditionGenerator:
         self.compute_directions = False
 
     def initialize_source(self):
-        self.image = imread(self.activity_source_filename)
+        self.image = itk.imread(self.activity_source_filename)
         self.img_info = get_info_from_image(self.image)
         self.sampler = VoxelizedSourcePDFSampler(self.image)
         self.rs = np.random

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -1,4 +1,4 @@
-from itk import imread
+import itk
 from box import Box
 from scipy.spatial.transform import Rotation
 
@@ -81,7 +81,7 @@ class VoxelsSource(GenericSource):
 
     def initialize(self, run_timing_intervals):
         # read source image
-        self.image = imread(check_filename_type(self.user_info.image))
+        self.image = itk.imread(check_filename_type(self.user_info.image))
 
         # compute position
         self.set_transform_from_user_info()


### PR DESCRIPTION
It seems that import itk by module, increase a lot the time of import for opengate

I did this:
```
python -X importtime testTime.py 2> import.log
tune import.log
```
with:
```tesTime.py
import opengate
```
With my MacOS and python 3.9

Before the modification:
it took 11s
<img width="1423" alt="Screenshot 2023-10-19 at 16 34 22" src="https://github.com/OpenGATE/opengate/assets/15010467/7c5f338c-abc9-49b4-aecf-88097a8ca41c">
<img width="1438" alt="Screenshot 2023-10-19 at 16 34 39" src="https://github.com/OpenGATE/opengate/assets/15010467/40f778ea-5ffa-44d6-b5b5-978b426ad853">

After the modification:
it tooks 5.2s
<img width="1419" alt="Screenshot 2023-10-19 at 16 48 46" src="https://github.com/OpenGATE/opengate/assets/15010467/4fe5ad62-fbc2-42d3-94d3-fd1f05dfa409">
<img width="1434" alt="Screenshot 2023-10-19 at 16 48 58" src="https://github.com/OpenGATE/opengate/assets/15010467/13316a69-d27e-414b-9d52-e750304eeb73">

ITK is still long to import due to torch. But it's import just once now





