### PR TITLE
warn user if unknown attribute

### DIFF
--- a/opengate/actors/arfactors.py
+++ b/opengate/actors/arfactors.py
@@ -74,6 +74,7 @@ class ARFTrainingDatasetActor(ActorBase, g4.GateARFTrainingDatasetActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output(ActorOutputRoot, "root_output")
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateARFTrainingDatasetActor.__init__(self, self.user_info)
@@ -219,6 +220,7 @@ class ARFActor(ActorBase, g4.GateARFActor):
 
         self._add_user_output(ActorOutputSingleImage, "arf_projection")
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateARFActor.__init__(self, self.user_info)

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -149,15 +149,15 @@ class ActorBase(GateObject):
         self.__initcpp__()
         self.__update_interface_properties__()
 
-    def __finalize_init__(self):
-        super().__finalize_init__()
-        # The following attributes exist. They are declared here to avoid warning
-        self.known_attributes.append("fFilters")
-        self.known_attributes.append("actor_engine")
-        self.known_attributes.append("user_output")
-        self.known_attributes.append("simulation")
-        self.known_attributes.append("__dict__")
-        self.known_attributes.append("output_filename")
+    # def __finalize_init__(self):
+    #     super().__finalize_init__()
+    #     # The following attributes exist. They are declared here to avoid warning
+    #     self.known_attributes.append("fFilters")
+    #     self.known_attributes.append("actor_engine")
+    #     self.known_attributes.append("user_output")
+    #     self.known_attributes.append("simulation")
+    #     self.known_attributes.append("__dict__")
+    #     self.known_attributes.append("output_filename")
 
     def to_dictionary(self):
         d = super().to_dictionary()

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -129,9 +129,8 @@ class ActorBase(GateObject):
 
     def __init__(self, *args, **kwargs):
         GateObject.__init__(self, *args, **kwargs)
-        self.actor_engine = (
-            None  # this is set by the actor engine during initialization
-        )
+        # this is set by the actor engine during initialization
+        self.actor_engine = None
         self.user_output = Box()
         self.interfaces_to_user_output = Box()
 
@@ -149,6 +148,16 @@ class ActorBase(GateObject):
             v.belongs_to_actor = self
         self.__initcpp__()
         self.__update_interface_properties__()
+
+    def __finalize_init__(self):
+        super().__finalize_init__()
+        # The following attributes exist. They are declared here to avoid warning
+        self.known_attributes.append("fFilters")
+        self.known_attributes.append("actor_engine")
+        self.known_attributes.append("user_output")
+        self.known_attributes.append("simulation")
+        self.known_attributes.append("__dict__")
+        self.known_attributes.append("output_filename")
 
     def to_dictionary(self):
         d = super().to_dictionary()

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -295,6 +295,7 @@ class DigitizerAdderActor(DigitizerBase, g4.GateDigitizerAdderActor):
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerAdderActor.__init__(self, self.user_info)
@@ -410,6 +411,7 @@ class DigitizerBlurringActor(DigitizerBase, g4.GateDigitizerBlurringActor):
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerBlurringActor.__init__(self, self.user_info)
@@ -538,6 +540,7 @@ class DigitizerSpatialBlurringActor(
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerSpatialBlurringActor.__init__(self, self.user_info)
@@ -614,6 +617,7 @@ class DigitizerEfficiencyActor(DigitizerBase, g4.GateDigitizerEfficiencyActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerEfficiencyActor.__init__(self, self.user_info)
@@ -680,6 +684,7 @@ class DigitizerEnergyWindowsActor(DigitizerBase, g4.GateDigitizerEnergyWindowsAc
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerEnergyWindowsActor.__init__(self, self.user_info)
@@ -737,6 +742,7 @@ class DigitizerHitsCollectionActor(DigitizerBase, g4.GateDigitizerHitsCollection
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerHitsCollectionActor.__init__(self, self.user_info)
@@ -833,6 +839,7 @@ class DigitizerProjectionActor(ActorBase, g4.GateDigitizerProjectionActor):
         self._add_user_output(ActorOutputSingleImage, "projection")
         self.start_output_origin = None
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerProjectionActor.__init__(self, self.user_info)
@@ -965,6 +972,7 @@ class DigitizerReadoutActor(DigitizerAdderActor, g4.GateDigitizerReadoutActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         # python 3.8 complains about init not called, we add explicit call to
@@ -1026,6 +1034,7 @@ class PhaseSpaceActor(DigitizerBase, g4.GatePhaseSpaceActor):
         self.total_number_of_entries = 0
         self.number_of_absorbed_events = 0
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GatePhaseSpaceActor.__init__(self, self.user_info)

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -496,6 +496,7 @@ class DoseActor(VoxelDepositActor, g4.GateDoseActor):
         self.user_output.density.set_item_suffix("density")
 
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDoseActor.__init__(self, self.user_info)
@@ -823,6 +824,7 @@ class LETActor(VoxelDepositActor, g4.GateLETActor):
         self.user_output.let.set_write_to_disk(True, item="quotient")
 
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateLETActor.__init__(self, self.user_info)
@@ -909,6 +911,7 @@ class FluenceActor(VoxelDepositActor, g4.GateFluenceActor):
         self._add_user_output(ActorOutputSingleImage, "fluence")
 
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateFluenceActor.__init__(self, self.user_info)

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -16,6 +16,7 @@ class DynamicGeometryActor(ActorBase, g4.GateVActor):
         ActorBase.__init__(self, *args, **kwargs)
         self.geometry_changers = []
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateVActor.__init__(self, {"name": self.name})

--- a/opengate/actors/filters.py
+++ b/opengate/actors/filters.py
@@ -36,6 +36,7 @@ class FilterBase(GateObject):
     def __setstate__(self, state):
         self.__dict__ = state
         self.__initcpp__()
+        self.__finalize_init__()
 
 
 class ParticleFilter(FilterBase, g4.GateParticleFilter):
@@ -55,6 +56,7 @@ class ParticleFilter(FilterBase, g4.GateParticleFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateParticleFilter.__init__(self)
@@ -84,6 +86,7 @@ class KineticEnergyFilter(FilterBase, g4.GateKineticEnergyFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateKineticEnergyFilter.__init__(self)  # no argument in cpp side
@@ -106,6 +109,7 @@ class TrackCreatorProcessFilter(FilterBase, g4.GateTrackCreatorProcessFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateTrackCreatorProcessFilter.__init__(self)  # no argument in cpp side
@@ -144,6 +148,7 @@ class ThresholdAttributeFilter(FilterBase, g4.GateThresholdAttributeFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateThresholdAttributeFilter.__init__(self)
@@ -161,6 +166,7 @@ class UnscatteredPrimaryFilter(FilterBase, g4.GateUnscatteredPrimaryFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateUnscatteredPrimaryFilter.__init__(self)

--- a/opengate/actors/miscactors.py
+++ b/opengate/actors/miscactors.py
@@ -201,11 +201,11 @@ class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):
         g4.GateSimulationStatisticsActor.__init__(self, self.user_info)
         self.AddActions({"StartSimulationAction", "EndSimulationAction"})
 
-    def __finalize_init__(self):
-        super().__finalize_init__()
-        # this attribute is considered sometimes in the read_stat_file
-        # we declare it here to avoid warning
-        self.known_attributes.append("date")
+    # def __finalize_init__(self):
+    #     super().__finalize_init__()
+    #     # this attribute is considered sometimes in the read_stat_file
+    #     # we declare it here to avoid warning
+    #     self.known_attributes.append("date")
 
     def __str__(self):
         s = self.user_output["stats"].__str__()

--- a/opengate/actors/miscactors.py
+++ b/opengate/actors/miscactors.py
@@ -195,10 +195,17 @@ class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):
         ActorBase.__init__(self, *args, **kwargs)
         output = self._add_user_output(ActorOutputStatisticsActor, "stats")
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateSimulationStatisticsActor.__init__(self, self.user_info)
         self.AddActions({"StartSimulationAction", "EndSimulationAction"})
+
+    def __finalize_init__(self):
+        super().__finalize_init__()
+        # this attribute is considered sometimes in the read_stat_file
+        # we declare it here to avoid warning
+        self.known_attributes.append("date")
 
     def __str__(self):
         s = self.user_output["stats"].__str__()
@@ -279,6 +286,7 @@ class KillActor(ActorBase, g4.GateKillActor):
         ActorBase.__init__(self, *args, **kwargs)
         self.number_of_killed_particles = 0
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateKillActor.__init__(self, self.user_info)
@@ -395,6 +403,7 @@ class ComptSplittingActor(SplittingActorBase, g4.GateOptrComptSplittingActor):
     def __init__(self, *args, **kwargs):
         SplittingActorBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateOptrComptSplittingActor.__init__(self, {"name": self.name})
@@ -424,6 +433,7 @@ class BremSplittingActor(SplittingActorBase, g4.GateBOptrBremSplittingActor):
     def __init__(self, *args, **kwargs):
         SplittingActorBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
+        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateBOptrBremSplittingActor.__init__(self, {"name": self.name})

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -68,7 +68,6 @@ def process_cls(cls):
         cls.known_attributes = set()
 
 
-
 # Utility function for object creation
 def check_property_name(name):
     if len(name.split()) > 1:
@@ -412,7 +411,9 @@ class GateObject:
     def __setstate__(self, d):
         """Method needed for pickling. May be overridden in inheriting classes."""
         self.__dict__ = d
-        print(f"DEBUG: in __setstate__ of {type(self).__name__}: {type(self).known_attributes}")
+        print(
+            f"DEBUG: in __setstate__ of {type(self).__name__}: {type(self).known_attributes}"
+        )
         print(f"DEBUG:    type(self).known_attributes: {type(self).known_attributes}")
         print(f"DEBUG:    list(self.__dict__.keys()): {list(self.__dict__.keys())}")
 
@@ -451,7 +452,7 @@ class GateObject:
                 s = ", ".join(str(a) for a in self.known_attributes)
                 warning(
                     f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
-                    f'Known attributes of this object are: {s}'
+                    f"Known attributes of this object are: {s}"
                 )
                 self.number_of_warnings += 1
         super().__setattr__(key, value)
@@ -472,7 +473,9 @@ class GateObject:
         """
 
         # we define this at the class-level
-        type(self).known_attributes = set(list(self.user_info.keys()) + list(self.__dict__.keys()))
+        type(self).known_attributes = set(
+            list(self.user_info.keys()) + list(self.__dict__.keys())
+        )
 
     def __add_to_simulation__(self):
         """Hook method which can be called by managers.

--- a/opengate/exception.py
+++ b/opengate/exception.py
@@ -43,8 +43,6 @@ def fatal(s):
     log.critical(ss)
     s = colored.stylize(s, color_error)
     log.critical(s)
-    # sys.exit(-1)
-    # FIXME: maybe better:
     raise Exception(s)
 
 

--- a/opengate/tests/src/test078_check_userinfo.py
+++ b/opengate/tests/src/test078_check_userinfo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+from opengate.exception import GateDeprecationError
 from opengate.tests.utility import (
     get_default_test_paths,
     test_ok,
@@ -46,20 +46,34 @@ if __name__ == "__main__":
     try:
         stats.mother = "nothing"
         is_ok = False and is_ok
-    except:
+    except GateDeprecationError as e:
+        print("Exception caught: ", e)
         pass
     print_test(
         is_ok, f"Try to set deprecated attribute 'mother', it should raise an exception"
     )
+    print()
 
-    """try:
-        stats.TOTO = "nothing"
-        is_ok = False and is_ok
-    except:
-        pass
-    print_test(is_ok, f"Try to set wring attribute 'TOTO', it should raise an exception")
-    """
+    # set a WRONG attribute
+    stats.TOTO = "nothing"
 
-    sim.run()
+    # check the number of warnings (before the run)
+    print(
+        f"(before run) Number of warnings for stats object: {stats.number_of_warnings}"
+    )
+    b = stats.number_of_warnings == 1
+    print_test(
+        b, f"Try to set a wrong attribute 'TOTO', it should print a single warning"
+    )
+    is_ok = is_ok and b
+
+    sim.run(start_new_process=True)
+
+    print(
+        f"(after run) Number of warnings for stats object: {stats.number_of_warnings}"
+    )
+    b = stats.number_of_warnings == 1
+    print_test(b, f"No additional warning should be raised")
+    is_ok = is_ok and b
 
     test_ok(is_ok)


### PR DESCRIPTION
Add finalize initialization method to actors and filters, to detect unknown attribute

Introduced the __finalize_init__() method to ensure proper setup of actor and filter classes, avoiding warnings related to undeclared attributes. Cleaned up exception handling and added logging for attribute warnings during tests.

Unsure: I manually add elements in the known_attributes for the ActorBase to avoid warning, but maybe it show some logic issue here. 