### PR TITLE
Filter any attribute with min/max

### DIFF
--- a/core/opengate_core/opengate_core.cpp
+++ b/core/opengate_core/opengate_core.cpp
@@ -237,7 +237,7 @@ void init_GateVFilter(py::module &);
 
 void init_GateParticleFilter(py::module &);
 
-void init_GateValueAttributeFilter(py::module &);
+void init_GateThresholdAttributeFilter(py::module &);
 
 void init_GateTrackCreatorProcessFilter(py::module &);
 
@@ -450,7 +450,7 @@ PYBIND11_MODULE(opengate_core, m) {
   init_GateParticleFilter(m);
   init_GateTrackCreatorProcessFilter(m);
   init_GateKineticEnergyFilter(m);
-  init_GateValueAttributeFilter(m);
+  init_GateThresholdAttributeFilter(m);
   init_itk_image(m);
   init_GateImageNestedParameterisation(m);
   init_GateRepeatParameterisation(m);

--- a/core/opengate_core/opengate_core.cpp
+++ b/core/opengate_core/opengate_core.cpp
@@ -237,6 +237,8 @@ void init_GateVFilter(py::module &);
 
 void init_GateParticleFilter(py::module &);
 
+void init_GateValueAttributeFilter(py::module &);
+
 void init_GateTrackCreatorProcessFilter(py::module &);
 
 void init_GateKineticEnergyFilter(py::module &);
@@ -448,6 +450,7 @@ PYBIND11_MODULE(opengate_core, m) {
   init_GateParticleFilter(m);
   init_GateTrackCreatorProcessFilter(m);
   init_GateKineticEnergyFilter(m);
+  init_GateValueAttributeFilter(m);
   init_itk_image(m);
   init_GateImageNestedParameterisation(m);
   init_GateRepeatParameterisation(m);

--- a/core/opengate_core/opengate_lib/GateKineticEnergyFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateKineticEnergyFilter.cpp
@@ -14,7 +14,7 @@ void GateKineticEnergyFilter::Initialize(py::dict &user_info) {
   fEnergyMax = DictGetDouble(user_info, "energy_max");
 }
 
-bool GateKineticEnergyFilter::Accept(const G4Step *step) const {
+bool GateKineticEnergyFilter::Accept(G4Step *step) const {
   auto e = step->GetPreStepPoint()->GetKineticEnergy();
   if (e < fEnergyMin)
     return false;

--- a/core/opengate_core/opengate_lib/GateKineticEnergyFilter.h
+++ b/core/opengate_core/opengate_lib/GateKineticEnergyFilter.h
@@ -24,7 +24,7 @@ public:
   // https://stackoverflow.com/questions/9995421/gcc-woverloaded-virtual-warnings
   using GateVFilter::Accept;
 
-  bool Accept(const G4Step *step) const override;
+  bool Accept(G4Step *step) const override;
 
   double fEnergyMin;
   double fEnergyMax;

--- a/core/opengate_core/opengate_lib/GateParticleFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateParticleFilter.cpp
@@ -20,7 +20,7 @@ bool GateParticleFilter::Accept(const G4Track *track) const {
   return false;
 }
 
-bool GateParticleFilter::Accept(const G4Step *step) const {
+bool GateParticleFilter::Accept(G4Step *step) const {
   auto p = step->GetTrack()->GetParticleDefinition()->GetParticleName();
   if (fPolicy == "keep" && p == fParticleName)
     return true;

--- a/core/opengate_core/opengate_lib/GateParticleFilter.h
+++ b/core/opengate_core/opengate_lib/GateParticleFilter.h
@@ -26,7 +26,7 @@ public:
 
   bool Accept(const G4Track *track) const override;
 
-  bool Accept(const G4Step *step) const override;
+  bool Accept(G4Step *step) const override;
 
   G4String fParticleName;
   std::string fPolicy;

--- a/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.cpp
@@ -50,7 +50,7 @@ bool GateThresholdAttributeFilter::Accept(G4Step *step) const {
   fAttribute->ProcessHits(step);
   double value = fAttribute->GetDValues()[0];
   fAttribute->Clear();
-  if (value >= fValueMin and value <= fValueMax)
+  if (value >= fValueMin && value <= fValueMax)
     return fKeep;
   return !fKeep;
 }

--- a/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.cpp
@@ -5,15 +5,15 @@
    See LICENSE.md for further details
    -------------------------------------------------- */
 
-#include "GateValueAttributeFilter.h"
+#include "GateThresholdAttributeFilter.h"
 #include "G4UnitsTable.hh"
 #include "GateHelpers.h"
 #include "GateHelpersDict.h"
 #include "digitizer/GateDigiAttributeManager.h"
 
-GateValueAttributeFilter::GateValueAttributeFilter() : GateVFilter() {}
+GateThresholdAttributeFilter::GateThresholdAttributeFilter() : GateVFilter() {}
 
-void GateValueAttributeFilter::Initialize(py::dict &user_info) {
+void GateThresholdAttributeFilter::Initialize(py::dict &user_info) {
   fAttributeName = DictGetStr(user_info, "attribute");
   fValueMin = DictGetDouble(user_info, "value_min");
   fValueMax = DictGetDouble(user_info, "value_max");
@@ -42,11 +42,11 @@ void GateValueAttributeFilter::Initialize(py::dict &user_info) {
   fAttribute = dynamic_cast<GateTDigiAttribute<double> *>(vatt);
 }
 
-bool GateValueAttributeFilter::Accept(const G4Track *track) const {
+bool GateThresholdAttributeFilter::Accept(const G4Track *track) const {
   return true;
 }
 
-bool GateValueAttributeFilter::Accept(G4Step *step) const {
+bool GateThresholdAttributeFilter::Accept(G4Step *step) const {
   fAttribute->ProcessHits(step);
   double value = fAttribute->GetDValues()[0];
   fAttribute->Clear();

--- a/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.h
+++ b/core/opengate_core/opengate_lib/GateThresholdAttributeFilter.h
@@ -5,8 +5,8 @@
    See LICENSE.md for further details
    -------------------------------------------------- */
 
-#ifndef GateValueAttributeFilter_h
-#define GateValueAttributeFilter_h
+#ifndef GateThresholdAttributeFilter_h
+#define GateThresholdAttributeFilter_h
 
 #include "G4Step.hh"
 #include "G4Track.hh"
@@ -17,10 +17,10 @@
 
 namespace py = pybind11;
 
-class GateValueAttributeFilter : public GateVFilter {
+class GateThresholdAttributeFilter : public GateVFilter {
 
 public:
-  GateValueAttributeFilter();
+  GateThresholdAttributeFilter();
 
   void Initialize(py::dict &user_info) override;
 
@@ -42,4 +42,4 @@ public:
   GateTDigiAttribute<double> *fAttribute{};
 };
 
-#endif // GateValueAttributeFilter_h
+#endif // GateThresholdAttributeFilter_h

--- a/core/opengate_core/opengate_lib/GateTrackCreatorProcessFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateTrackCreatorProcessFilter.cpp
@@ -15,7 +15,7 @@ void GateTrackCreatorProcessFilter::Initialize(py::dict &user_info) {
   fPolicy = DictGetStr(user_info, "policy");
 }
 
-bool GateTrackCreatorProcessFilter::Accept(const G4Step *step) const {
+bool GateTrackCreatorProcessFilter::Accept(G4Step *step) const {
   const auto *p = step->GetTrack()->GetCreatorProcess();
   std::string name = "none";
   if (p != nullptr)

--- a/core/opengate_core/opengate_lib/GateVFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateVFilter.cpp
@@ -7,9 +7,9 @@
 
 #include "GateVFilter.h"
 
-GateVFilter::GateVFilter() {}
+GateVFilter::GateVFilter() = default;
 
-GateVFilter::~GateVFilter() {}
+GateVFilter::~GateVFilter() = default;
 
 void GateVFilter::Initialize(py::dict &) {}
 
@@ -19,4 +19,4 @@ bool GateVFilter::Accept(const G4Event *) const { return true; }
 
 bool GateVFilter::Accept(const G4Track *) const { return true; }
 
-bool GateVFilter::Accept(const G4Step *) const { return true; }
+bool GateVFilter::Accept(G4Step *) const { return true; }

--- a/core/opengate_core/opengate_lib/GateVFilter.h
+++ b/core/opengate_core/opengate_lib/GateVFilter.h
@@ -30,7 +30,7 @@ public:
 
   virtual bool Accept(const G4Track *track) const;
 
-  virtual bool Accept(const G4Step *step) const;
+  virtual bool Accept(G4Step *step) const;
 };
 
 #endif // GateVFilter_h

--- a/core/opengate_core/opengate_lib/GateValueAttributeFilter.cpp
+++ b/core/opengate_core/opengate_lib/GateValueAttributeFilter.cpp
@@ -1,0 +1,56 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include "GateValueAttributeFilter.h"
+#include "G4UnitsTable.hh"
+#include "GateHelpers.h"
+#include "GateHelpersDict.h"
+#include "digitizer/GateDigiAttributeManager.h"
+
+GateValueAttributeFilter::GateValueAttributeFilter() : GateVFilter() {}
+
+void GateValueAttributeFilter::Initialize(py::dict &user_info) {
+  fAttributeName = DictGetStr(user_info, "attribute");
+  fValueMin = DictGetDouble(user_info, "value_min");
+  fValueMax = DictGetDouble(user_info, "value_max");
+  fFilterName = DictGetStr(user_info, "_name");
+  fPolicy = DictGetStr(user_info, "policy");
+  if (fPolicy == "keep")
+    fKeep = true;
+  else if (fPolicy == "discard")
+    fKeep = false;
+  else {
+    std::ostringstream oss;
+    oss << "Error policy must be 'keep' or 'discard' for the filter "
+        << fFilterName << " while it is " << fPolicy;
+    Fatal(oss.str());
+  }
+
+  auto *dgm = GateDigiAttributeManager::GetInstance();
+  auto *att = dgm->GetDigiAttribute(fAttributeName);
+  auto *vatt = dgm->CopyDigiAttribute(att);
+  if (vatt->GetDigiAttributeType() != 'D') {
+    std::ostringstream oss;
+    oss << "Error the type of the attribute " << vatt->GetDigiAttributeName()
+        << " must be 'D', while it is " << vatt->GetDigiAttributeType();
+    Fatal(oss.str());
+  }
+  fAttribute = dynamic_cast<GateTDigiAttribute<double> *>(vatt);
+}
+
+bool GateValueAttributeFilter::Accept(const G4Track *track) const {
+  return true;
+}
+
+bool GateValueAttributeFilter::Accept(G4Step *step) const {
+  fAttribute->ProcessHits(step);
+  double value = fAttribute->GetDValues()[0];
+  fAttribute->Clear();
+  if (value >= fValueMin and value <= fValueMax)
+    return fKeep;
+  return !fKeep;
+}

--- a/core/opengate_core/opengate_lib/GateValueAttributeFilter.h
+++ b/core/opengate_core/opengate_lib/GateValueAttributeFilter.h
@@ -5,18 +5,22 @@
    See LICENSE.md for further details
    -------------------------------------------------- */
 
-#ifndef GateTrackCreatorProcessFilter_h
-#define GateTrackCreatorProcessFilter_h
+#ifndef GateValueAttributeFilter_h
+#define GateValueAttributeFilter_h
 
+#include "G4Step.hh"
+#include "G4Track.hh"
 #include "GateVFilter.h"
+#include "digitizer/GateDigiCollectionManager.h"
+#include "digitizer/GateTDigiAttribute.h"
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
 
-class GateTrackCreatorProcessFilter : public GateVFilter {
+class GateValueAttributeFilter : public GateVFilter {
 
 public:
-  GateTrackCreatorProcessFilter() : GateVFilter() {}
+  GateValueAttributeFilter();
 
   void Initialize(py::dict &user_info) override;
 
@@ -24,10 +28,18 @@ public:
   // https://stackoverflow.com/questions/9995421/gcc-woverloaded-virtual-warnings
   using GateVFilter::Accept;
 
+  bool Accept(const G4Track *track) const override;
+
   bool Accept(G4Step *step) const override;
 
-  std::string fProcessName;
+  std::string fAttributeName;
   std::string fPolicy;
+  double fValueMin{};
+  double fValueMax{};
+  bool fKeep{};
+  std::string fFilterName;
+  GateDigiCollection *fDigiCollection{};
+  GateTDigiAttribute<double> *fAttribute{};
 };
 
-#endif // GateTrackCreatorProcessFilter_h
+#endif // GateValueAttributeFilter_h

--- a/core/opengate_core/opengate_lib/pyGateThresholdAttributeFilter.cpp
+++ b/core/opengate_core/opengate_lib/pyGateThresholdAttributeFilter.cpp
@@ -9,11 +9,11 @@
 
 namespace py = pybind11;
 
-#include "GateValueAttributeFilter.h"
+#include "GateThresholdAttributeFilter.h"
 
-void init_GateValueAttributeFilter(py::module &m) {
-  py::class_<GateValueAttributeFilter, GateVFilter>(m,
-                                                    "GateValueAttributeFilter")
+void init_GateThresholdAttributeFilter(py::module &m) {
+  py::class_<GateThresholdAttributeFilter, GateVFilter>(
+      m, "GateThresholdAttributeFilter")
       .def(py::init())
-      .def("Initialize", &GateValueAttributeFilter::Initialize);
+      .def("Initialize", &GateThresholdAttributeFilter::Initialize);
 }

--- a/core/opengate_core/opengate_lib/pyGateVFilter.cpp
+++ b/core/opengate_core/opengate_lib/pyGateVFilter.cpp
@@ -35,7 +35,7 @@ public:
     PYBIND11_OVERLOAD(void, GateVFilter, Initialize, user_info);
   }
 
-  bool Accept(const G4Step *step) const override {
+  bool Accept(G4Step *step) const override {
     PYBIND11_OVERLOAD(bool, GateVFilter, Accept, step);
   }
 

--- a/core/opengate_core/opengate_lib/pyGateValueAttributeFilter.cpp
+++ b/core/opengate_core/opengate_lib/pyGateValueAttributeFilter.cpp
@@ -1,0 +1,19 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+#include "GateValueAttributeFilter.h"
+
+void init_GateValueAttributeFilter(py::module &m) {
+  py::class_<GateValueAttributeFilter, GateVFilter>(m,
+                                                    "GateValueAttributeFilter")
+      .def(py::init())
+      .def("Initialize", &GateValueAttributeFilter::Initialize);
+}

--- a/opengate/actors/builders.py
+++ b/opengate/actors/builders.py
@@ -2,7 +2,7 @@ from .filters import (
     KineticEnergyFilter,
     ParticleFilter,
     TrackCreatorProcessFilter,
-    ValueAttributeFilter,
+    ThresholdAttributeFilter,
 )
 from ..utility import make_builders
 
@@ -10,6 +10,6 @@ filter_type_names = {
     ParticleFilter,
     KineticEnergyFilter,
     TrackCreatorProcessFilter,
-    ValueAttributeFilter,
+    ThresholdAttributeFilter,
 }
 filter_builders = make_builders(filter_type_names)

--- a/opengate/actors/builders.py
+++ b/opengate/actors/builders.py
@@ -1,5 +1,15 @@
-from .filters import KineticEnergyFilter, ParticleFilter, TrackCreatorProcessFilter
+from .filters import (
+    KineticEnergyFilter,
+    ParticleFilter,
+    TrackCreatorProcessFilter,
+    ValueAttributeFilter,
+)
 from ..utility import make_builders
 
-filter_type_names = {ParticleFilter, KineticEnergyFilter, TrackCreatorProcessFilter}
+filter_type_names = {
+    ParticleFilter,
+    KineticEnergyFilter,
+    TrackCreatorProcessFilter,
+    ValueAttributeFilter,
+}
 filter_builders = make_builders(filter_type_names)

--- a/opengate/actors/filters.py
+++ b/opengate/actors/filters.py
@@ -96,8 +96,8 @@ class TrackCreatorProcessFilter(g4.GateTrackCreatorProcessFilter, FilterBase):
             )
 
 
-class ValueAttributeFilter(g4.GateValueAttributeFilter, FilterBase):
-    type_name = "ValueAttributeFilter"
+class ThresholdAttributeFilter(g4.GateThresholdAttributeFilter, FilterBase):
+    type_name = "ThresholdAttributeFilter"
 
     def set_default_user_info(user_info):
         FilterBase.set_default_user_info(user_info)
@@ -111,13 +111,13 @@ class ValueAttributeFilter(g4.GateValueAttributeFilter, FilterBase):
         if user_info.attribute is None:
             fatal(
                 f"You must set the 'attribute' in the "
-                f"ValueAttributeFilter named {user_info._name}"
+                f"ThresholdAttributeFilter named {user_info._name}"
             )
         if user_info.policy != "keep" and user_info.policy != "discard":
             fatal(
-                f'ValueAttributeFilter "{user_info.name}" policy must be either "keep" '
+                f'ThresholdAttributeFilter "{user_info.name}" policy must be either "keep" '
                 f'or "discard", while it is "{user_info.policy}"'
             )
-        g4.GateValueAttributeFilter.__init__(self)  # no argument in cpp side
+        g4.GateThresholdAttributeFilter.__init__(self)  # no argument in cpp side
         FilterBase.__init__(self, user_info)
         # type_name MUST be defined in class that inherit from a Filter

--- a/opengate/actors/filters.py
+++ b/opengate/actors/filters.py
@@ -31,13 +31,13 @@ class FilterBase(UserElement):
     def close(self):
         if self.verbose_close:
             warning(
-                f"Closing ParticleFilter {self.user_info.type_name} {self.user_info.name}"
+                f"Closing FilterBase {self.user_info.type_name} {self.user_info.name}"
             )
 
     def __getstate__(self):
         if self.verbose_getstate:
             warning(
-                f"getstate ParticleFilter {self.user_info.type_name} {self.user_info.name}"
+                f"getstate FilterBase {self.user_info.type_name} {self.user_info.name}"
             )
 
 
@@ -94,3 +94,30 @@ class TrackCreatorProcessFilter(g4.GateTrackCreatorProcessFilter, FilterBase):
                 f'TrackCreatorProcessFilter "{user_info.name}" policy must be either "keep" '
                 f'or "discard", while it is "{user_info.policy}"'
             )
+
+
+class ValueAttributeFilter(g4.GateValueAttributeFilter, FilterBase):
+    type_name = "ValueAttributeFilter"
+
+    def set_default_user_info(user_info):
+        FilterBase.set_default_user_info(user_info)
+        # required user info, default values
+        user_info.value_min = 0
+        user_info.value_max = sys.float_info.max
+        user_info.attribute = None
+        user_info.policy = "keep"  # or "discard"
+
+    def __init__(self, user_info):
+        if user_info.attribute is None:
+            fatal(
+                f"You must set the 'attribute' in the "
+                f"ValueAttributeFilter named {user_info._name}"
+            )
+        if user_info.policy != "keep" and user_info.policy != "discard":
+            fatal(
+                f'ValueAttributeFilter "{user_info.name}" policy must be either "keep" '
+                f'or "discard", while it is "{user_info.policy}"'
+            )
+        g4.GateValueAttributeFilter.__init__(self)  # no argument in cpp side
+        FilterBase.__init__(self, user_info)
+        # type_name MUST be defined in class that inherit from a Filter

--- a/opengate/tests/src/test023_filters_attribute.py
+++ b/opengate/tests/src/test023_filters_attribute.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import opengate as gate
+from opengate.tests import utility
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, "", "test023")
+
+    # create the simulation
+    sim = gate.Simulation()
+
+    # main options
+    ui = sim.user_info
+    # ui.visu = True
+    ui.visu_type = "vrml"
+    # ui.random_seed = 6549 # FIXME
+
+    # units
+    m = gate.g4_units.m
+    cm = gate.g4_units.cm
+    MeV = gate.g4_units.MeV
+    Bq = gate.g4_units.Bq
+    nm = gate.g4_units.nm
+    mm = gate.g4_units.mm
+    sec = gate.g4_units.second
+    keV = gate.g4_units.keV
+
+    #  change world size
+    world = sim.world
+    world.size = [1 * m, 1 * m, 1 * m]
+    world.material = "G4_AIR"
+
+    # waterbox
+    # waterbox = sim.add_volume("Box", "waterbox")
+    # waterbox.size = [10 * cm, 10 * cm, 10 * cm]
+    # waterbox.material = "G4_WATER"
+    # waterbox.color = [0, 0, 1, 1]
+
+    # default source for tests
+    source = sim.add_source("GenericSource", "mysource")
+    source.energy.type = "gauss"
+    source.energy.mono = 1 * MeV
+    source.energy.sigma_gauss = 1 * MeV
+    source.particle = "gamma"
+    source.position.type = "sphere"
+    source.position.radius = 1 * cm
+    source.direction.type = "iso"
+    source.activity = 1000 * Bq
+
+    # plane
+    plane1a = sim.add_volume("Box", "plane1a")
+    plane1a.size = [1 * m, 1 * m, 1 * nm]
+    plane1a.translation = [0, 0, 1 * cm]
+    plane1a.material = "G4_AIR"
+    plane1a.color = [1, 0, 0, 1]  # red
+
+    plane1b = sim.add_volume("Box", "plane1b")
+    plane1b.size = [1 * m, 1 * m, 1 * nm]
+    plane1b.translation = [0, 0, 2 * cm]
+    plane1b.material = "G4_AIR"
+    plane1b.color = [1, 0, 0, 1]  # red
+
+    plane2a = sim.add_volume("Box", "plane2a")
+    plane2a.size = [1 * m, 1 * m, 1 * nm]
+    plane2a.translation = [0, 0, -1 * cm]
+    plane2a.material = "G4_AIR"
+    plane2a.color = [0, 1, 0, 1]  # green
+
+    plane2b = sim.add_volume("Box", "plane2b")
+    plane2b.size = [1 * m, 1 * m, 1 * nm]
+    plane2b.translation = [0, 0, -2 * cm]
+    plane2b.material = "G4_AIR"
+    plane2b.color = [0, 1, 0, 1]  # green
+
+    # kill according to time
+    ka = sim.add_actor("KillActor", "kill_actor1")
+    ka.mother = plane1a.name
+    att_filter = sim.add_filter("ValueAttributeFilter", "time_filter")
+    # we don't kill the particle within the time range, so
+    # we discard the kill filter when the time is in the correct range
+    att_filter.attribute = "GlobalTime"
+    att_filter.value_min = 20 * sec
+    att_filter.value_max = 70 * sec
+    att_filter.policy = "discard"
+    ka.filters.append(att_filter)
+
+    # kill according to energy
+    ka = sim.add_actor("KillActor", "kill_actor2")
+    ka.mother = plane2a.name
+    att_filter = sim.add_filter("ValueAttributeFilter", "ene_filter")
+    att_filter.attribute = "KineticEnergy"
+    att_filter.value_min = 300 * keV
+    att_filter.value_max = 1200 * keV
+    att_filter.policy = "keep"
+    ka.filters.append(att_filter)
+
+    # stats
+    s = sim.add_actor("SimulationStatisticsActor", "stats")
+    s.track_types_flag = True
+
+    # phsp
+    phsp1 = sim.add_actor("PhaseSpaceActor", "phsp1")
+    # warning, if the plane is plane1a the particle may be marked as "killed"
+    # but will still be in the phsp
+    phsp1.mother = plane1b.name
+    phsp1.attributes = ["GlobalTime", "KineticEnergy"]
+    phsp1.output = paths.output / f"test023_filters_attribute.root"
+    phsp1.priority = ka.priority + 10
+
+    # phsp
+    phsp2 = sim.add_actor("PhaseSpaceActor", "phsp2")
+    phsp2.mother = plane2b.name
+    phsp2.attributes = ["GlobalTime", "KineticEnergy"]
+    phsp2.output = paths.output / f"test023_filters_attribute.root"
+
+    # physics
+    sim.physics_manager.physics_list_name = "G4EmStandardPhysics_option4"
+
+    # start simulation
+    duration = 100 * sec
+    sim.run_timing_intervals = [[0, duration]]
+    sim.run()
+
+    # print results at the end
+    stat = sim.output.get_actor("stats")
+    print(stat)
+    # reference :
+    # stat.write(paths.output_ref / "test023_att_stats.txt")
+
+    # tests
+    stats_ref = utility.read_stat_file(paths.output_ref / "test023_att_stats.txt")
+    is_ok = utility.assert_stats(stat, stats_ref, 0.01)
+
+    # image root files (no comparison here, just for plot)
+    print()
+    utility.compare_root3(
+        phsp1.output,
+        phsp1.output,
+        "phsp1",
+        "phsp2",
+        keys1=phsp1.attributes,
+        keys2=phsp1.attributes,
+        tols=[1e20] * 2,
+        scalings1=[1e-9, 1.0],
+        scalings2=[1e-9, 1.0],
+        img=paths.output / "test023_att.png",
+        hits_tol=1e20,
+    )
+
+    # compare root files (no comparison here)
+    print()
+    is_ok = (
+        utility.compare_root3(
+            paths.output_ref / f"test023_filters_attribute.root",
+            phsp1.output,
+            "phsp1",
+            "phsp1",
+            keys1=phsp1.attributes,
+            keys2=phsp1.attributes,
+            tols=[0.4, 0.02],
+            scalings1=[1e-9, 1.0],
+            scalings2=[1e-9, 1.0],
+            img=paths.output / "test023_att_phsp1.png",
+            hits_tol=2,
+        )
+        and is_ok
+    )
+    print()
+    is_ok = (
+        utility.compare_root3(
+            paths.output_ref / f"test023_filters_attribute.root",
+            phsp1.output,
+            "phsp2",
+            "phsp2",
+            keys1=phsp1.attributes,
+            keys2=phsp1.attributes,
+            tols=[0.4, 0.02],
+            scalings1=[1e-9, 1.0],
+            scalings2=[1e-9, 1.0],
+            img=paths.output / "test023_att_phsp2.png",
+            hits_tol=2,
+        )
+        and is_ok
+    )
+
+    utility.test_ok(is_ok)

--- a/opengate/tests/src/test023_filters_attribute.py
+++ b/opengate/tests/src/test023_filters_attribute.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     ui = sim.user_info
     # ui.visu = True
     ui.visu_type = "vrml"
-    # ui.random_seed = 6549 # FIXME
+    ui.random_seed = 321456987
 
     # units
     m = gate.g4_units.m
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     # kill according to time
     ka = sim.add_actor("KillActor", "kill_actor1")
     ka.mother = plane1a.name
-    att_filter = sim.add_filter("ValueAttributeFilter", "time_filter")
+    att_filter = sim.add_filter("ThresholdAttributeFilter", "time_filter")
     # we don't kill the particle within the time range, so
     # we discard the kill filter when the time is in the correct range
     att_filter.attribute = "GlobalTime"
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     # kill according to energy
     ka = sim.add_actor("KillActor", "kill_actor2")
     ka.mother = plane2a.name
-    att_filter = sim.add_filter("ValueAttributeFilter", "ene_filter")
+    att_filter = sim.add_filter("ThresholdAttributeFilter", "ene_filter")
     att_filter.attribute = "KineticEnergy"
     att_filter.value_min = 300 * keV
     att_filter.value_max = 1200 * keV
@@ -175,7 +175,7 @@ if __name__ == "__main__":
             "phsp2",
             keys1=phsp1.attributes,
             keys2=phsp1.attributes,
-            tols=[0.4, 0.02],
+            tols=[0.6, 0.02],
             scalings1=[1e-9, 1.0],
             scalings2=[1e-9, 1.0],
             img=paths.output / "test023_att_phsp2.png",


### PR DESCRIPTION
A generic filter (min/max) for any attribute with double value.
Example : 

```
ka = sim.add_actor("KillActor", "kill_actor2")
ka.mother = plane2a.name
att_filter = sim.add_filter("ThresholdAttributeFilter", "ene_filter")
att_filter.attribute = "KineticEnergy"
att_filter.value_min = 300 * keV
att_filter.value_max = 1200 * keV
att_filter.policy = "keep"
ka.filters.append(att_filter)
```
In this case, all particles within 300-1200 keV are killed. 
