### PR TITLE
Replace os by pathlib to avoid OS related errors and improve code maintenance

### DIFF
--- a/core/opengate_core/g4DataSetup.py
+++ b/core/opengate_core/g4DataSetup.py
@@ -51,7 +51,7 @@ def check_g4_data():
 
 
 def download_with_resume(url, out, retries=5, delay=10):
-    temp_file = out + ".part"
+    temp_file = str(out) + ".part"
     headers = {}
     if os.path.exists(temp_file):
         file_size = os.path.getsize(temp_file)
@@ -65,7 +65,7 @@ def download_with_resume(url, out, retries=5, delay=10):
                     for chunk in r.iter_content(chunk_size=8192):
                         if chunk:
                             f.write(chunk)
-            os.rename(temp_file, out)
+            os.rename(temp_file, str(out))
             print(f"Downloaded {url} successfully.")
             return
         except requests.exceptions.RequestException as e:

--- a/core/opengate_core/g4DataSetup.py
+++ b/core/opengate_core/g4DataSetup.py
@@ -5,6 +5,7 @@ import platform
 import sys
 import requests
 from time import sleep
+from pathlib import Path
 
 # Data for Geant4
 # Geant4 11.2.1
@@ -26,9 +27,9 @@ data_packages = [
 def check_g4_data():
     # check if the G4 data folder is there
     dataLocation = get_g4_data_folder()
-    if not os.path.exists(dataLocation):
+    if not dataLocation.exists():
         print("Geant4 data folder does not exist.")
-        print("I will create it for you here: " + dataLocation)
+        print("I will create it for you here: " + str(dataLocation))
         print("... and download the G4 data.")
         print("This will take a moment.")
         download_g4_data()
@@ -80,8 +81,7 @@ def download_with_resume(url, out, retries=5, delay=10):
 # Download Geant4 data:
 def download_g4_data():
     data_location = get_g4_data_folder()
-    if not os.path.exists(data_location):
-        os.mkdir(data_location)
+    data_location.mkdir(parents=True, exist_ok=True)
     folder_names_from_tar = set()
     for i, package in enumerate(data_packages):
         print(f"\nDownloading {i + 1}/{len(data_packages)} {package}")
@@ -98,14 +98,14 @@ def download_g4_data():
             # into which the G4 data will be extracted
             extract_to_folder = sorted(tar.getnames(), key=lambda n: len(n))[0]
             folder_names_from_tar.update([extract_to_folder])
-            extract_to_path = os.path.join(data_location, extract_to_folder)
+            extract_to_path = data_location / extract_to_folder
             # remove the directory into which tar wants extract if it
             # already exists to avoid permission error
-            if os.path.exists(extract_to_path):
+            if extract_to_path.exists():
                 print(f"\nNeed to extract into {extract_to_path},")
                 print("but that directory already exists.")
                 print("I need to remove it.")
-                shutil.rmtree(os.path.join(data_location, extract_to_folder))
+                shutil.rmtree(extract_to_path)
             print("Extracting the data archive (tar) ...")
             tar.extractall(path=data_location)
             print("done")
@@ -117,58 +117,53 @@ def check_for_non_required_files_folders():
     """Check if there are old data folders and inform the user."""
     dataLocation = get_g4_data_folder()
     required_paths = set(get_g4_data_paths().values())
-    existing_paths = set(
-        [os.path.join(dataLocation, f) for f in os.listdir(dataLocation)]
-    )
+    existing_paths = set([(dataLocation / f) for f in dataLocation.iterdir()])
     outdated_paths = existing_paths.difference(required_paths)
     if len(outdated_paths) > 0:
         print("\n" + 10 * "*")
         print(f"The following files and folders in {dataLocation}")
         print(f"are not required and can be safely deleted:\n")
         for f in outdated_paths:
-            print(os.path.basename(f))
+            print(str(f))
         print("\n" + 10 * "*")
 
 
-def check_consistency_g4_data_folders():
+def check_consistency_g4_data_folders() -> bool:
     dataLocation = get_g4_data_folder()
     required_paths = set(get_g4_data_paths().values())
-    existing_paths = set(
-        [os.path.join(dataLocation, f) for f in os.listdir(dataLocation)]
-    )
+    existing_paths = set([(dataLocation / f) for f in dataLocation.iterdir()])
     missing_paths = required_paths.difference(existing_paths)
     if len(missing_paths) > 0:
         print("\nSome Geant4 data folder seem to be missing, namely:")
         for p in missing_paths:
-            print(p)
+            print(str(p))
         return False
     else:
         return True
 
 
 # Return Geant4 data folder:
-def get_g4_data_folder():
-    packageLocation = os.path.dirname(os.path.realpath(__file__))
-    dataLocation = os.path.join(packageLocation, "geant4_data")
-    return dataLocation
+def get_g4_data_folder() -> Path:
+    package_location = Path(__file__).resolve().parent
+    return package_location / "geant4_data"
 
 
 # Return Geant4 data path:
-def get_g4_data_paths():
-    dataLocation = get_g4_data_folder()
-    # 11.1
+def get_g4_data_paths() -> dict:
+    data_location = get_g4_data_folder()
+    # 11.2.1
     g4_data_path = {
-        "G4NEUTRONHPDATA": os.path.join(dataLocation, "G4NDL4.7"),
-        "G4LEDATA": os.path.join(dataLocation, "G4EMLOW8.5"),
-        "G4LEVELGAMMADATA": os.path.join(dataLocation, "PhotonEvaporation5.7"),
-        "G4RADIOACTIVEDATA": os.path.join(dataLocation, "RadioactiveDecay5.6"),
-        "G4PARTICLEXSDATA": os.path.join(dataLocation, "G4PARTICLEXS4.0"),
-        "G4PIIDATA": os.path.join(dataLocation, "G4PII1.3"),
-        "G4REALSURFACEDATA": os.path.join(dataLocation, "RealSurface2.2"),
-        "G4SAIDXSDATA": os.path.join(dataLocation, "G4SAIDDATA2.0"),
-        "G4ABLADATA": os.path.join(dataLocation, "G4ABLA3.3"),
-        "G4INCLDATA": os.path.join(dataLocation, "G4INCL1.2"),
-        "G4ENSDFSTATEDATA": os.path.join(dataLocation, "G4ENSDFSTATE2.3"),
+        "G4NEUTRONHPDATA": data_location / "G4NDL4.7",
+        "G4LEDATA": data_location / "G4EMLOW8.5",
+        "G4LEVELGAMMADATA": data_location / "PhotonEvaporation5.7",
+        "G4RADIOACTIVEDATA": data_location / "RadioactiveDecay5.6",
+        "G4PARTICLEXSDATA": data_location / "G4PARTICLEXS4.0",
+        "G4PIIDATA": data_location / "G4PII1.3",
+        "G4REALSURFACEDATA": data_location / "RealSurface2.2",
+        "G4SAIDXSDATA": data_location / "G4SAIDDATA2.0",
+        "G4ABLADATA": data_location / "G4ABLA3.3",
+        "G4INCLDATA": data_location / "G4INCL1.2",
+        "G4ENSDFSTATEDATA": data_location / "G4ENSDFSTATE2.3",
     }
     return g4_data_path
 
@@ -177,26 +172,22 @@ def get_g4_data_paths():
 def set_g4_data_path():
     g4_data_path = get_g4_data_paths()
     for key, value in g4_data_path.items():
-        os.environ[key] = value
+        os.environ[key] = str(value)
     s = platform.system()
     g4_lib_folder = None
 
     if s == "Linux" or s == "Windows":
-        g4_lib_folder = os.path.join(
-            os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "..", "opengate_core.libs"
-            )
-        )
+        g4_lib_folder = Path(__file__).resolve().parent.parent / "opengate_core.libs"
     elif s == "Darwin":
-        g4_lib_folder = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), ".dylibs"
-        )
+        g4_lib_folder = Path(__file__).resolve().parent / ".dylibs"
 
     if s == "Windows":
-        os.add_dll_directory(g4_lib_folder)
+        os.add_dll_directory(str(g4_lib_folder))
     else:
-        sys.path.append(g4_lib_folder)
+        sys.path.append(str(g4_lib_folder))
 
-    if not "LD_LIBRARY_PATH" in os.environ:
+    if "LD_LIBRARY_PATH" not in os.environ:
         os.environ["LD_LIBRARY_PATH"] = ""
-    os.environ["LD_LIBRARY_PATH"] = g4_lib_folder + ":" + os.environ["LD_LIBRARY_PATH"]
+    os.environ["LD_LIBRARY_PATH"] = (
+        str(g4_lib_folder) + ":" + os.environ["LD_LIBRARY_PATH"]
+    )

--- a/core/opengate_core/testsDataSetup.py
+++ b/core/opengate_core/testsDataSetup.py
@@ -3,6 +3,7 @@ import shutil
 import zipfile
 import requests
 import colored
+from pathlib import Path
 from .g4DataSetup import *
 
 try:
@@ -14,53 +15,56 @@ except AttributeError:
 
 # Check and download opengate tests data if not present:
 def check_tests_data_folder():
-    dataLocation = get_tests_data_folder()
-    if not os.path.exists(dataLocation):
-        print("No Opengate test data available in: " + dataLocation)
+    data_location = get_tests_data_folder()
+    if not data_location.exists():
+        print("No Opengate test data available in: " + str(data_location))
         print("I download it for you.")
-        download_tests_data(dataLocation)
+        download_tests_data(data_location)
         print("")
         print("Done")
     else:
         # Check if the commit is correct if file HEAD is present
-        if os.path.isfile(os.path.join(dataLocation, "..", "HEAD")):
-            f = open(os.path.join(dataLocation, "..", "HEAD"), "r")
-            checkoutReferenceDataGit = str(f.readline()).strip()
-            if os.path.isfile(os.path.join(dataLocation, "sha.log")):
-                f = open(os.path.join(dataLocation, "sha.log"), "r")
-                checkoutRealDataGit = str(f.readline()).strip()
-                if not checkoutReferenceDataGit == checkoutRealDataGit:
-                    shutil.rmtree(dataLocation)
-                    print("No correct Opengate test data version in: " + dataLocation)
+        if (data_location.parent / "HEAD").exists():
+            with (data_location.parent / "HEAD").open("r") as f:
+                checkout_reference_data_git = f.readline().strip()
+            if (data_location / "sha.log").exists():
+                with (data_location / "sha.log").open("r") as f:
+                    checkout_real_data_git = f.readline().strip()
+                if checkout_reference_data_git != checkout_real_data_git:
+                    shutil.rmtree(data_location)
+                    print(
+                        "No correct Opengate test data version in: "
+                        + str(data_location)
+                    )
                     print("I update it for you.")
-                    download_tests_data(dataLocation)
+                    download_tests_data(data_location)
                     print("")
                     print("Done")
             else:
-                shutil.rmtree(dataLocation)
-                print("No Opengate test data available in: " + dataLocation)
+                shutil.rmtree(data_location)
+                print("No Opengate test data available in: " + str(data_location))
                 print("I download it for you.")
-                download_tests_data(dataLocation)
+                download_tests_data(data_location)
                 print("")
                 print("Done")
         # Check if the size of one .raw file is correct to detect lfs
-        if "ct_4mm.raw" in os.listdir(dataLocation):
-            filesize = os.stat(os.path.join(dataLocation, "ct_4mm.raw")).st_size
+        if "ct_4mm.raw" in data_location.iterdir():
+            filesize = (data_location / "ct_4mm.raw").stat().st_size
             if filesize < 4000000:
                 print(
                     "It seems the test data in: "
-                    + dataLocation
+                    + str(data_location)
                     + " do not have the correct size"
                 )
                 print("Maybe you do not have git-lfs. Execute this:")
                 print("Install git-lfs from https://git-lfs.com/")
-                print("cd " + dataLocation)
+                print("cd " + str(data_location))
                 print("git-lfs pull")
                 return False
         else:  # if the file is not present
             print(
                 colored.stylize(
-                    "The data are not present in: " + dataLocation,
+                    "The data are not present in: " + str(data_location),
                     color_error,
                 )
             )
@@ -71,57 +75,57 @@ def check_tests_data_folder():
 
 
 # Download opengate tests data:
-def download_tests_data(data_location):
-    os.mkdir(data_location)
-    f = open(os.path.join(data_location, "..", "HEAD"), "r")
-    checkoutDataGit = str(f.readline()).strip()
+def download_tests_data(data_location: Path):
+    data_location.mkdir(parents=True, exist_ok=True)
+    with (data_location.parent / "HEAD").open("r") as f:
+        checkout_data_git = str(f.readline()).strip()
     url = (
         "https://gitlab.in2p3.fr/api/v4/projects/15155/repository/commits/"
-        + checkoutDataGit
+        + checkout_data_git
     )
     r = requests.get(url=url)
     js = r.json()
-    idPipeline = str(js["last_pipeline"]["id"])
+    id_pipeline = str(js["last_pipeline"]["id"])
     url = (
         "https://gitlab.in2p3.fr/api/v4/projects/15155/pipelines/"
-        + idPipeline
+        + id_pipeline
         + "/jobs"
     )
     r = requests.get(url=url)
     js = r.json()[0]
-    idPipeline = str(js["id"])
+    id_pipeline = str(js["id"])
     url = (
         "https://gitlab.in2p3.fr/api/v4/projects/15155/jobs/"
-        + idPipeline
+        + id_pipeline
         + "/artifacts"
     )
 
     # download the archive (with resume if the connexion failed)
     filename = url.split("/")[-1]
-    out = os.path.join(data_location, filename)
+    out = data_location / filename
     download_with_resume(url, out)
 
     if filename == "artifacts":
-        with zipfile.ZipFile(os.path.join(data_location, filename), "r") as zip_ref:
+        with zipfile.ZipFile(data_location / filename, "r") as zip_ref:
             zip_ref.extractall(data_location)
-    os.remove(os.path.join(data_location, filename))
+    os.remove(data_location / filename)
+
     with zipfile.ZipFile(
-        os.path.join(data_location, "artifact_zip", checkoutDataGit + ".zip"), "r"
+        data_location / "artifact_zip" / f"{checkout_data_git}.zip",
+        "r",
     ) as zip_ref:
-        zip_ref.extractall(data_location)
-    shutil.rmtree(os.path.join(data_location, "artifact_zip"))
+        zip_ref.extractall(str(data_location))
+    shutil.rmtree(data_location / "artifact_zip", ignore_errors=True)
 
 
 # Return opengate tests data folder:
-def get_tests_data_folder():
-    packageLocation = os.path.dirname(os.path.realpath(__file__))
+def get_tests_data_folder() -> Path:
+    packageLocation = Path(__file__).resolve().parent
     dataLocation = ""
-    if os.path.exists(os.path.join(packageLocation, "..", "opengate")):
-        dataLocation = os.path.join(packageLocation, "..", "opengate", "tests", "data")
-    elif os.path.exists(os.path.join(packageLocation, "..", "..", "opengate")):
-        dataLocation = os.path.join(
-            packageLocation, "..", "..", "opengate", "tests", "data"
-        )
-    else:
-        print("Cannot find opengate folder near: " + packageLocation)
+    for parent in packageLocation.parents:
+        if (parent / "opengate" / "tests" / "data").exists():
+            dataLocation = parent / "opengate" / "tests" / "data"
+            break
+    if not dataLocation:
+        print("Cannot find opengate folder near: " + str(packageLocation))
     return dataLocation

--- a/core/opengate_core/testsDataSetup.py
+++ b/core/opengate_core/testsDataSetup.py
@@ -48,7 +48,7 @@ def check_tests_data_folder():
                 print("")
                 print("Done")
         # Check if the size of one .raw file is correct to detect lfs
-        if "ct_4mm.raw" in data_location.iterdir():
+        if (data_location / "ct_4mm.raw").is_file():
             filesize = (data_location / "ct_4mm.raw").stat().st_size
             if filesize < 4000000:
                 print(
@@ -120,12 +120,12 @@ def download_tests_data(data_location: Path):
 
 # Return opengate tests data folder:
 def get_tests_data_folder() -> Path:
-    packageLocation = Path(__file__).resolve().parent
-    dataLocation = ""
-    for parent in packageLocation.parents:
-        if (parent / "opengate" / "tests" / "data").exists():
-            dataLocation = parent / "opengate" / "tests" / "data"
+    package_location = Path(__file__).resolve().parent
+    data_location = package_location.parent / "opengate" / "tests" / "data"
+    for parent in package_location.parents:
+        if (parent / "opengate").exists():
+            data_location = parent / "opengate" / "tests" / "data"
             break
-    if not dataLocation:
-        print("Cannot find opengate folder near: " + str(packageLocation))
-    return dataLocation
+    if not data_location:
+        print("Cannot find opengate folder near: " + str(package_location))
+    return data_location

--- a/core/setup.py
+++ b/core/setup.py
@@ -13,7 +13,7 @@ def warning(s):
     print(s)
 
 
-def get_cmake_dir():
+def get_cmake_dir() -> Path:
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
@@ -22,14 +22,14 @@ def get_cmake_dir():
     return cmake_dir
 
 
-def get_base_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+def get_base_dir() -> Path:
+    return Path(__file__).parent.parent.resolve()
 
 
 with open("../VERSION", "r") as fh:
     version = fh.read()[:-1]
 
-from setuptools import setup, Extension, find_packages
+from setuptools import Extension, find_packages
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 

--- a/opengate/bin/opengate_library_path.py
+++ b/opengate/bin/opengate_library_path.py
@@ -3,35 +3,30 @@
 import site
 import os
 import click
+from pathlib import Path
 
 
-def return_site_packages_dir():
+def return_site_packages_dir() -> Path:
     site_package = [p for p in site.getsitepackages() if "site-packages" in p][0]
-    return site_package
+    return Path(site_package)
 
 
 def get_site_packages_dir():
-    print(return_site_packages_dir())
+    print(str(return_site_packages_dir()))
 
 
 def get_libG4processes_path():
-    for element in os.listdir(
-        os.path.join(return_site_packages_dir(), "opengate_core.libs")
-    ):
-        if "libG4processes" in element:
-            print(
-                os.path.join(return_site_packages_dir(), "opengate_core.libs", element)
-            )
+    lib_path = return_site_packages_dir() / "opengate_core.libs"
+    for element in lib_path.iterdir():
+        if "libG4processes" in element.name:
+            print(str(element))
 
 
 def get_libG4geometry_path():
-    for element in os.listdir(
-        os.path.join(return_site_packages_dir(), "opengate_core.libs")
-    ):
-        if "libG4geometry" in element:
-            print(
-                os.path.join(return_site_packages_dir(), "opengate_core.libs", element)
-            )
+    lib_path = return_site_packages_dir() / "opengate_core.libs"
+    for element in lib_path.iterdir():
+        if "libG4geometry" in element.name:
+            print(str(element))
 
 
 # -----------------------------------------------------------------------------

--- a/opengate/bin/opengate_tests.py
+++ b/opengate/bin/opengate_tests.py
@@ -24,16 +24,18 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 def go(test_id, random_tests):
     pathFile = pathlib.Path(__file__).parent.resolve()
-    if "src" in os.listdir(pathFile):
-        mypath = os.path.join(pathFile, "../tests/src")
+    if "src" in pathFile.iterdir():
+        mypath = pathFile.parent / "tests" / "src"
     else:
         import opengate.tests
 
-        mypath = os.path.join(
-            pathlib.Path(opengate.tests.__file__).resolve().parent, "../tests/src"
+        mypath = (
+            pathlib.Path(opengate.tests.__file__).resolve().parent.parent
+            / "tests"
+            / "src"
         )
 
-    print("Looking for tests in: " + mypath)
+    print("Looking for tests in: " + str(mypath))
 
     if not check_tests_data_folder():
         return False
@@ -62,9 +64,7 @@ def go(test_id, random_tests):
         "test045_speedup",  # this is a binary (still work in progress)
     ]
 
-    onlyfiles = [
-        f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))
-    ]
+    onlyfiles = [f.name for f in mypath.glob("**/*") if f.is_file()]
 
     files = []
     for f in onlyfiles:
@@ -116,15 +116,15 @@ def go(test_id, random_tests):
         files = sorted(files)
 
     print(f"Running {len(files)} tests")
-    print(f"-" * 70)
+    print("-" * 70)
 
     failure = False
 
     for f in files:
         start = time.time()
         print(f"Running: {f:<46}  ", end="")
-        cmd = "python " + os.path.join(mypath, f"{f}")
-        log = os.path.join(os.path.dirname(mypath), f"log/{f}.log")
+        cmd = "python " + str(mypath / f)
+        log = str(mypath.parent / "log" / f) + ".log"
         r = os.system(f"{cmd} > {log} 2>&1")
         # subprocess.run(cmd, stdout=f, shell=True, check=True)
         if r == 0:

--- a/opengate/bin/opengate_tests.py
+++ b/opengate/bin/opengate_tests.py
@@ -64,7 +64,7 @@ def go(test_id, random_tests):
         "test045_speedup",  # this is a binary (still work in progress)
     ]
 
-    onlyfiles = [f.name for f in mypath.glob("**/*") if f.is_file()]
+    onlyfiles = [f for f in os.listdir(str(mypath)) if (mypath / f).is_file()]
 
     files = []
     for f in onlyfiles:

--- a/opengate/bin/opengate_tests_utils.py
+++ b/opengate/bin/opengate_tests_utils.py
@@ -3,35 +3,30 @@
 import site
 import os
 import click
+from pathlib import Path
 
 
-def return_site_packages_dir():
+def return_site_packages_dir() -> Path:
     site_package = [p for p in site.getsitepackages() if "site-packages" in p][0]
-    return site_package
+    return Path(site_package)
 
 
 def get_site_packages_dir():
-    print(return_site_packages_dir())
+    print(str(return_site_packages_dir()))
 
 
 def get_libG4processes_path():
-    for element in os.listdir(
-        os.path.join(return_site_packages_dir(), "opengate_core.libs")
-    ):
-        if "libG4processes" in element:
-            print(
-                os.path.join(return_site_packages_dir(), "opengate_core.libs", element)
-            )
+    lib_path = return_site_packages_dir() / "opengate_core.libs"
+    for element in lib_path.iterdir():
+        if "libG4processes" in element.name:
+            print(str(element))
 
 
 def get_libG4geometry_path():
-    for element in os.listdir(
-        os.path.join(return_site_packages_dir(), "opengate_core.libs")
-    ):
-        if "libG4geometry" in element:
-            print(
-                os.path.join(return_site_packages_dir(), "opengate_core.libs", element)
-            )
+    lib_path = return_site_packages_dir() / "opengate_core.libs"
+    for element in lib_path.iterdir():
+        if "libG4geometry" in element.name:
+            print(str(element))
 
 
 # -----------------------------------------------------------------------------

--- a/opengate/definitions.py
+++ b/opengate/definitions.py
@@ -1,4 +1,3 @@
-import collections.abc
 import sys
 import numpy as np
 

--- a/opengate/tests/src/test007_volumes.py
+++ b/opengate/tests/src/test007_volumes.py
@@ -38,7 +38,7 @@ def check_mat(se):
     dbn = sim.volume_manager.dump_material_database_names()
     mnist = se.volume_engine.get_database_material_names("NIST")
     mdb = se.volume_engine.get_database_material_names(
-        pathFile / ".." / "data" / "GateMaterials.db"
+        pathFile.parent / "data" / "GateMaterials.db"
     )
     dm = se.volume_engine.dump_build_materials()
     print("Material info:")
@@ -48,7 +48,7 @@ def check_mat(se):
     print("\t defined mat  :", dm)
 
     print("dbn", dbn)
-    assert dbn == [pathFile / ".." / "data" / "GateMaterials.db"]
+    assert dbn == [pathFile.parent / "data" / "GateMaterials.db"]
     # assert len(mnist) == 308  # Geant4 11.02
     assert len(mnist) == 309  # Geant4 11.1
     assert mdb == [
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
     # add a material database
     sim.volume_manager.add_material_database(
-        pathFile / ".." / "data" / "GateMaterials.db"
+        pathFile.parent / "data" / "GateMaterials.db"
     )
 
     #  change world size

--- a/opengate/tests/src/test010_generic_source_angular_distribution.py
+++ b/opengate/tests/src/test010_generic_source_angular_distribution.py
@@ -7,7 +7,7 @@ import pathlib
 
 if __name__ == "__main__":
     current_path = pathlib.Path(__file__).parent.resolve()
-    ref_path = current_path / ".." / "data" / "output_ref" / "test010"
+    ref_path = current_path.parent / "data" / "output_ref" / "test010"
     paths = utility.get_default_test_paths(
         __file__, gate_folder=None, output_folder="test010"
     )
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     sim.visu_type = "vrml"
     sim.number_of_threads = 1
     sim.random_seed = 123654
-    sim.output_dir = current_path / ".." / "output"
+    sim.output_dir = current_path.parent / "output"
 
     # set the world size like in the Gate macro
     world = sim.world

--- a/opengate/tests/src/test011_mt.py
+++ b/opengate/tests/src/test011_mt.py
@@ -66,8 +66,7 @@ if __name__ == "__main__":
     # gate_test4_simulation_stats_actor
     # Gate mac/main.mac
     stats_ref = utility.read_stat_file(
-        pathFile
-        / ".."
+        pathFile.parent
         / "data"
         / "gate"
         / "gate_test004_simulation_stats_actor"

--- a/opengate/tests/src/test018_pet_wip.py
+++ b/opengate/tests/src/test018_pet_wip.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # check
     stats = sim.output.get_actor("Stats")
     stats_ref = utility.read_stat_file(
-        pathFile / ".." / "data" / "output_ref" / "test018_stats_ref.txt"
+        pathFile.parent / "data" / "output_ref" / "test018_stats_ref.txt"
     )
     is_ok = utility.assert_stats(stats, stats_ref, tolerance=0.15)
 

--- a/opengate/tests/src/test026_simple_signal.py
+++ b/opengate/tests/src/test026_simple_signal.py
@@ -57,8 +57,7 @@ if __name__ == "__main__":
     # gate_test4_simulation_stats_actor
     # Gate mac/main.mac
     stats_ref = utility.read_stat_file(
-        pathFile
-        / ".."
+        pathFile.parent
         / "data"
         / "gate"
         / "gate_test004_simulation_stats_actor"

--- a/opengate/tests/src/test044_pbs.py
+++ b/opengate/tests/src/test044_pbs.py
@@ -116,8 +116,7 @@ if __name__ == "__main__":
     s.track_types_flag = True
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test044_pbs_rot_transl.py
+++ b/opengate/tests/src/test044_pbs_rot_transl.py
@@ -121,8 +121,7 @@ if __name__ == "__main__":
     print(sim.source_manager.dump_sources())
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test044_pbs_source_to_volume.py
+++ b/opengate/tests/src/test044_pbs_source_to_volume.py
@@ -119,8 +119,7 @@ if __name__ == "__main__":
     print(sim.source_manager.dump_sources())
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test044_pbs_unfocused.py
+++ b/opengate/tests/src/test044_pbs_unfocused.py
@@ -124,8 +124,7 @@ if __name__ == "__main__":
     print(sim.source_manager.dump_sources())
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test044_pbs_weight.py
+++ b/opengate/tests/src/test044_pbs_weight.py
@@ -157,8 +157,7 @@ if __name__ == "__main__":
     print(sim.source_manager.dump_sources())
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test058_calc_uncertainty_mt.py
+++ b/opengate/tests/src/test058_calc_uncertainty_mt.py
@@ -90,7 +90,7 @@ def assert_uncertainty(
 
 if __name__ == "__main__":
     current_path = pathlib.Path(__file__).parent.resolve()
-    output_path = current_path / ".." / "output"
+    output_path = current_path.parent / "output"
 
     # create the simulation
     sim = gate.Simulation()

--- a/opengate/tests/src/test058_calc_uncertainty_mt_ste_mean.py
+++ b/opengate/tests/src/test058_calc_uncertainty_mt_ste_mean.py
@@ -98,7 +98,7 @@ def assert_uncertainty(
 
 if __name__ == "__main__":
     current_path = pathlib.Path(__file__).parent.resolve()
-    output_path = current_path / ".." / "output"
+    output_path = current_path.parent / "output"
 
     # create the simulation
     sim = gate.Simulation()

--- a/opengate/tests/src/test059_tpsource_abs_dose.py
+++ b/opengate/tests/src/test059_tpsource_abs_dose.py
@@ -134,8 +134,7 @@ if __name__ == "__main__":
     # start simulation
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     sim.run()
     output = sim.output

--- a/opengate/tests/src/test059_tpsource_flat_generation_flag.py
+++ b/opengate/tests/src/test059_tpsource_flat_generation_flag.py
@@ -218,8 +218,7 @@ if __name__ == "__main__":
     # sim.set_user_limits("phantom_a_2","max_step_size",1,['proton'])
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test059_tpsource_gantry_rot.py
+++ b/opengate/tests/src/test059_tpsource_gantry_rot.py
@@ -169,8 +169,7 @@ if __name__ == "__main__":
     s.track_types_flag = True
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test059_tpsource_optics.py
+++ b/opengate/tests/src/test059_tpsource_optics.py
@@ -120,8 +120,7 @@ if __name__ == "__main__":
     s.track_types_flag = True
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test059_tpsource_optics_vbl.py
+++ b/opengate/tests/src/test059_tpsource_optics_vbl.py
@@ -116,8 +116,7 @@ if __name__ == "__main__":
     s.track_types_flag = True
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test059_tpsource_range_ref.py
+++ b/opengate/tests/src/test059_tpsource_range_ref.py
@@ -123,8 +123,7 @@ if __name__ == "__main__":
     s.track_types_flag = True
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test059_tpsource_weights.py
+++ b/opengate/tests/src/test059_tpsource_weights.py
@@ -138,8 +138,7 @@ if __name__ == "__main__":
     # sim.set_user_limits("phantom_a_2","max_step_size",1,['proton'])
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/test065_dose2water_from_edep2water_ct.py
+++ b/opengate/tests/src/test065_dose2water_from_edep2water_ct.py
@@ -15,8 +15,7 @@ if __name__ == "__main__":
     ref_path = paths.output_ref / "test059_ref"
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # create the simulation
     sim = gate.Simulation()

--- a/opengate/tests/src/test065_dose_from_edep_ct.py
+++ b/opengate/tests/src/test065_dose_from_edep_ct.py
@@ -15,8 +15,7 @@ if __name__ == "__main__":
     ref_path = paths.output_ref / "test059_ref"
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # create the simulation
     sim = gate.Simulation()

--- a/opengate/tests/src/test065_dose_from_edep_volume.py
+++ b/opengate/tests/src/test065_dose_from_edep_volume.py
@@ -15,8 +15,7 @@ if __name__ == "__main__":
     ref_path = paths.output_ref / "test059_ref"
 
     # create output dir, if it doesn't exist
-    if not os.path.isdir(output_path):
-        os.mkdir(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     # create the simulation
     sim = gate.Simulation()

--- a/opengate/tests/src/test065_sim_as_dict.py
+++ b/opengate/tests/src/test065_sim_as_dict.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     # add a material database
     sim.volume_manager.add_material_database(
-        pathFile / ".." / "data" / "GateMaterials.db"
+        pathFile.parent / "data" / "GateMaterials.db"
     )
 
     m = gate.g4_units.m

--- a/opengate/tests/src/test066_phspsource_activity.py
+++ b/opengate/tests/src/test066_phspsource_activity.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     source_1 = sim.add_source("PhaseSpaceSource", "phsp_source_global_1")
     source_1.mother = plane_1.name
-    source_1.phsp_file = paths.output_ref / ".." / "test019" / "test019_hits.root"
+    source_1.phsp_file = paths.output_ref.parent / "test019" / "test019_hits.root"
     source_1.position_key = "PrePosition"
     source_1.direction_key = "PreDirection"
     source_1.weight_key = "Weight"

--- a/opengate/tests/utility.py
+++ b/opengate/tests/utility.py
@@ -674,24 +674,22 @@ def get_default_test_paths(f, gate_folder=None, output_folder=None):
     p = Box()
     p.current = pathlib.Path(f).parent.resolve()
     # data
-    p.data = p.current / ".." / "data"
+    p.data = p.current.parent / "data"
     # gate
     if gate_folder:
-        p.gate = p.current / ".." / "data" / "gate" / gate_folder
+        p.gate = p.current.parent / "data" / "gate" / gate_folder
         p.gate_output = p.gate / "output"
         p.gate_data = p.gate / "data"
     # output
-    p.output = p.current / ".." / "output"
+    p.output = p.current.parent / "output"
     if output_folder is not None:
         p.output = p.output / output_folder
-        if not pathlib.Path.is_dir(p.output):
-            pathlib.Path.mkdir(p.output)
+        p.output.mkdir(parents=True, exist_ok=True)
     # output ref
-    p.output_ref = p.current / ".." / "data" / "output_ref"
+    p.output_ref = p.current.parent / "data" / "output_ref"
     if output_folder is not None:
         p.output_ref = p.output_ref / output_folder
-        if not pathlib.Path.is_dir(p.output_ref):
-            pathlib.Path.mkdir(p.output_ref)
+        p.output_ref.mkdir(parents=True, exist_ok=True)
     return p
 
 

--- a/opengate/utility.py
+++ b/opengate/utility.py
@@ -37,8 +37,7 @@ def assert_equal_dic(d1, d2, name=""):
 
 def ensure_directory_exists(directory):
     p = Path(directory)
-    if p.exists() is False:
-        p.mkdir(parents=True)
+    p.mkdir(parents=True, exist_ok=True)
 
 
 g4_units = Box()
@@ -171,11 +170,12 @@ def insert_suffix_before_extension(file_path, suffix, suffixSeparator="-"):
 def get_random_folder_name(size=8, create=True):
     r = "".join(random.choices(string.ascii_lowercase + string.digits, k=size))
     r = "run." + r
+    directory = Path(r)
     if create:
-        if not os.path.exists(r):
+        if not directory.exists():
             print(f"Creating output folder {r}")
-            os.mkdir(r)
-        if not os.path.isdir(r):
+            directory.mkdir(parents=True, exist_ok=True)
+        if not directory.isdir():
             fatal(f"Error, while creating {r}.")
     return r
 
@@ -279,7 +279,7 @@ def print_opengate_info():
     print(f"GATE tests       {get_tests_folder()}")
 
     # check if from a git version ?
-    git_path = module_path / ".."
+    git_path = Path(module_path).parent
     try:
         git_repo = git.Repo(git_path)
         sha = git_repo.head.object.hexsha


### PR DESCRIPTION
This PR fixes fresh installations errors when parent folders are not created by default giving 
```
FileNotFoundError: [Errno 2] No such file or directory: '...
```

These errors were triggered by some tests and are all solved by this PR. The change ensures the folders AND all their parents are created.