### PR TITLE
Prepare qt6 for linux

### DIFF
--- a/.github/workflows/Dockerfile_opengate_core_arm64
+++ b/.github/workflows/Dockerfile_opengate_core_arm64
@@ -1,12 +1,15 @@
 #Docker for opengate_core
 #systemctl start docker
 #login: docker login
-#build: docker build -t tbaudier/opengate_core -f Dockerfile_opengate_core .
+#build: docker build -t tbaudier/opengate_core -f Dockerfile_opengate_core_arm64 .
 #push: docker push tbaudier/opengate_core
 #run: docker run --rm -e "PYTHONFOLDER=${PYTHONFOLDERMANYLINUX}" -v $(Pipeline.Workspace)/software:/home tbaudier/opengate_core /home/opengate_core/azureCreateWheelLinux.sh
-#interactive: docker run -ti --rm -v $PWD:/home quay.io/pypa/manylinux_2_34_x86_64 /bin/bash
+#interactive: docker run -ti --rm -v $PWD:/home quay.io/pypa/manylinux_2_34_aarch64 /bin/bash
+#with arm64 on x86 machines: use qemu and run
+#docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#docker build --platform linux/arm64 -t tbaudier/opengate_core -f Dockerfile_opengate_core_arm64 .
 
-FROM quay.io/pypa/manylinux_2_34_x86_64
+FROM quay.io/pypa/manylinux_2_34_aarch64
 MAINTAINER Thomas Baudier <thomas.baudier@creatis.insa-lyon.fr>
 #Install packages
 RUN     yum install -y gcc wget git expat-devel fftw-devel qt6-qtbase-devel freeglut-devel libXmu-devel xerces-c-devel \
@@ -16,10 +19,10 @@ RUN     yum install -y gcc wget git expat-devel fftw-devel qt6-qtbase-devel free
 
 #Install cmake
     &&  cd /software/cmake \
-    &&  wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz \
-    &&  tar xzvf cmake-3.18.2-Linux-x86_64.tar.gz \
-    &&  rm -rf cmake-3.18.2-Linux-x86_64.tar.gz \
-    &&  export PATH=/software/cmake/cmake-3.18.2-Linux-x86_64/bin/:${PATH} \
+    &&  wget https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-aarch64.tar.gz \
+    &&  tar xzvf cmake-3.31.7-linux-aarch64.tar.gz \
+    &&  rm -rf cmake-3.31.7-linux-aarch64.tar.gz \
+    &&  export PATH=/software/cmake/cmake-3.31.7-linux-aarch64/bin/:${PATH} \
 
 #Compile Geant4
     &&  cd /software/geant4 \

--- a/.github/workflows/createWheelLinux.sh
+++ b/.github/workflows/createWheelLinux.sh
@@ -6,16 +6,17 @@ cd /home/core/
 export PATH=/software/cmake/cmake-3.18.2-Linux-x86_64/bin/:${PATH}
 source /software/geant4/bin/geant4make.sh
 export CMAKE_PREFIX_PATH=/software/geant4/bin:/software/itk/bin/:${CMAKE_PREFIX_PATH}
+. /opt/rh/gcc-toolset-14/enable
 mkdir opengate_core/plugins
-cp -r /lib64/qt5/plugins/platforms opengate_core/plugins
-cp -r /lib64/qt5/plugins/imageformats opengate_core/plugins
+cp -r /lib64/qt6/plugins/platforms/* opengate_core/plugins/
+cp -r /lib64/qt6/plugins/imageformats opengate_core/plugins/
 /opt/python/${PYTHONFOLDER}/bin/pip install wget colored setuptools
 /opt/python/${PYTHONFOLDER}/bin/python setup.py sdist bdist_wheel
 archi=`uname -m`
 if [ "$(uname -m)" = "aarch64" ]; then
-  auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux2014_aarch64"
+  auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux_2_34_aarch64"
 else
-  auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux2014_x86_64"
+  auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux_2_34_x86_64"
 fi
 cp -r /software/wheelhouse /home/
 #/opt/python/${PYTHONFOLDER}/bin/pip install twine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
           if [ ${{ matrix.os }} == "ubuntu-24.04-arm" ]; then
             export ARMDOCKER="_arm64"
           fi
-          docker run --rm -e "PYTHONFOLDER=${PYTHONFOLDER}" -v $GITHUB_WORKSPACE:/home tbaudier/opengate_core:${{ env.GEANT4_VERSION }}$ARMDOCKER /home/.github/workflows/createWheelLinux.sh
+          docker run --rm -e "PYTHONFOLDER=${PYTHONFOLDER}" -v $GITHUB_WORKSPACE:/home tbaudier/opengate_core:${{ env.GEANT4_VERSION }}_qt6$ARMDOCKER /home/.github/workflows/createWheelLinux.sh
           ls wheelhouse
           rm -rf dist
           mv wheelhouse dist

--- a/core/opengate_core/opengate_lib/GateHelpers.cpp
+++ b/core/opengate_core/opengate_lib/GateHelpers.cpp
@@ -10,6 +10,10 @@
 #include "G4BiasingProcessInterface.hh"
 #include "G4GammaGeneralProcess.hh"
 #include <G4VProcess.hh>
+#if USE_USE_VISU == 1
+#include <QApplication>
+#include <QWidget>
+#endif
 #include <stdexcept>
 
 const int LogLevel_RUN = 20;
@@ -56,4 +60,22 @@ std::string DebugStep(const G4Step *step) {
       << " E= " << step->GetPreStepPoint()->GetKineticEnergy()
       << " w=" << step->GetTrack()->GetWeight() << " " << pp;
   return oss.str();
+}
+
+int createTestQtWindow() {
+#if USE_USE_VISU == 1
+  int argc = 1;
+  char *argv[] = {(char *)"minimal", nullptr};
+  QApplication app(argc, argv);
+
+  QWidget window;
+  window.resize(320, 240);
+  window.setWindowTitle("Minimal Qt Example");
+  window.show();
+
+  return app.exec();
+#else
+  std::cerr << "Qt is not available in this build of OpenGate." << std::endl;
+  return -1;
+#endif
 }

--- a/core/opengate_core/opengate_lib/GateHelpers.h
+++ b/core/opengate_core/opengate_lib/GateHelpers.h
@@ -64,6 +64,8 @@ static const double fwhm_to_sigma = 1.0 / sigma_to_fwhm;
 
 std::string DebugStep(const G4Step *step);
 
+int createTestQtWindow();
+
 #include "GateHelpers.txx"
 
 #endif // GateHelpers_h

--- a/core/opengate_core/opengate_lib/pyGateHelpers.cpp
+++ b/core/opengate_core/opengate_lib/pyGateHelpers.cpp
@@ -9,8 +9,10 @@
 
 namespace py = pybind11;
 
+#include "GateHelpers.h"
 #include "GateHelpersDict.h"
 
 void init_GateHelpers(py::module &m) {
   m.def("DictGetG4RotationMatrix", DictGetG4RotationMatrix);
+  m.def("createTestQtWindow", &createTestQtWindow);
 }

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE=" + sys.executable,
         ]
 
-        # cfg = 'Debug' if self.debug else 'Release'
+        # cfg = "Debug" if self.debug else 'Release'
         cfg = "Release"
         build_args = ["--config", cfg]
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -156,11 +156,10 @@ if platform.system() == "Darwin":
     package_data = {
         "opengate_core": ["plugins/platforms/*.dylib"]
         + ["plugins/imageformats/*.dylib"]
-        + ["plugins/miniconda/libQt5Svg.5.9.7.dylib"]
     }
     # package_data = {}
 else:
-    package_data = {"opengate_core": ["plugins/*/*.so"]}
+    package_data = {"opengate_core": ["plugins/*/*.so"] + ["plugins/*.so"]}
 
 setuptools.setup(
     name="opengate-core",

--- a/docs/source/developer_guide/developer_guide_installation.rst
+++ b/docs/source/developer_guide/developer_guide_installation.rst
@@ -70,13 +70,13 @@ STEP 1 - Geant4 and Qt
 Installing QT is optional. Currently, QT visualisation is not working on
 all architectures.
 
-If you wish to use QT, you must install qt5 **before** installing Geant4
+If you wish to use QT, you must install qt6 **before** installing Geant4
 so that Geant4 can find the correct qt lib. It can be done for example
 with conda:
 
 .. code:: bash
 
-     conda install qt=5
+     conda install conda-forge::qt6-main conda-forge::qt6-3d
 
 For **Geant4**, you need to compile with the following options:
 
@@ -90,6 +90,7 @@ For **Geant4**, you need to compile with the following options:
          -DGEANT4_INSTALL_DATADIR=$HOME/software/geant4/data \
          -DGEANT4_USE_QT=ON \
          -DGEANT4_USE_OPENGL_X11=ON \
+         -DGEANT4_USE_QT_QT6=ON \
          -DGEANT4_BUILD_MULTITHREADED=ON \
          ../geant4
    make -j 32

--- a/opengate/bin/opengate_visu.py
+++ b/opengate/bin/opengate_visu.py
@@ -3,7 +3,7 @@
 
 import click
 import os
-
+import opengate_core as g4
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -12,7 +12,13 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.option("--input", "-i", default="", help="Input visualization file")
 @click.option("--vrml", "-v", is_flag=True, help="VRML file")
 @click.option("--gdml", "-g", is_flag=True, help="GDML file")
-def go(input, vrml, gdml):
+@click.option("--qt", "-q", is_flag=True, help="Test Qt window")
+def go(input, vrml, gdml, qt):
+
+    if qt:
+        g4.createTestQtWindow()
+        return ()
+
     if not os.path.isfile(input):
         print("The file " + input + " does not exist")
         return ()


### PR DESCRIPTION
For linux we need to change the manylinux version:
 - manylinux2014 (= manylinux_2_17) : gcc version is too old to compile qt6
 - manylinux_2_24 cannot be used because apt do not delivered packages (gcc, ...) for this version
 - manylinux_2_28: qt6 can be installed manually. But this version of manylinux could lead to compatibility version for older computer like computer center using Centos8.

What is needed:
 
- [x]  Push the docker to docker hub (which version?)
- [x]  Create a wheel for visualisation and one for cluster?
- [x] Update doc (https://opengate-python.readthedocs.io/en/latest/developer_guide.html#step-1-geant4-and-qt)
