### PR TITLE
Test dose actor variants mt

### DIFF
--- a/core/opengate_core/opengate_core.cpp
+++ b/core/opengate_core/opengate_core.cpp
@@ -249,6 +249,8 @@ void init_GateKineticEnergyFilter(py::module &);
 
 void init_GateDoseActor(py::module &m);
 
+void init_GateDoseSpeedTestActor(py::module &m);
+
 void init_GateFluenceActor(py::module &m);
 
 void init_GateLETActor(py::module &m);
@@ -477,6 +479,7 @@ PYBIND11_MODULE(opengate_core, m) {
   init_GateEventAction(m);
   init_GateTrackingAction(m);
   init_GateDoseActor(m);
+  init_GateDoseSpeedTestActor(m);
   init_GateFluenceActor(m);
   init_GateLETActor(m);
   init_GateSimulationStatisticsActor(m);

--- a/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.cpp
+++ b/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.cpp
@@ -1,0 +1,195 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   ------------------------------------ -------------- */
+
+#include "GateDoseSpeedTestActor.h"
+#include "G4Navigator.hh"
+#include "G4RandomTools.hh"
+#include "G4RunManager.hh"
+#include "GateHelpers.h"
+#include "GateHelpersDict.h"
+#include "GateHelpersImage.h"
+
+#include "G4Deuteron.hh"
+#include "G4Electron.hh"
+#include "G4EmCalculator.hh"
+#include "G4Gamma.hh"
+#include "G4MaterialTable.hh"
+#include "G4NistManager.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ParticleTable.hh"
+#include "G4Positron.hh"
+#include "G4Proton.hh"
+#include "G4Threading.hh"
+#include "G4Types.hh"
+
+// Mutex that will be used by thread to write in the edep/dose image
+// TODO
+G4Mutex EndOfRunMutex = G4MUTEX_INITIALIZER;
+
+GateDoseSpeedTestActor::GateDoseSpeedTestActor(py::dict &user_info)
+    : GateVActor(user_info, true) {
+  // Create the image pointer
+  // (the size and allocation will be performed on the py side)
+  cpp_reference_image = ImageType::New();
+  // Action for this actor: during stepping
+  fActions.insert("SteppingAction");
+  fActions.insert("BeginOfRunAction");
+  fActions.insert("EndOfRunAction");
+  fActions.insert("EndSimulationAction");
+  fInitialTranslation = DictGetG4ThreeVector(user_info, "translation");
+  fstorageMethod = DictGetStr(user_info, "storage_method");
+}
+
+GateDoseSpeedTestActor::~GateDoseSpeedTestActor() {
+  delete deposit_vector_atomic_pointer;
+}
+
+void GateDoseSpeedTestActor::ActorInitialize() {
+  fNumberOfThreads = G4Threading::GetNumberOfRunningWorkerThreads();
+  if (fNumberOfThreads == 0) {
+    fNumberOfThreads = 1;
+  }
+}
+
+void GateDoseSpeedTestActor::PrepareStorage() {
+  ImageType::RegionType region =
+      cpp_reference_image->GetLargestPossibleRegion();
+  fimageSize = region.GetSize();
+  fnumberOfVoxels = fimageSize[0] * fimageSize[1] * fimageSize[2];
+
+  cpp_image = ImageType::New();
+  cpp_image->CopyInformation(cpp_reference_image);
+  RegionType region_cpp_image;
+  region_cpp_image.SetIndex(
+      cpp_reference_image->GetLargestPossibleRegion().GetIndex());
+  region_cpp_image.SetSize(
+      cpp_reference_image->GetLargestPossibleRegion().GetSize());
+  cpp_image->SetRegions(region_cpp_image);
+  cpp_image->Allocate();
+
+  if (fstorageMethod == "atomic") {
+    for (int i = 0; i < fnumberOfVoxels; i++) {
+      deposit_vector.emplace_back();
+    }
+  } else if (fstorageMethod == "standard") {
+    for (int i = 0; i < fnumberOfVoxels; i++) {
+      deposit_vector_standard.emplace_back(0);
+    }
+  } else if (fstorageMethod == "atomic_vec_pointer") {
+    delete deposit_vector_atomic_pointer;
+    deposit_vector_atomic_pointer =
+        new std::vector<std::atomic<double>>(fnumberOfVoxels);
+  }
+}
+
+void GateDoseSpeedTestActor::PrepareStorageLocal() {
+  auto &l = fThreadLocalData.Get();
+  l.deposit_vector_local.resize(fnumberOfVoxels);
+  std::fill(l.deposit_vector_local.begin(), l.deposit_vector_local.end(), 0.0);
+}
+
+void GateDoseSpeedTestActor::BeginOfRunAction(const G4Run *) {
+
+  if (fstorageMethod == "local") {
+    PrepareStorageLocal();
+  }
+
+  // Important ! The volume may have moved, so we re-attach each run
+  AttachImageToVolume<ImageType>(cpp_reference_image, fPhysicalVolumeName,
+                                 fInitialTranslation);
+  // compute volume of a dose voxel
+  auto sp = cpp_reference_image->GetSpacing();
+  fVoxelVolume = sp[0] * sp[1] * sp[2];
+}
+
+void GateDoseSpeedTestActor::SteppingAction(G4Step *step) {
+  auto position = step->GetPostStepPoint()->GetPosition();
+  auto touchable = step->GetPreStepPoint()->GetTouchable();
+  auto localPosition =
+      touchable->GetHistory()->GetTransform(0).TransformPoint(position);
+
+  // convert G4ThreeVector to itk PointType
+  ImageType::PointType point;
+  point[0] = localPosition[0];
+  point[1] = localPosition[1];
+  point[2] = localPosition[2];
+
+  // get pixel index
+  ImageType::IndexType index;
+  bool isInside =
+      cpp_reference_image->TransformPhysicalPointToIndex(point, index);
+
+  // set value
+  if (isInside) {
+    auto w = step->GetTrack()->GetWeight();
+    auto edep = step->GetTotalEnergyDeposit() / CLHEP::MeV * w;
+    int index_1d = (int)cpp_reference_image->ComputeOffset(index);
+    ftotalDepositWrites++;
+    if (fstorageMethod == "atomic") {
+      //      deposit_vector[index_1d] += edep;
+      atomic_add_double(deposit_vector[index_1d].dep, edep);
+      //      ftotalReattemptsAtomicAdd +=
+      //      atomic_add_double_return_reattempts(deposit_vector[index_1d].dep,
+      //      edep);
+    } else if (fstorageMethod == "standard") {
+      deposit_vector_standard[index_1d] += edep;
+    } else if (fstorageMethod == "local") {
+      auto &l = fThreadLocalData.Get();
+      l.deposit_vector_local[index_1d] += edep;
+    } else if (fstorageMethod == "atomic_vec_pointer") {
+      atomic_add_double((*deposit_vector_atomic_pointer)[index_1d], edep);
+      //      ftotalReattemptsAtomicAdd +=
+      //      atomic_add_double_return_reattempts((*deposit_vector_atomic_pointer)[index_1d],
+      //      edep);
+    }
+  } // else : outside the image
+}
+
+void GateDoseSpeedTestActor::EndSimulationAction() {
+  if (fstorageMethod == "atomic" || fstorageMethod == "standard" ||
+      fstorageMethod == "atomic_vec_pointer") {
+    PrepareOutput();
+  }
+}
+
+void GateDoseSpeedTestActor::EndOfRunAction(const G4Run *run) {
+  if (fstorageMethod == "local") {
+    WriteOutputToImageLocal();
+  }
+}
+
+void GateDoseSpeedTestActor::WriteOutputToImageLocal() {
+  G4AutoLock mutex(&EndOfRunMutex);
+
+  int index_1d;
+  auto &l = fThreadLocalData.Get();
+  ImageIteratorType it(cpp_image, cpp_image->GetLargestPossibleRegion());
+  it.GoToBegin();
+  while (!it.IsAtEnd()) {
+    index_1d = (int)cpp_reference_image->ComputeOffset(it.GetIndex());
+    ImageAddValue<ImageType>(cpp_image, it.GetIndex(),
+                             l.deposit_vector_local[index_1d]);
+    ++it;
+  }
+}
+
+void GateDoseSpeedTestActor::PrepareOutput() {
+  int index_1d;
+  ImageIteratorType it(cpp_image, cpp_image->GetLargestPossibleRegion());
+  it.GoToBegin();
+  while (!it.IsAtEnd()) {
+    index_1d = (int)cpp_reference_image->ComputeOffset(it.GetIndex());
+    if (fstorageMethod == "atomic") {
+      it.Set(deposit_vector[index_1d].dep);
+    } else if (fstorageMethod == "standard") {
+      it.Set(deposit_vector_standard[index_1d]);
+    } else if (fstorageMethod == "atomic_vec_pointer") {
+      it.Set((*deposit_vector_atomic_pointer)[index_1d]);
+    }
+    ++it;
+  }
+}

--- a/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.h
+++ b/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.h
@@ -1,0 +1,170 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#ifndef GateDoseSpeedTestActor_h
+#define GateDoseSpeedTestActor_h
+
+#include "G4Cache.hh"
+#include "G4NistManager.hh"
+#include "G4VPrimitiveScorer.hh"
+#include "GateHelpers.h"
+#include "GateVActor.h"
+#include "itkImage.h"
+#include "itkImageRegionIterator.h"
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <pybind11/stl.h>
+#include <stdlib.h>
+#include <vector>
+
+#define CACHELINESIZE 64
+
+namespace py = pybind11;
+
+struct dose_bin {
+  alignas(CACHELINESIZE) std::atomic<double> dep;
+  dose_bin() { dep = 0; }
+
+  dose_bin &operator+=(const double a) {
+    atomic_add_double(dep, a);
+    return *this;
+  }
+};
+
+// From https://github.com/zhourrr/aligned-memory-allocator
+// A minimal implementation of an allocator for C++ Standard Library, which
+// allocates aligned memory (specified by the alignment argument).
+template <typename T, std::size_t alignment> class AlignedAllocator {
+public:
+  using value_type = T;
+
+public:
+  // According to Microsoft's documentation, default ctor is not required
+  // by C++ Standard Library.
+  AlignedAllocator() noexcept {};
+
+  template <typename U>
+  AlignedAllocator(const AlignedAllocator<U, alignment> &other) noexcept {};
+
+  template <typename U>
+  inline bool
+  operator==(const AlignedAllocator<U, alignment> &other) const noexcept {
+    return true;
+  }
+
+  template <typename U>
+  inline bool
+  operator!=(const AlignedAllocator<U, alignment> &other) const noexcept {
+    return false;
+  }
+
+  template <typename U> struct rebind {
+    using other = AlignedAllocator<U, alignment>;
+  };
+
+  // STL containers call this function to allocate unintialized memory block to
+  // store (no more than n) elements of type T (value_type).
+  inline value_type *allocate(const std::size_t n) const {
+    auto size = n;
+    /*
+      If you wish, for some strange reason, that the size of allocated buffer is
+      also aligned to alignment, uncomment the following statement.
+
+      Note: this increases the size of underlying memory, but STL containers
+      still treat it as a memory block of size n, i.e., STL containers will not
+      put more than n elements into the returned memory.
+    */
+    // size = (n + alignment - 1) / alignment * alignment;
+    value_type *ptr;
+    auto ret = posix_memalign((void **)&ptr, alignment, sizeof(T) * size);
+    if (ret != 0)
+      throw std::bad_alloc();
+    return ptr;
+  };
+
+  // STL containers call this function to free a memory block beginning at a
+  // specified position.
+  inline void deallocate(value_type *const ptr, std::size_t n) const noexcept {
+    free(ptr);
+  }
+};
+
+class GateDoseSpeedTestActor : public GateVActor {
+
+public:
+  // Constructor
+  GateDoseSpeedTestActor(py::dict &user_info);
+
+  ~GateDoseSpeedTestActor();
+
+  // Main function called every step in attached volume
+  virtual void SteppingAction(G4Step *) override;
+
+  // Called every time a Run starts (all threads)
+  virtual void BeginOfRunAction(const G4Run *run) override;
+
+  virtual void EndOfRunAction(const G4Run *run) override;
+
+  virtual void EndSimulationAction() override;
+
+  // Called from the python-side when engines are initialized
+  virtual void ActorInitialize() override;
+
+  // pre-fill the vectors into which dose is written
+  virtual void PrepareStorage();
+
+  virtual void PrepareStorageLocal();
+
+  // prepare the dose images
+  void PrepareOutput();
+
+  void WriteOutputToImageLocal();
+
+  // Image type is 3D float by default
+  // TODO double precision required
+  using ImageType = itk::Image<double, 3>;
+  using ImageIteratorType = itk::ImageRegionIterator<ImageType>;
+  using RegionType = ImageType::RegionType;
+
+  // The image is accessible on py side (shared by all threads)
+  ImageType::Pointer cpp_reference_image;
+  ImageType::Pointer cpp_image;
+
+  using deposit_map_type = std::deque<dose_bin>;
+  //  using deposit_map_type = std::deque<dose_bin, AlignedAllocator<dose_bin,
+  //  CACHELINESIZE>>;
+  deposit_map_type deposit_vector;
+
+  std::vector<double> deposit_vector_standard;
+
+  std::vector<std::atomic<double>> *deposit_vector_atomic_pointer{};
+
+  std::string fPhysicalVolumeName;
+
+  int GetTotalReattemptsAtomicAdd() { return (int)ftotalReattemptsAtomicAdd; }
+
+  int GetTotalDepositWrites() { return (int)ftotalDepositWrites; }
+
+protected:
+  struct threadLocalT {
+    std::vector<double> deposit_vector_local;
+  };
+  G4Cache<threadLocalT> fThreadLocalData;
+
+private:
+  G4ThreeVector fInitialTranslation;
+  std::string fstorageMethod;
+  int fnumberOfVoxels;
+  double fVoxelVolume;
+  ImageType::SizeType fimageSize;
+  int fNumberOfThreads;
+  std::atomic<int> ftotalReattemptsAtomicAdd = 0;
+  std::atomic<int> ftotalDepositWrites = 0;
+};
+
+#endif // GateDoseSpeedTestActor_h

--- a/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.h
+++ b/core/opengate_core/opengate_lib/GateDoseSpeedTestActor.h
@@ -159,6 +159,7 @@ protected:
 private:
   G4ThreeVector fInitialTranslation;
   std::string fstorageMethod;
+  bool fcountWriteAttempts;
   int fnumberOfVoxels;
   double fVoxelVolume;
   ImageType::SizeType fimageSize;

--- a/core/opengate_core/opengate_lib/GateHelpers.cpp
+++ b/core/opengate_core/opengate_lib/GateHelpers.cpp
@@ -20,3 +20,32 @@ void Fatal(std::string s) {
 void FatalKeyError(std::string s) {
   throw py::key_error("Error in the Opengate library (C++): " + s);
 }
+
+// implement a thread-safe incremental addition for atomic doubles
+// memory order is taking from comment in the code example on:
+// https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange
+void atomic_add_double(std::atomic<double> &ad, double const d) {
+  double old;
+  double new_val;
+  //  int i = 0;
+  do {
+    old = ad;
+    new_val = old + d;
+    //    i++;
+  } while (!ad.compare_exchange_weak(old, new_val));
+  //  std::cout << i << std::endl;
+}
+
+// same as above, but returns the number of repeated attempts
+int atomic_add_double_return_reattempts(std::atomic<double> &ad,
+                                        double const d) {
+  double old;
+  double new_val;
+  int i = 0;
+  do {
+    old = ad;
+    new_val = old + d;
+    i++;
+  } while (!ad.compare_exchange_weak(old, new_val));
+  return i - 1;
+}

--- a/core/opengate_core/opengate_lib/GateHelpers.h
+++ b/core/opengate_core/opengate_lib/GateHelpers.h
@@ -62,6 +62,9 @@ extern const int LogLevel_EVENT;
 static const double sigma_to_fwhm = 2.0 * sqrt(2.0 * log(2.0));
 static const double fwhm_to_sigma = 1.0 / sigma_to_fwhm;
 
+void atomic_add_double(std::atomic<double> &ad, double d);
+int atomic_add_double_return_reattempts(std::atomic<double> &ad, double d);
+
 #include "GateHelpers.txx"
 
 #endif // GateHelpers_h

--- a/core/opengate_core/opengate_lib/pyGateDoseSpeedTestActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateDoseSpeedTestActor.cpp
@@ -1,0 +1,30 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "GateDoseSpeedTestActor.h"
+
+void init_GateDoseSpeedTestActor(py::module &m) {
+  py::class_<GateDoseSpeedTestActor,
+             std::unique_ptr<GateDoseSpeedTestActor, py::nodelete>, GateVActor>(
+      m, "GateDoseSpeedTestActor")
+      .def(py::init<py::dict &>())
+      .def("PrepareStorage", &GateDoseSpeedTestActor::PrepareStorage)
+      .def("GetTotalReattemptsAtomicAdd",
+           &GateDoseSpeedTestActor::GetTotalReattemptsAtomicAdd)
+      .def("GetTotalDepositWrites",
+           &GateDoseSpeedTestActor::GetTotalDepositWrites)
+      .def_readwrite("cpp_reference_image",
+                     &GateDoseSpeedTestActor::cpp_reference_image)
+      .def_readwrite("cpp_image", &GateDoseSpeedTestActor::cpp_image)
+      .def_readwrite("fPhysicalVolumeName",
+                     &GateDoseSpeedTestActor::fPhysicalVolumeName);
+}

--- a/opengate/actors/actorbuilders.py
+++ b/opengate/actors/actorbuilders.py
@@ -1,5 +1,5 @@
 from .arfactors import ARFActor, ARFTrainingDatasetActor
-from .doseactors import DoseActor, LETActor, FluenceActor
+from .doseactors import DoseActor, LETActor, FluenceActor, DoseSpeedTestActor
 from .digitizers import (
     DigitizerAdderActor,
     DigitizerReadoutActor,
@@ -27,6 +27,7 @@ actor_type_names = {
     DoseActor,
     FluenceActor,
     LETActor,
+    DoseSpeedTestActor,
     SourceInfoActor,
     PhaseSpaceActor,
     DigitizerHitsCollectionActor,

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -627,3 +627,152 @@ class FluenceActor(g4.GateFluenceActor, ActorBase):
                 self.simulation.get_output_path(self.user_info.output)
             )
             itk.imwrite(self.py_fluence_image, out_p)
+
+
+class DoseSpeedTestActor(g4.GateDoseSpeedTestActor, ActorBase):
+
+    type_name = "DoseSpeedTestActor"
+
+    def set_default_user_info(user_info):
+        ActorBase.set_default_user_info(user_info)
+        # required user info, default values
+        mm = g4_units.mm
+        user_info.size = [10, 10, 10]
+        user_info.spacing = [1 * mm, 1 * mm, 1 * mm]
+        user_info.output = "DoseSpeedTestActor.mhd"  # FIXME change to 'output' ?
+        user_info.translation = [0, 0, 0]
+        user_info.img_coord_system = None
+        user_info.output_origin = None
+        user_info.physical_volume_index = None
+        user_info.storage_method = "atomic"
+
+    def __init__(self, user_info):
+        ## TODO: why not super? what would happen?
+        ActorBase.__init__(self, user_info)
+        g4.GateDoseSpeedTestActor.__init__(self, user_info.__dict__)
+        # attached physical volume (at init)
+        self.g4_phys_vol = None
+        # default image (py side)
+        self.py_reference_image = None
+        self.py_image = None
+        self.dose_array = None
+
+        # internal states
+        self.img_origin_during_run = None
+        self.first_run = None
+        self.output_origin = None
+
+    def __str__(self):
+        u = self.user_info
+        s = f'DoseSpeedTestActor "{u.name}": dim={u.size} spacing={u.spacing} {u.output} tr={u.translation}'
+        return s
+
+    def __getstate__(self):
+        # superclass getstate
+        ActorBase.__getstate__(self)
+        # do not pickle itk images
+        self.py_reference_image = None
+        self.py_image = None
+        return self.__dict__
+
+    def initialize(self, volume_engine=None):
+        """
+        At the start of the run, the image is centered according to the coordinate system of
+        the mother volume. This function computes the correct origin = center + translation.
+        Note that there is a half-pixel shift to align according to the center of the pixel,
+        like in ITK.
+        """
+        super().initialize(volume_engine)
+        # create itk image (py side)
+        size = np.array(self.user_info.size)
+        spacing = np.array(self.user_info.spacing)
+        self.py_reference_image = create_3d_image(size, spacing, "double")
+        # TODO remove code
+        # compute the center, using translation and half pixel spacing
+        self.img_origin_during_run = (
+            -size * spacing / 2.0 + spacing / 2.0 + self.user_info.translation
+        )
+        # for initialization during the first run
+        self.first_run = True
+
+    def StartSimulationAction(self):
+        # init the origin and direction according to the physical volume
+        # (will be updated in the BeginOfRun)
+        attached_to_volume = self.volume_engine.get_volume(self.user_info.mother)
+        if self.user_info.physical_volume_index is None:
+            physical_volume_index = 0
+        else:
+            physical_volume_index = self.user_info.physical_volume_index
+        try:
+            self.g4_phys_vol = attached_to_volume.g4_physical_volumes[
+                physical_volume_index
+            ]
+        except:  # FIXME: need explicit exception
+            fatal(f"Error in the DoseSpeedTestActor {self.user_info.name}")
+        align_image_with_physical_volume(
+            attached_to_volume,
+            self.py_reference_image,
+            initial_translation=self.user_info.translation,
+        )
+
+        # Set the real physical volume name
+        self.fPhysicalVolumeName = str(self.g4_phys_vol.GetName())
+
+        # FIXME for multiple run and motion
+        if not self.first_run:
+            warning(f"Not implemented yet: LETActor with several runs")
+        # send itk image to cpp side, copy data only the first run.
+        update_image_py_to_cpp(
+            self.py_reference_image, self.cpp_reference_image, copy_data=False
+        )
+        self.PrepareStorage()
+
+        # now, indicate the next run will not be the first
+        self.first_run = False
+
+        # If attached to a voxelized volume, we may want to use its coord system.
+        # So, we compute in advance what will be the final origin of the dose map
+        vol = self.simulation.volume_manager.get_volume(self.user_info.mother)
+        self.output_origin = self.img_origin_during_run
+
+        # FIXME put out of the class ?
+        if vol.volume_type == "Image":
+            if self.user_info.img_coord_system:
+                vol = self.volume_engine.g4_volumes[vol.name]
+                # Translate the output dose map so that its center correspond to the image center.
+                # The origin is thus the center of the first voxel.
+                img_info = get_info_from_image(vol.image)
+                dose_info = get_info_from_image(self.py_reference_image)
+                self.output_origin = get_origin_wrt_images_g4_position(
+                    img_info, dose_info, self.user_info.translation
+                )
+        else:
+            if self.user_info.img_coord_system:
+                warning(
+                    f'DoseSpeedTestActor "{self.user_info.name}" has '
+                    f"the flag img_coord_system set to True, "
+                    f"but it is not attached to an Image "
+                    f'volume ("{vol.name}", of type "{vol.volume_type}"). '
+                    f"So the flag is ignored."
+                )
+        # user can set the output origin
+        if self.user_info.output_origin is not None:
+            if self.user_info.img_coord_system:
+                warning(
+                    f'DoseSpeedTestActor "{self.user_info.name}" has '
+                    f"the flag img_coord_system set to True, "
+                    f"but output_origin is set, so img_coord_system ignored."
+                )
+            self.output_origin = self.user_info.output_origin
+
+    def EndSimulationAction(self):
+        g4.GateLETActor.EndSimulationAction(self)
+        self.py_image = create_image_like(self.py_reference_image)
+        self.py_image = get_cpp_image(self.cpp_image)
+
+        self.dose_array = np.array(self.py_image)
+
+        # write the image at the end of the run
+        # FIXME : maybe different for several runs
+        if self.user_info.output:
+            itk.imwrite(self.py_image, ensure_filename_is_str(self.user_info.output))

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -645,6 +645,7 @@ class DoseSpeedTestActor(g4.GateDoseSpeedTestActor, ActorBase):
         user_info.output_origin = None
         user_info.physical_volume_index = None
         user_info.storage_method = "atomic"
+        user_info.count_write_attempts = False
 
     def __init__(self, user_info):
         ## TODO: why not super? what would happen?

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -978,6 +978,7 @@ class SimulationOutput:
         self.ppid = os.getppid()
         self.current_random_seed = None
         self.hook_log = []
+        self.simulation_time = None
 
     def store_actors(self, simulation_engine):
         self.actors = simulation_engine.actor_engine.actors
@@ -1098,6 +1099,7 @@ class SimulationEngine:
         # a list to store short log messages
         # produced by hook function such as user_hook_after_init
         self.hook_log = []  # FIXME: turn this into dictionary
+        self.simulation_time = None
 
     def close_engines(self):
         if self.volume_engine:
@@ -1189,7 +1191,10 @@ class SimulationEngine:
             self.user_hook_after_init(self)
 
         # go
+        start = time.time()
         self.start_and_stop()
+        end = time.time()
+        self.simulation_time = end - start
 
         # start visualization if vrml or gdml
         self.visu_engine.start_visualisation()
@@ -1203,6 +1208,7 @@ class SimulationEngine:
         output.store_sources(self)
         output.store_hook_log(self)
         output.current_random_seed = self.current_random_seed
+        output.simulation_time = self.simulation_time
 
         return output
 

--- a/opengate/image.py
+++ b/opengate/image.py
@@ -44,9 +44,8 @@ def create_3d_image(size, spacing, pixel_type="float", allocate=True, fill_value
     size = np.array(size)
     region.SetSize(size.tolist())
     region.SetIndex([0, 0, 0])
-    spacing = np.array(spacing)
     img.SetRegions(region)
-    img.SetSpacing(spacing)
+    img.SetSpacing(list(spacing))
     # (default origin and direction)
     if allocate:
         img.Allocate()

--- a/opengate/tests/src/test080_dose_speed_compare_profiles.py
+++ b/opengate/tests/src/test080_dose_speed_compare_profiles.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test080_dose_speed_test_helpers import plot_profile_comparison, test_scenarios
+
+if __name__ == "__main__":
+    scenarios = dict(
+        (k, s) for k, s in test_scenarios.items() if s["number_of_threads"] == 4
+    )
+    plot_profile_comparison(scenarios, n_primaries=1e4)

--- a/opengate/tests/src/test080_dose_speed_test_1d_voxels.py
+++ b/opengate/tests/src/test080_dose_speed_test_1d_voxels.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test080_dose_speed_test_helpers import run_experiment, test_scenarios
+
+if __name__ == "__main__":
+    run_experiment(test_scenarios, "large")

--- a/opengate/tests/src/test080_dose_speed_test_3d_small_voxels.py
+++ b/opengate/tests/src/test080_dose_speed_test_3d_small_voxels.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test080_dose_speed_test_helpers import run_experiment, test_scenarios
+
+if __name__ == "__main__":
+    run_experiment(test_scenarios, "small")

--- a/opengate/tests/src/test080_dose_speed_test_all.py
+++ b/opengate/tests/src/test080_dose_speed_test_all.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test080_dose_speed_test_helpers import run_experiment, test_scenarios
+
+if __name__ == "__main__":
+    run_experiment(test_scenarios, "small")
+    run_experiment(test_scenarios, "large")
+    run_experiment(test_scenarios, "single")

--- a/opengate/tests/src/test080_dose_speed_test_helpers.py
+++ b/opengate/tests/src/test080_dose_speed_test_helpers.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 
 from scipy.spatial.transform import Rotation
+import numpy as np
+import json
+import matplotlib.pyplot as plt
+
 import opengate as gate
 from opengate.tests import utility
-
 
 test_paths = utility.get_default_test_paths(__file__, "gate_test080_dose_speed_test")
 
@@ -24,44 +27,54 @@ def create_dict_key(s):
     return f"{s['storage_method']}_{s['number_of_threads']}"
 
 
-scenarios = {}
+def create_label(s):
+    return f"{s['name']}, {s['number_of_threads']} threads"
+
+
+test_scenarios = {}
 s = {"storage_method": "local", "number_of_threads": 1, "name": "G4Cache<threadLocalT>"}
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {"storage_method": "local", "number_of_threads": 4, "name": "G4Cache<threadLocalT>"}
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {
     "storage_method": "standard",
     "number_of_threads": 1,
     "name": "std::vector<double>",
 }
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {
     "storage_method": "atomic",
     "number_of_threads": 1,
     "name": "std::deque<std::atomic<double>>",
 }
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {
     "storage_method": "atomic",
     "number_of_threads": 4,
     "name": "std::deque<std::atomic<double>>",
 }
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {
     "storage_method": "atomic_vec_pointer",
     "number_of_threads": 1,
     "name": "std::vector<std::atomic<double>>*",
 }
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 s = {
     "storage_method": "atomic_vec_pointer",
     "number_of_threads": 4,
     "name": "std::vector<std::atomic<double>>*",
 }
-scenarios[create_dict_key(s)] = s
+test_scenarios[create_dict_key(s)] = s
 
 
-def run_simu(number_of_primaries, storage_method, number_of_threads, pixel_size):
+def run_simu(
+    number_of_primaries,
+    storage_method,
+    number_of_threads,
+    pixel_size,
+    count_write_attempts=False,
+):
     # create the simulation
     sim = gate.Simulation()
 
@@ -71,9 +84,6 @@ def run_simu(number_of_primaries, storage_method, number_of_threads, pixel_size)
     sim.visu = False
     sim.random_seed = 12345678910
     sim.number_of_threads = number_of_threads
-
-    # numPartSimTest = 2000
-    numPartSimTest = number_of_primaries
 
     # units
     cm = gate.g4_units.cm
@@ -86,50 +96,107 @@ def run_simu(number_of_primaries, storage_method, number_of_threads, pixel_size)
 
     # waterbox
     phantom = sim.add_volume("Box", "phantom")
-    phantom.size = [10 * cm, 10 * cm, 10 * cm]
-    phantom.translation = [-5 * cm, 0, 0]
+    phantom.size = [20 * cm, 10 * cm, 10 * cm]
+    phantom.translation = [15 * cm, 0, 0]
     phantom.material = "G4_WATER"
     phantom.color = [0, 0, 1, 1]
-
-    test_material_name = "G4_WATER"
-    phantom_off = sim.add_volume("Box", "phantom_off")
-    phantom_off.mother = phantom.name
-    phantom_off.size = [100 * mm, 60 * mm, 60 * mm]
-    phantom_off.translation = [0 * mm, 0 * mm, 0 * mm]
-    phantom_off.material = test_material_name
-    phantom_off.color = [0, 0, 1, 1]
-    # phantom_off.set_max_step_size(1 * mm)
-    # sim.physics_manager.user_limits_particles.all = True
+    phantom.set_max_step_size(2 * mm)
+    sim.physics_manager.user_limits_particles.all = True
 
     # default source for tests
     source = sim.add_source("GenericSource", "mysource")
-    source.energy.mono = 80 * MeV
+    source.energy.mono = 150 * MeV
     source.particle = "proton"
     source.position.type = "disc"
     source.position.rotation = Rotation.from_euler("y", 90, degrees=True).as_matrix()
-    source.position.radius = 30 * mm
+    source.position.radius = 10 * mm
     source.position.translation = [0, 0, 0]
     source.direction.type = "momentum"
-    source.direction.momentum = [-1, 0, 0]
-    source.n = numPartSimTest / sim.number_of_threads
+    source.direction.momentum = [1, 0, 0]
+    source.n = number_of_primaries / sim.number_of_threads
 
     if pixel_size == "small":
         spacing = [2.0 * mm, 2.0 * mm, 2.0 * mm]
     elif pixel_size == "large":
-        spacing = [10.0 * mm, phantom_off.size[1], phantom_off.size[2]]
+        spacing = [10.0 * mm, phantom.size[1], phantom.size[2]]
     elif pixel_size == "single":
-        spacing = phantom_off.size
-    size = [int(length / s) for length, s in zip(phantom_off.size, spacing)]
+        spacing = phantom.size
+    else:
+        raise ValueError(
+            "Unknown pixelation. Known values are 'small', 'large', 'single'."
+        )
+    size = [int(length / s) for length, s in zip(phantom.size, spacing)]
     print(f"size: {size}")
 
     dose_speed_test_actor = sim.add_actor("DoseSpeedTestActor", "dose_speed_test_actor")
-    dose_speed_test_actor.mother = phantom_off.name
+    dose_speed_test_actor.mother = phantom.name
     dose_speed_test_actor.size = size
     dose_speed_test_actor.spacing = spacing
     dose_speed_test_actor.storage_method = storage_method
+    dose_speed_test_actor.count_write_attempts = count_write_attempts
 
     # start simulation
     sim.user_hook_after_run = hook_number_of_reattempts
     sim.run(start_new_process=True)
 
     return sim.output
+
+
+def run_experiment(scenarios, pixelation):
+    """
+    scenarios: A dictionary of dictionary, e.g. as defined above.
+        Each dictionary contains the parameters of a test case.
+    pixelation: A string specifying how the dose actor should be pixelated.
+        'small' means 2 mm voxels,
+        'large' means 10 mm depth slices, no transverse slicing
+        'single' means one single voxel covering the entire volume
+    """
+    n_primaries_list = np.logspace(3, 7, num=9)
+
+    for k, scenario in scenarios.items():
+        sim_times = []
+        for n_primaries in n_primaries_list:
+            print(30 * "*")
+            print(f"Running {k} with {n_primaries} primaries.")
+            print(30 * "*")
+            output = run_simu(
+                n_primaries,
+                scenario["storage_method"],
+                scenario["number_of_threads"],
+                pixel_size=pixelation,
+            )
+            sim_times.append(output.simulation_time)
+
+        scenario["sim_times"] = sim_times
+        scenario["n_primaries_list"] = n_primaries_list.tolist()
+
+    with open(
+        test_paths.output / f"results_doseactor_speed_comparison_{pixelation}.json", "w"
+    ) as fp:
+        json.dump(scenarios, fp, indent=4)
+
+
+def plot_profile_comparison(scenarios, n_primaries=1e5):
+    """
+    scenarios: A dictionary of dictionary, e.g. as defined above.
+        Each dictionary contains the parameters of a test case.
+    pixelation: A string specifying how the dose actor should be pixelated.
+        'small' means 2 mm voxels,
+        'large' means 10 mm depth slices, no transverse slicing
+        'single' means one single voxel covering the entire volume
+    """
+    plt.figure()
+    for s in scenarios.values():
+        print(30 * "*")
+        print(f"Running {create_label(s)} with {n_primaries} primaries.")
+        print(30 * "*")
+        output = run_simu(
+            n_primaries, s["storage_method"], s["number_of_threads"], "large"
+        )
+        dose = output.get_actor("dose_speed_test_actor").dose_array
+        dose_profile = dose.squeeze()
+        plt.plot(dose_profile, label=create_label(s))
+
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(test_paths.output / "dose_speed_test_profile_comparison.pdf")

--- a/opengate/tests/src/test080_dose_speed_test_helpers.py
+++ b/opengate/tests/src/test080_dose_speed_test_helpers.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from scipy.spatial.transform import Rotation
+import opengate as gate
+from opengate.tests import utility
+
+
+test_paths = utility.get_default_test_paths(__file__, "gate_test080_dose_speed_test")
+
+
+def hook_number_of_reattempts(se):
+    a = se.actor_engine.get_actor("dose_speed_test_actor")
+    nb_reattempts = a.GetTotalReattemptsAtomicAdd()
+    nb_deposit_writes = a.GetTotalDepositWrites()
+    print(
+        f"Nb. reattempts / total writes: {nb_reattempts}/{nb_deposit_writes} = {float(nb_reattempts) / float(nb_deposit_writes) * 100.} %"
+    )
+    se.hook_log.append(nb_reattempts)
+    se.hook_log.append(nb_deposit_writes)
+
+
+def create_dict_key(s):
+    return f"{s['storage_method']}_{s['number_of_threads']}"
+
+
+scenarios = {}
+s = {"storage_method": "local", "number_of_threads": 1, "name": "G4Cache<threadLocalT>"}
+scenarios[create_dict_key(s)] = s
+s = {"storage_method": "local", "number_of_threads": 4, "name": "G4Cache<threadLocalT>"}
+scenarios[create_dict_key(s)] = s
+s = {
+    "storage_method": "standard",
+    "number_of_threads": 1,
+    "name": "std::vector<double>",
+}
+scenarios[create_dict_key(s)] = s
+s = {
+    "storage_method": "atomic",
+    "number_of_threads": 1,
+    "name": "std::deque<std::atomic<double>>",
+}
+scenarios[create_dict_key(s)] = s
+s = {
+    "storage_method": "atomic",
+    "number_of_threads": 4,
+    "name": "std::deque<std::atomic<double>>",
+}
+scenarios[create_dict_key(s)] = s
+s = {
+    "storage_method": "atomic_vec_pointer",
+    "number_of_threads": 1,
+    "name": "std::vector<std::atomic<double>>*",
+}
+scenarios[create_dict_key(s)] = s
+s = {
+    "storage_method": "atomic_vec_pointer",
+    "number_of_threads": 4,
+    "name": "std::vector<std::atomic<double>>*",
+}
+scenarios[create_dict_key(s)] = s
+
+
+def run_simu(number_of_primaries, storage_method, number_of_threads, pixel_size):
+    # create the simulation
+    sim = gate.Simulation()
+
+    # main options
+    sim.g4_verbose = False
+    sim.g4_verbose_level = 1
+    sim.visu = False
+    sim.random_seed = 12345678910
+    sim.number_of_threads = number_of_threads
+
+    # numPartSimTest = 2000
+    numPartSimTest = number_of_primaries
+
+    # units
+    cm = gate.g4_units.cm
+    mm = gate.g4_units.mm
+    MeV = gate.g4_units.MeV
+
+    #  change world size
+    world = sim.world
+    world.size = [600 * cm, 500 * cm, 500 * cm]
+
+    # waterbox
+    phantom = sim.add_volume("Box", "phantom")
+    phantom.size = [10 * cm, 10 * cm, 10 * cm]
+    phantom.translation = [-5 * cm, 0, 0]
+    phantom.material = "G4_WATER"
+    phantom.color = [0, 0, 1, 1]
+
+    test_material_name = "G4_WATER"
+    phantom_off = sim.add_volume("Box", "phantom_off")
+    phantom_off.mother = phantom.name
+    phantom_off.size = [100 * mm, 60 * mm, 60 * mm]
+    phantom_off.translation = [0 * mm, 0 * mm, 0 * mm]
+    phantom_off.material = test_material_name
+    phantom_off.color = [0, 0, 1, 1]
+    # phantom_off.set_max_step_size(1 * mm)
+    # sim.physics_manager.user_limits_particles.all = True
+
+    # default source for tests
+    source = sim.add_source("GenericSource", "mysource")
+    source.energy.mono = 80 * MeV
+    source.particle = "proton"
+    source.position.type = "disc"
+    source.position.rotation = Rotation.from_euler("y", 90, degrees=True).as_matrix()
+    source.position.radius = 30 * mm
+    source.position.translation = [0, 0, 0]
+    source.direction.type = "momentum"
+    source.direction.momentum = [-1, 0, 0]
+    source.n = numPartSimTest / sim.number_of_threads
+
+    if pixel_size == "small":
+        spacing = [2.0 * mm, 2.0 * mm, 2.0 * mm]
+    elif pixel_size == "large":
+        spacing = [10.0 * mm, phantom_off.size[1], phantom_off.size[2]]
+    elif pixel_size == "single":
+        spacing = phantom_off.size
+    size = [int(length / s) for length, s in zip(phantom_off.size, spacing)]
+    print(f"size: {size}")
+
+    dose_speed_test_actor = sim.add_actor("DoseSpeedTestActor", "dose_speed_test_actor")
+    dose_speed_test_actor.mother = phantom_off.name
+    dose_speed_test_actor.size = size
+    dose_speed_test_actor.spacing = spacing
+    dose_speed_test_actor.storage_method = storage_method
+
+    # start simulation
+    sim.user_hook_after_run = hook_number_of_reattempts
+    sim.run(start_new_process=True)
+
+    return sim.output

--- a/opengate/tests/src/test080_dose_speed_test_reattempts.py
+++ b/opengate/tests/src/test080_dose_speed_test_reattempts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from scipy.spatial.transform import Rotation
+import opengate as gate
+from opengate.tests import utility
+
+import matplotlib.pyplot as plt
+import numpy as np
+import json
+
+from test080_dose_speed_test_helpers import run_simu, create_dict_key, test_paths
+
+
+if __name__ == "__main__":
+
+    scenarios = {}
+    s = {
+        "storage_method": "atomic",
+        "number_of_threads": 4,
+        "name": "std::deque<std::atomic<double>>",
+    }
+    scenarios[create_dict_key(s)] = s
+    s = {
+        "storage_method": "atomic_vec_pointer",
+        "number_of_threads": 4,
+        "name": "std::vector<std::atomic<double>>*",
+    }
+    scenarios[create_dict_key(s)] = s
+
+    n_primaries = 1e4
+    pixel_size_list = ["small", "large", "single"]
+
+    for k, s in scenarios.items():
+        reattempts = []
+        total_writes = []
+        for ps in pixel_size_list:
+            print(30 * "*")
+            print(f"Running {k} with {n_primaries} primaries and pixel size '{ps}'.")
+            print(30 * "*")
+            output = run_simu(
+                n_primaries,
+                s["storage_method"],
+                s["number_of_threads"],
+                pixel_size=ps,
+                count_write_attempts=True,
+            )
+            reattempts.append(output.hook_log[0])
+            total_writes.append(output.hook_log[1])
+
+        s["reattempts"] = reattempts
+        s["total_writes"] = total_writes
+        s["n_primaries"] = n_primaries
+        s["pixel_size_list"] = pixel_size_list
+
+    with open(
+        test_paths.output / "results_doseactor_speed_comparison_reattempts.json", "w"
+    ) as fp:
+        json.dump(scenarios, fp, indent=4)

--- a/opengate/tests/src/test080_dose_speed_test_single_voxel.py
+++ b/opengate/tests/src/test080_dose_speed_test_single_voxel.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from test080_dose_speed_test_helpers import run_experiment, test_scenarios
+
+if __name__ == "__main__":
+    run_experiment(test_scenarios, "single")

--- a/opengate/tests/src/test080_plot_dose_speed_test.py
+++ b/opengate/tests/src/test080_plot_dose_speed_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import matplotlib.pyplot as plt
+import matplotlib
+from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
+from mpl_toolkits.axes_grid1.inset_locator import mark_inset
+import numpy as np
+import json
+
+from test080_dose_speed_test_helpers import create_label, test_paths
+
+matplotlib.style.use("ggplot")
+
+
+def get_color_from_key(k):
+    if "local" in k:
+        return "C1"
+    elif "standard" in k:
+        return "k"
+    elif "pointer" in k:
+        return "C0"
+    elif "atomic" in k:
+        return "C5"
+
+
+def get_marker_from_key(k):
+    if "local" in k:
+        return "s"
+    elif "standard" in k:
+        return "o"
+    elif "pointer" in k:
+        return "v"
+    elif "atomic" in k:
+        return "^"
+
+
+def plot_results(which):
+    filename = test_paths.output / f"results_doseactor_speed_comparison_{which}.json"
+    n_primaries_list = [1e3, 1e4]  # , 1e5, 1e6]
+    plt.figure(figsize=(7, 5))
+    ax = plt.gca()
+    axins = zoomed_inset_axes(
+        ax, 8, loc="upper left", axes_kwargs={"frame_on": True}
+    )  # zoom = 6
+    with open(filename, "r") as fp:
+        scenarios = json.load(fp)
+        marker_size = 20
+        for k, s in scenarios.items():
+            if s["number_of_threads"] == 1:
+                ls = "--"
+            else:
+                ls = "-"
+            # s['n_primaries_list']
+            color = get_color_from_key(k)
+            marker = get_marker_from_key(k)
+            (l,) = ax.plot(
+                s["n_primaries_list"],
+                s["sim_times"],
+                label=create_label(s),
+                color=color,
+                linestyle=ls,
+            )
+            ax.scatter(
+                s["n_primaries_list"],
+                s["sim_times"],
+                s=marker_size,
+                marker=marker,
+                color=l.get_color(),
+                alpha=0.5,
+            )
+            axins.plot(
+                s["n_primaries_list"], s["sim_times"], color=l.get_color(), linestyle=ls
+            )
+            axins.scatter(
+                s["n_primaries_list"],
+                s["sim_times"],
+                s=marker_size,
+                marker=marker,
+                color=l.get_color(),
+                alpha=0.5,
+            )
+            marker_size *= 1.2
+
+    axins.yaxis.set_ticklabels([])
+    plt.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
+    axins.set_xlim([0.05 * v for v in ax.get_xlim()])
+    axins.set_ylim([0.05 * v for v in ax.get_ylim()])
+    mark_inset(ax, axins, loc1=2, loc2=4, fc="none", ec="0.5")
+
+    for pos in ["top", "bottom", "right", "left"]:
+        axins.spines[pos].set_edgecolor("k")
+        axins.spines[pos].set(linewidth=0.5)
+
+    ax.set_xlabel("Number of primaries")
+    ax.set_ylabel("Simulation time in s")
+
+    ax.legend(loc=(0, 1.02), fontsize="xx-small")
+
+    plt.tight_layout()
+    plt.show()
+    plt.savefig(test_paths.output / f"dose_actor_speed_test_{which}.pdf")
+    plt.savefig(test_paths.output / f"dose_actor_speed_test_{which}.png", dpi=300)
+
+
+if __name__ == "__main__":
+    plot_results("small")
+    plot_results("large")
+    plot_results("single")


### PR DESCRIPTION
This PR is to test different ways to implement the DoseActor (and similar actors) in multithread mode. 

It particularly, it implements different lock-free structures to store the dose per voxel deposited in the SteppingAction. 
It tests an approach via thread-local vectors against structures based on std::atomic, in particular std::duque<std::double> and std::vector<std::atomic<double>>*. 

The PR contains several tests relying on a helper module and a plot script. 

This PR should currently not be merged. It is for testing only. 