### PR TITLE
Add back to back source 

### DIFF
--- a/core/opengate_core/opengate_lib/GateGenericSource.h
+++ b/core/opengate_core/opengate_lib/GateGenericSource.h
@@ -50,18 +50,12 @@ public:
   void SetTAC(const std::vector<double> &times,
               const std::vector<double> &activities);
 
+  void InitializeBackToBackMode(py::dict &user_info);
+
 protected:
-  // unsigned long fMaxN;
   //  We cannot not use a std::unique_ptr
   //  (or maybe by controlling the deletion during the CleanWorkerThread ?)
   GateSingleParticleSource *fSPS;
-  /*
-  double fActivity;
-  double fInitialActivity;
-  double fHalfLife;
-  double fLambda;
-  */
-
   G4ParticleDefinition *fParticleDefinition;
   G4ThreeVector fInitializeMomentum;
   G4ThreeVector fInitiliazeFocusPoint;
@@ -83,6 +77,9 @@ protected:
   double fE; // E: Excitation energy
   double fWeight;
   double fWeightSigma;
+
+  // back to back source
+  bool fBackToBackMode;
 
   // Force the rotation of momentum and focal point to follow rotation of the
   // source, eg: needed for motion actor

--- a/core/opengate_core/opengate_lib/GateSingleParticleSource.h
+++ b/core/opengate_core/opengate_lib/GateSingleParticleSource.h
@@ -52,6 +52,11 @@ public:
   G4ThreeVector GenerateDirectionWithAA(const G4ThreeVector &position,
                                         bool &accept);
 
+  void GeneratePrimaryVertexBackToBack(G4Event *event, G4ThreeVector &position,
+                                       G4ThreeVector &direction, double energy);
+
+  void SetBackToBackMode(bool flag, bool accolinearityFlag);
+
 protected:
   G4ParticleDefinition *fParticleDefinition;
   double fCharge;
@@ -60,6 +65,8 @@ protected:
   G4SPSAngDistribution *fDirectionGenerator;
   GateSPSEneDistribution *fEnergyGenerator;
   G4SPSRandomGenerator *fBiasRndm;
+  bool fAccolinearityFlag;
+  bool fBackToBackMode;
 
   // for acceptance angle
   GateAcceptanceAngleTesterManager *fAAManager;

--- a/opengate/sources/generic.py
+++ b/opengate/sources/generic.py
@@ -3,13 +3,11 @@ from scipy.spatial.transform import Rotation
 import pathlib
 import numpy as np
 
-
 import opengate_core
 from ..utility import g4_units
 from ..exception import fatal, warning
 from ..definitions import __world_name__
 from ..userelement import UserElement
-
 
 gate_source_path = pathlib.Path(__file__).parent.resolve()
 
@@ -346,6 +344,7 @@ class GenericSource(SourceBase):
         user_info.direction.acceptance_angle.normal_flag = False
         user_info.direction.acceptance_angle.normal_vector = [0, 0, 1]
         user_info.direction.acceptance_angle.normal_tolerance = 3 * deg
+        user_info.direction.accolinearity_flag = False  # only for back_to_back source
         # energy
         user_info.energy = Box()
         user_info.energy.type = "mono"
@@ -400,6 +399,11 @@ class GenericSource(SourceBase):
             fatal(
                 f"Generic Source: user_info.energy must be a Box, but is: {self.user_info.energy}"
             )
+
+        if self.user_info.particle == "back_to_back":
+            # force the energy to 511 keV
+            self.user_info.energy.type = "mono"
+            self.user_info.energy.mono = 511 * g4_units.keV
 
         # check energy type
         l = [

--- a/opengate/tests/src/test072_back_to_back_source.py
+++ b/opengate/tests/src/test072_back_to_back_source.py
@@ -1,9 +1,97 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+#########################################################################################
+# Imports
+#########################################################################################
 import opengate as gate
 from opengate.tests import utility
 
+import uproot
+import numpy as np
+
+
+#########################################################################################
+# Simulations configuration that may be relevant to change
+#########################################################################################
+# Number of back-to-back to generate
+nbEvents = 100
+
+
+#########################################################################################
+# Constants
+#########################################################################################
+# Units
+MeV = gate.g4_units.MeV
+keV = gate.g4_units.keV
+Bq = gate.g4_units.Bq
+deg = gate.g4_units.deg
+mm = gate.g4_units.mm
+m = gate.g4_units.m
+cm = gate.g4_units.cm
+
+
+#########################################################################################
+# Methods used in this test
+#########################################################################################
+def test_backToBack(_pathToRootFile, _nbB2b):
+    """
+    Def.: zxc FIXME
+    """
+    # get data from root file
+    b2b_root = uproot.open(_pathToRootFile)["phsp;1"].arrays(library="numpy")
+
+    # Assuming that trackId is relative to a eventId, it provides use a way to check
+    # that everything start with two gammas.
+    # It does not take into account 3+ gamma cases but I do not know how to do better
+    b2b_eventId_adamEve = b2b_root["TrackID"] <= 2
+
+    b2b_emissionEnergy = b2b_root["EventKineticEnergy"][b2b_eventId_adamEve]
+
+    b2b_particleName = b2b_root["ParticleName"][b2b_eventId_adamEve]
+
+    b2b_dir = (
+        np.stack(
+            (
+                b2b_root["PreDirection_X"],
+                b2b_root["PreDirection_Y"],
+                b2b_root["PreDirection_Z"],
+            )
+        ).T
+    )[b2b_eventId_adamEve]
+    # For easier manipulation
+    b2b_dir = b2b_dir.reshape((_nbB2b, 2, 3))
+
+    # Note: We assumes that thing that are not specific to back-to-back were already
+    # tested, for example the number of particle
+    # FIXME Would be better to check fAccolinearityFlag but might not be accessible?
+    is_b2b = source.particle == "back_to_back"
+    is_monoEnergy = source.energy.type == "mono"
+    is_def511kev = source.energy.mono == 511 * keV
+    is_defNoAcolin = source.direction.accolinearity_flag == False
+    is_allB2b511keV = np.all(np.isclose(b2b_emissionEnergy, 0.511, atol=10**-3))
+    is_allEmissionGamme = np.all(b2b_particleName == "gamma")
+    is_b2bColin = np.all(
+        np.isclose(
+            np.sum(b2b_dir[:, 0, :] * b2b_dir[:, 1, :], axis=-1), -1.0, atol=10**-3
+        )
+    )
+    # FIXME: Confirm it stay in the sphere?
+
+    return (
+        is_b2b
+        & is_monoEnergy
+        & is_def511kev
+        & is_defNoAcolin
+        & is_allB2b511keV
+        & is_allEmissionGamme
+        & is_b2bColin
+    )
+
+
+#########################################################################################
+# Main : We use this to launch the test
+#########################################################################################
 if __name__ == "__main__":
     paths = utility.get_default_test_paths(__file__, output_folder="test072")
 
@@ -18,15 +106,6 @@ if __name__ == "__main__":
     sim.number_of_threads = 1
     # sim.random_seed = 123456
 
-    # useful units
-    MeV = gate.g4_units.MeV
-    keV = gate.g4_units.keV
-    Bq = gate.g4_units.Bq
-    deg = gate.g4_units.deg
-    mm = gate.g4_units.mm
-    m = gate.g4_units.m
-    cm = gate.g4_units.cm
-
     # set the world size like in the Gate macro
     world = sim.world
     world.size = [2 * m, 2 * m, 2 * m]
@@ -34,7 +113,7 @@ if __name__ == "__main__":
     # test sources
     source = sim.add_source("GenericSource", "b2b")
     source.particle = "back_to_back"
-    source.n = 100
+    source.n = nbEvents
     source.position.type = "sphere"
     source.position.radius = 5 * mm
     source.direction.type = "iso"
@@ -46,12 +125,14 @@ if __name__ == "__main__":
     stats_actor = sim.add_actor("SimulationStatisticsActor", "Stats")
 
     # store phsp
-    phsp = sim.add_actor("PhaseSpaceActor", "phsp")
-    phsp.attributes = [
+    phsp_actor = sim.add_actor("PhaseSpaceActor", "phsp")
+    phsp_actor.attributes = [
         "EventID",
         "TrackID",
         "EventPosition",
         "EventDirection",
+        "Direction",
+        "EventKineticEnergy",
         "KineticEnergy",
         "ParticleName",
         "TimeFromBeginOfEvent",
@@ -59,9 +140,9 @@ if __name__ == "__main__":
         "LocalTime",
         "PDGCode",
         "PostPosition",
-        "PostDirection",
+        "PreDirection",
     ]
-    phsp.output = paths.output / "b2b.root"
+    phsp_actor.output = paths.output / "b2b.root"
 
     # verbose
     # sim.g4_verbose = True
@@ -73,10 +154,14 @@ if __name__ == "__main__":
     # start simulation
     sim.run()
 
-    # get results
+    # get results FIXME I might need to do something with this?
     stats = sim.output.get_actor("Stats")
-    print(stats)
+    # print(stats)
 
-    # FIXME : test something
-    is_ok = False
-    utility.test_ok(is_ok)
+    is_ok = test_backToBack(phsp_actor.output, nbEvents)
+    # FIXME confirm acolin when activated
+    # FIXME Other tests?
+
+    # zxc: Hack to see print
+    print("!!!!!!!!!!!!!!! Do all tests passes?", is_ok)
+    utility.test_ok(False)

--- a/opengate/tests/src/test072_back_to_back_source.py
+++ b/opengate/tests/src/test072_back_to_back_source.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import opengate as gate
+from opengate.tests import utility
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test072")
+
+    # create the simulation
+    sim = gate.Simulation()
+
+    # main options
+    sim.g4_verbose = False
+    sim.g4_verbose_level = 1
+    # sim.visu = True
+    sim.visu_type = "vrml"
+    sim.number_of_threads = 1
+    # sim.random_seed = 123456
+
+    # useful units
+    MeV = gate.g4_units.MeV
+    keV = gate.g4_units.keV
+    Bq = gate.g4_units.Bq
+    deg = gate.g4_units.deg
+    mm = gate.g4_units.mm
+    m = gate.g4_units.m
+    cm = gate.g4_units.cm
+
+    # set the world size like in the Gate macro
+    world = sim.world
+    world.size = [2 * m, 2 * m, 2 * m]
+
+    # test sources
+    source = sim.add_source("GenericSource", "b2b")
+    source.particle = "back_to_back"
+    source.n = 100
+    source.position.type = "sphere"
+    source.position.radius = 5 * mm
+    source.direction.type = "iso"
+    source.direction.accolinearity_flag = False
+    # note : source.energy is ignored (always 511 keV)
+    # FIXME : do another test with accolinearity_flag set to True
+
+    # actors
+    stats_actor = sim.add_actor("SimulationStatisticsActor", "Stats")
+
+    # store phsp
+    phsp = sim.add_actor("PhaseSpaceActor", "phsp")
+    phsp.attributes = [
+        "EventID",
+        "TrackID",
+        "EventPosition",
+        "EventDirection",
+        "KineticEnergy",
+        "ParticleName",
+        "TimeFromBeginOfEvent",
+        "GlobalTime",
+        "LocalTime",
+        "PDGCode",
+        "PostPosition",
+        "PostDirection",
+    ]
+    phsp.output = paths.output / "b2b.root"
+
+    # verbose
+    # sim.g4_verbose = True
+    # sim.add_g4_command_after_init("/tracking/verbose 2")
+    # sim.add_g4_command_after_init("/run/verbose 2")
+    # sim.add_g4_command_after_init("/event/verbose 2")
+    # sim.add_g4_command_after_init("/tracking/verbose 1")
+
+    # start simulation
+    sim.run()
+
+    # get results
+    stats = sim.output.get_actor("Stats")
+    print(stats)
+
+    # FIXME : test something
+    is_ok = False
+    utility.test_ok(is_ok)


### PR DESCRIPTION
Start back to back source: the continuation.

David Sarrut made a branch which implements back-to-back. Here, it is the follow-up. Since I can't, I believe, "take-over" his Pull request, see #367, I branched it and started a "new" one. @dsarrut, as long as it seems that I make progress, I suggest that #367 to be closed to make sure that there a no mix-up.

For now, I am trying my teeth and I have added some tests for back-to-back. When this is done, I will implement the acolinearity feature.

However, I have a severe lack of understanding of what Geant4 does. If anyone can provide me a link to a comprehensive description of particle's attributes, it would be a great help. While testing, I do not know if I should look at 'PreDirection', 'Direction' or 'EventDirection'...

Also, @dsarrut , by doc, did you mean document the methods introduced in this PR or a document somewhere?