### PR TITLE
Check attributes v2

### DIFF
--- a/opengate/actors/arfactors.py
+++ b/opengate/actors/arfactors.py
@@ -74,7 +74,6 @@ class ARFTrainingDatasetActor(ActorBase, g4.GateARFTrainingDatasetActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output(ActorOutputRoot, "root_output")
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateARFTrainingDatasetActor.__init__(self, self.user_info)
@@ -220,7 +219,6 @@ class ARFActor(ActorBase, g4.GateARFActor):
 
         self._add_user_output(ActorOutputSingleImage, "arf_projection")
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateARFActor.__init__(self, self.user_info)

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -149,13 +149,13 @@ class ActorBase(GateObject):
         self.__initcpp__()
         self.__update_interface_properties__()
 
-    def __finalize_init__(self):
-        super().__finalize_init__()
-        # The following attributes exist. They are declared here to avoid warning
-        # fFilters is not known here because ActorBase does not inherit from a cpp counterpart.
-        self.known_attributes.add("fFilters")
-        # output_filename is a property
-        self.known_attributes.add("output_filename")
+    # def __finalize_init__(self):
+    #     super().__finalize_init__()
+    #     # The following attributes exist. They are declared here to avoid warning
+    #     # fFilters is not known here because ActorBase does not inherit from a cpp counterpart.
+    #     self.known_attributes.add("fFilters")
+    #     # output_filename is a property
+    #     self.known_attributes.add("output_filename")
 
     def to_dictionary(self):
         d = super().to_dictionary()

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -328,7 +328,6 @@ class DigitizerAdderActor(DigitizerBase, g4.GateDigitizerAdderActor):
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerAdderActor.__init__(self, self.user_info)
@@ -444,7 +443,6 @@ class DigitizerBlurringActor(DigitizerBase, g4.GateDigitizerBlurringActor):
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerBlurringActor.__init__(self, self.user_info)
@@ -573,7 +571,6 @@ class DigitizerSpatialBlurringActor(
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerSpatialBlurringActor.__init__(self, self.user_info)
@@ -651,7 +648,6 @@ class DigitizerEfficiencyActor(DigitizerBase, g4.GateDigitizerEfficiencyActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerEfficiencyActor.__init__(self, self.user_info)
@@ -721,7 +717,6 @@ class DigitizerEnergyWindowsActor(DigitizerBase, g4.GateDigitizerEnergyWindowsAc
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerEnergyWindowsActor.__init__(self, self.user_info)
@@ -779,7 +774,6 @@ class DigitizerHitsCollectionActor(DigitizerBase, g4.GateDigitizerHitsCollection
         DigitizerBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerHitsCollectionActor.__init__(self, self.user_info)
@@ -856,7 +850,6 @@ class DigitizerProjectionActor(DigitizerBase, g4.GateDigitizerProjectionActor):
         self._add_user_output(ActorOutputSingleImage, "projection")
         self.start_output_origin = None
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDigitizerProjectionActor.__init__(self, self.user_info)
@@ -1037,7 +1030,6 @@ class DigitizerReadoutActor(DigitizerAdderActor, g4.GateDigitizerReadoutActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output_root()
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         # python 3.8 complains about init not called, we add explicit call to
@@ -1100,7 +1092,6 @@ class PhaseSpaceActor(DigitizerBase, g4.GatePhaseSpaceActor):
         self.total_number_of_entries = 0
         self.number_of_absorbed_events = 0
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GatePhaseSpaceActor.__init__(self, self.user_info)

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -496,7 +496,6 @@ class DoseActor(VoxelDepositActor, g4.GateDoseActor):
         self.user_output.density.set_item_suffix("density")
 
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateDoseActor.__init__(self, self.user_info)
@@ -824,7 +823,6 @@ class LETActor(VoxelDepositActor, g4.GateLETActor):
         self.user_output.let.set_write_to_disk(True, item="quotient")
 
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateLETActor.__init__(self, self.user_info)
@@ -911,7 +909,6 @@ class FluenceActor(VoxelDepositActor, g4.GateFluenceActor):
         self._add_user_output(ActorOutputSingleImage, "fluence")
 
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateFluenceActor.__init__(self, self.user_info)

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -16,7 +16,6 @@ class DynamicGeometryActor(ActorBase, g4.GateVActor):
         ActorBase.__init__(self, *args, **kwargs)
         self.geometry_changers = []
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateVActor.__init__(self, {"name": self.name})

--- a/opengate/actors/filters.py
+++ b/opengate/actors/filters.py
@@ -36,7 +36,6 @@ class FilterBase(GateObject):
     def __setstate__(self, state):
         self.__dict__ = state
         self.__initcpp__()
-        self.__finalize_init__()
 
 
 class ParticleFilter(FilterBase, g4.GateParticleFilter):
@@ -56,7 +55,6 @@ class ParticleFilter(FilterBase, g4.GateParticleFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateParticleFilter.__init__(self)
@@ -86,7 +84,6 @@ class KineticEnergyFilter(FilterBase, g4.GateKineticEnergyFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateKineticEnergyFilter.__init__(self)  # no argument in cpp side
@@ -109,7 +106,6 @@ class TrackCreatorProcessFilter(FilterBase, g4.GateTrackCreatorProcessFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateTrackCreatorProcessFilter.__init__(self)  # no argument in cpp side
@@ -148,7 +144,6 @@ class ThresholdAttributeFilter(FilterBase, g4.GateThresholdAttributeFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateThresholdAttributeFilter.__init__(self)
@@ -166,7 +161,6 @@ class UnscatteredPrimaryFilter(FilterBase, g4.GateUnscatteredPrimaryFilter):
     def __init__(self, *args, **kwargs):
         FilterBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateUnscatteredPrimaryFilter.__init__(self)

--- a/opengate/actors/miscactors.py
+++ b/opengate/actors/miscactors.py
@@ -204,7 +204,6 @@ class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):
         ActorBase.__init__(self, *args, **kwargs)
         self._add_user_output(ActorOutputStatisticsActor, "stats")
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateSimulationStatisticsActor.__init__(self, self.user_info)
@@ -285,7 +284,6 @@ class KillActor(ActorBase, g4.GateKillActor):
         ActorBase.__init__(self, *args, **kwargs)
         self.number_of_killed_particles = 0
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateKillActor.__init__(self, self.user_info)
@@ -400,7 +398,6 @@ class ComptSplittingActor(SplittingActorBase, g4.GateOptrComptSplittingActor):
     def __init__(self, *args, **kwargs):
         SplittingActorBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateOptrComptSplittingActor.__init__(self, {"name": self.name})
@@ -429,7 +426,6 @@ class BremSplittingActor(SplittingActorBase, g4.GateBOptrBremSplittingActor):
     def __init__(self, *args, **kwargs):
         SplittingActorBase.__init__(self, *args, **kwargs)
         self.__initcpp__()
-        self.__finalize_init__()
 
     def __initcpp__(self):
         g4.GateBOptrBremSplittingActor.__init__(self, {"name": self.name})

--- a/opengate/actors/miscactors.py
+++ b/opengate/actors/miscactors.py
@@ -209,11 +209,11 @@ class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):
         g4.GateSimulationStatisticsActor.__init__(self, self.user_info)
         self.AddActions({"StartSimulationAction", "EndSimulationAction"})
 
-    def __finalize_init__(self):
-        super().__finalize_init__()
-        # this attribute is considered sometimes in the read_stat_file
-        # we declare it here to avoid warning
-        self.known_attributes.add("date")
+    # def __finalize_init__(self):
+    #     super().__finalize_init__()
+    #     # this attribute is considered sometimes in the read_stat_file
+    #     # we declare it here to avoid warning
+    #     self.known_attributes.add("date")
 
     def __str__(self):
         s = self.user_output["stats"].__str__()

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -1,6 +1,7 @@
 import copy
 from pathlib import Path
 from typing import Optional, List
+from difflib import get_close_matches
 
 from box import Box
 import sys
@@ -454,6 +455,10 @@ class GateObject:
         if len(known_attributes) > 0:
             if key not in known_attributes:
                 msg = f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
+                close_matches = get_close_matches(key, known_attributes)
+                if len(close_matches)> 0:
+                    msg_close_matches = f"Did you mean: " + " or ".join(close_matches) + "\n"
+                    msg += msg_close_matches
                 known_attr = ", ".join(str(a) for a in known_attributes)
                 msg += f"Known attributes of this object are: {known_attr}"
                 self.warn_user(msg)

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -540,11 +540,7 @@ class GateObject:
         """
 
         # we define this at the class-level
-        type(self).known_attributes = set(
-            list(self.user_info.keys())
-            + list(self.__dict__.keys())
-            + list(["__dict__"])
-        )
+        type(self).known_attributes = set(dir(self))
 
     def __add_to_simulation__(self):
         """Hook method which can be called by managers.

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -66,8 +66,8 @@ def process_cls(cls):
             # type(cls)._created_classes[cls] = digest_user_info_defaults(cls)
             digest_user_info_defaults(cls)
         except AttributeError:
-            fatal(
-                "Developer error: Looks like you are calling process_cls on a class "
+            raise GateImplementationError(
+                "Looks like you are calling process_cls on a class "
                 "that does not inherit from GateObject."
             )
         cls.known_attributes = set()

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -76,9 +76,9 @@ def process_cls(cls):
                 "Looks like you are calling process_cls on a class "
                 "that does not inherit from GateObject."
             )
-        # this class attribute is needed by the __setattr__ method of GateObject
+        # the class attribute known_attributes is needed by the __setattr__ method of GateObject
         cls.known_attributes = set()
-        # enhance the __init__ method
+        # enhance the __init__ method to ensure __finalize_init__ is called at the end
         wrap_init_method(cls)
 
 

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -447,17 +447,16 @@ class GateObject:
             )
 
         # check if the attribute is known, otherwise warn the user
-        if len(self.known_attributes) > 0:
-            if key not in self.known_attributes:
-                s = ", ".join(str(a) for a in self.known_attributes)
-                self.warn_user(
-                    f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
-                    f"Known attributes of this object are: {s}"
-                )
         known_attributes = type(self).__dict__.get("known_attributes")
         if known_attributes is None:
             raise GateImplementationError(f"Did not find 'known_attributes' in the {self.type_name}. "
                                           f"Has the class correctly been processed by process_cls()?")
+        if len(known_attributes) > 0:
+            if key not in known_attributes:
+                msg = f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
+                known_attr = ", ".join(str(a) for a in known_attributes)
+                msg += f"Known attributes of this object are: {known_attr}"
+                self.warn_user(msg)
                 self.number_of_warnings += 1
         super().__setattr__(key, value)
 

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -389,6 +389,7 @@ class GateObject:
         self._simulation = simulation
         # keep internal number of raised warnings (for debug)
         self.number_of_warnings = 0
+        self._temporary_warning_cache = []
         # prefill user info with defaults
         self.user_info = Box(
             [
@@ -619,11 +620,14 @@ class GateObject:
                         )
 
     def warn_user(self, message):
-        # this may be called without simulation object, so we guard with try/except
-        try:
+        # If this GateObject does not (yet) have a reference to the simulation,
+        # we store the warning in a temporary cache
+        # (will be registered later to the simulation's warning cache)
+        if self.simulation is None:
+            self._temporary_warning_cache.append(message)
+        # if possible, register the warning directly
+        else:
             self.simulation._user_warnings.append(message)
-        except:
-            pass
         warning(message)
 
 

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -50,9 +50,10 @@ class MetaUserInfo(type):
 
 
 def process_cls(cls):
-    """Digest the class's user_infos and store the augmented class
-    in a dictionary inside the metaclass which handles the class creation.
-    Example: type(cls) yields the metaclass MetaUserInfo for the class GateObject.
+    """The factory function is meant to process classes inheriting from GateObject.
+    It digests the user info parametrisation from all classes in the inheritance tree
+    and enhances the __init__ method, so it calls the __finalize_init__ method at the
+    very end of the __init__ call, which is required to check for invalid attribute setting.
     """
     # check if the class already has an attribute inherited_user_info_defaults
     # cannot use hasattr because it would find the attribute from already processed super classes

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -55,9 +55,12 @@ def process_cls(cls):
     and enhances the __init__ method, so it calls the __finalize_init__ method at the
     very end of the __init__ call, which is required to check for invalid attribute setting.
     """
-    # check if the class already has an attribute inherited_user_info_defaults
-    # cannot use hasattr because it would find the attribute from already processed super classes
-    # -> must use __dict__ which contains only attribute of the specific cls object
+    # The class attribute inherited_user_info_defaults is exclusively set by this factory function
+    # Therefore, if this class does not yet have an attribute inherited_user_info_defaults,
+    # it means that it has not been processed yet.
+    # Note: we cannot use hasattr(cls, 'inherited_user_info_defaults')
+    # because it would potentially find the attribute from already processed super classes
+    # Therefore, we must use cls.__dict__ which contains only attributes of the specific cls object
     if "inherited_user_info_defaults" not in cls.__dict__:
         try:
             # type(cls)._created_classes[cls] = digest_user_info_defaults(cls)

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -63,13 +63,13 @@ def process_cls(cls):
     # Therefore, we must use cls.__dict__ which contains only attributes of the specific cls object
     if "inherited_user_info_defaults" not in cls.__dict__:
         try:
-            # type(cls)._created_classes[cls] = digest_user_info_defaults(cls)
             digest_user_info_defaults(cls)
         except AttributeError:
             raise GateImplementationError(
                 "Looks like you are calling process_cls on a class "
                 "that does not inherit from GateObject."
             )
+        # this class attribute is needed by the __setattr__ method of GateObject
         cls.known_attributes = set()
 
 

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -386,9 +386,7 @@ class GateObject:
         return new_instance
 
     def __init__(self, *args, simulation=None, **kwargs):
-        self.simulation = None
-        if simulation is not None:
-            self.simulation = simulation
+        self._simulation = simulation
         # keep internal number of raised warnings (for debug)
         self.number_of_warnings = 0
         # prefill user info with defaults
@@ -426,6 +424,16 @@ class GateObject:
                     f"Hint: The user input parameters of {type(self).__name__} are: "
                     f"{list(self.inherited_user_info_defaults.keys())}.\n"
                 )
+
+    @property
+    def simulation(self):
+        return self._simulation
+
+    @simulation.setter
+    def simulation(self, sim):
+        sim.warnings.extend(self._temporary_warning_cache)
+        self._temporary_warning_cache = []
+        self._simulation = sim
 
     def __str__(self):
         ret_string = (

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -68,7 +68,7 @@ def process_cls(cls):
     # Note: we cannot use hasattr(cls, 'inherited_user_info_defaults')
     # because it would potentially find the attribute from already processed super classes
     # Therefore, we must use cls.__dict__ which contains only attributes of the specific cls object
-    if "inherited_user_info_defaults" not in cls.__dict__:
+    if not cls.has_been_processed():
         try:
             digest_user_info_defaults(cls)
         except AttributeError:
@@ -388,6 +388,10 @@ class GateObject:
     inherited_user_info_defaults: dict
 
     user_info_defaults = {"name": (None, {"required": True})}
+
+    @classmethod
+    def has_been_processed(cls):
+        return "inherited_user_info_defaults" in cls.__dict__
 
     def __new__(cls, *args, **kwargs):
         process_cls(cls)

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -103,7 +103,7 @@ def wrap_init_method(cls):
             for c in type(self).mro():
                 classes_up_to_first_init_in_mro.append(c)
                 if '__init__' in c.__dict__:
-                    # found an __init__, so __init__ methods in further super classes
+                    # found an __init__, so __init__ methods in classes further up the inheritance tree
                     # should not call the __finalize_init__ method
                     break
             # Now check if the class in which the __init__ we are wrapping is implemented

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -6,7 +6,13 @@ from difflib import get_close_matches
 from box import Box
 import sys
 
-from .exception import fatal, warning, GateDeprecationError, GateFeatureUnavailableError, GateImplementationError
+from .exception import (
+    fatal,
+    warning,
+    GateDeprecationError,
+    GateFeatureUnavailableError,
+    GateImplementationError,
+)
 from .definitions import (
     __gate_list_objects__,
     __gate_dictionary_objects__,
@@ -85,7 +91,7 @@ def wrap_init_method(cls):
     The method __finalize_init__ is needed to allow GateObject.__setattr__ to check for invalid attribute setting.
     """
     # Get the __init__ method as the class implements it
-    original_init = cls.__dict__.get('__init__')
+    original_init = cls.__dict__.get("__init__")
     # if it is implemented, i.e. present in __dict__, wrap it
     if original_init is not None:
         # define a closure
@@ -94,15 +100,16 @@ def wrap_init_method(cls):
             original_init(self, *args, **kwargs)
             # figure out in which class the __init__ method is implemented.
             # It could be in some super class with respect to the instance self.
-            class_to_which_original_init_belongs = vars(sys.modules[original_init.__module__])[
-                original_init.__qualname__.split('.')[0]]
+            class_to_which_original_init_belongs = vars(
+                sys.modules[original_init.__module__]
+            )[original_init.__qualname__.split(".")[0]]
             # Now figure out which is the "last" class in the inheritance chain
             # (with respect to the instance self)
             # which implements an __init__ method. Plus the children which do not implement an __init__
             classes_up_to_first_init_in_mro = []
             for c in type(self).mro():
                 classes_up_to_first_init_in_mro.append(c)
-                if '__init__' in c.__dict__:
+                if "__init__" in c.__dict__:
                     # found an __init__, so __init__ methods in classes further up the inheritance tree
                     # should not call the __finalize_init__ method
                     break
@@ -116,7 +123,7 @@ def wrap_init_method(cls):
                 self.__finalize_init__()
 
         # reattach the wrapped __init__ to the class, so it is used instead of the original one.
-        setattr(cls, '__init__', wrapped_init)
+        setattr(cls, "__init__", wrapped_init)
 
 
 # Utility function for object creation
@@ -509,16 +516,22 @@ class GateObject:
         # check if the attribute is known, otherwise warn the user
         known_attributes = type(self).__dict__.get("known_attributes")
         if known_attributes is None:
-            raise GateImplementationError(f"Did not find 'known_attributes' in the {self.type_name}. "
-                                          f"Has the class correctly been processed by process_cls()?")
+            raise GateImplementationError(
+                f"Did not find 'known_attributes' in the {self.type_name}. "
+                f"Has the class correctly been processed by process_cls()?"
+            )
         if len(known_attributes) > 0:
             if key not in known_attributes:
                 msg = f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
                 close_matches = get_close_matches(key, known_attributes)
-                if len(close_matches)> 0:
-                    msg_close_matches = f"Did you mean: " + " or ".join(close_matches) + "\n"
+                if len(close_matches) > 0:
+                    msg_close_matches = (
+                        f"Did you mean: " + " or ".join(close_matches) + "\n"
+                    )
                     msg += msg_close_matches
-                known_attr = ", ".join(str(a) for a in known_attributes if not a.startswith('_'))
+                known_attr = ", ".join(
+                    str(a) for a in known_attributes if not a.startswith("_")
+                )
                 msg += f"Known attributes of this object are: {known_attr}"
                 self.warn_user(msg)
                 self.number_of_warnings += 1

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -518,7 +518,7 @@ class GateObject:
                 if len(close_matches)> 0:
                     msg_close_matches = f"Did you mean: " + " or ".join(close_matches) + "\n"
                     msg += msg_close_matches
-                known_attr = ", ".join(str(a) for a in known_attributes)
+                known_attr = ", ".join(str(a) for a in known_attributes if not a.startswith('_'))
                 msg += f"Known attributes of this object are: {known_attr}"
                 self.warn_user(msg)
                 self.number_of_warnings += 1

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -6,7 +6,7 @@ from difflib import get_close_matches
 from box import Box
 import sys
 
-from .exception import fatal, warning, GateDeprecationError, GateFeatureUnavailableError
+from .exception import fatal, warning, GateDeprecationError, GateFeatureUnavailableError, GateImplementationError
 from .definitions import (
     __gate_list_objects__,
     __gate_dictionary_objects__,

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -454,6 +454,10 @@ class GateObject:
                     f'For object "{self.name}", attribute "{key}" is not known. Maybe a typo?\n'
                     f"Known attributes of this object are: {s}"
                 )
+        known_attributes = type(self).__dict__.get("known_attributes")
+        if known_attributes is None:
+            raise GateImplementationError(f"Did not find 'known_attributes' in the {self.type_name}. "
+                                          f"Has the class correctly been processed by process_cls()?")
                 self.number_of_warnings += 1
         super().__setattr__(key, value)
 

--- a/opengate/base.py
+++ b/opengate/base.py
@@ -2,6 +2,7 @@ import copy
 from pathlib import Path
 from typing import Optional, List
 from difflib import get_close_matches
+from functools import wraps
 
 from box import Box
 import sys
@@ -95,6 +96,7 @@ def wrap_init_method(cls):
     # if it is implemented, i.e. present in __dict__, wrap it
     if original_init is not None:
         # define a closure
+        @wraps(original_init)
         def wrapped_init(self, *args, **kwargs):
             # original_init is the __init__ captured in the closure
             original_init(self, *args, **kwargs)

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -912,6 +912,7 @@ class SimulationOutput:
         self.ppid = os.getppid()
         self.current_random_seed = None
         self.user_hook_log = []
+        self.warnings = None
 
     def store_actors(self, simulation_engine):
         self.actors = simulation_engine.simulation.actor_manager.actors
@@ -1121,6 +1122,13 @@ class SimulationEngine(GateSingletonFatal):
         # prepare the output
         output = SimulationOutput()
 
+        # if the simulation is run in a subprocess,
+        # we want to capture only the warnings from this point on
+        # because everything else has already been executed in the main process
+        # and potential warnings have already been registered.
+        if self.new_process is True:
+            self.simulation.reset_warnings()
+
         # initialization
         self.initialize()
 
@@ -1156,16 +1164,7 @@ class SimulationEngine(GateSingletonFatal):
         output.store_hook_log(self)
         output.current_random_seed = self.current_random_seed
         output.expected_number_of_events = self.source_engine.expected_number_of_events
-
-        if len(self.simulation.warnings) > 0:
-            print("*" * 20)
-            print(
-                f"{len(self.simulation.warnings)} warnings occurred in this simulation: "
-            )
-            for w in self.simulation.warnings:
-                print(w)
-                print("-" * 10)
-            print("*" * 20)
+        output.warnings = self.simulation.warnings
 
         return output
 

--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -241,7 +241,7 @@ class VolumeBase(DynamicGateObject, NodeMixin):
         super().__finalize_init__()
         # need to add this explciitly because anytree does not properly declare
         # the attribute __parent in the NodeMixin.__init__ which leads to falls warnings
-        self.known_attributes.add('_NodeMixin__parent')
+        self.known_attributes.add("_NodeMixin__parent")
 
     def _update_node(self):
         """Internal method which retrieves the volume object

--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -237,6 +237,12 @@ class VolumeBase(DynamicGateObject, NodeMixin):
         return_dict["_is_constructed"] = False
         return return_dict
 
+    def __finalize_init__(self):
+        super().__finalize_init__()
+        # need to add this explciitly because anytree does not properly declare
+        # the attribute __parent in the NodeMixin.__init__ which leads to falls warnings
+        self.known_attributes.add('_NodeMixin__parent')
+
     def _update_node(self):
         """Internal method which retrieves the volume object
         from the volume manager based on the mother's name stored as user info 'mother'

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1406,6 +1406,9 @@ class Simulation(GateObject):
         kwargs.pop('simulation', None)
         super().__init__(name=name, **kwargs)
 
+        # list to store warning messages issued somewhere in the simulation
+        self._user_warnings = []
+
         # for debug only
         self.verbose_getstate = False
         self.verbose_close = False
@@ -1425,8 +1428,6 @@ class Simulation(GateObject):
         # read-only info
         self._current_random_seed = None
 
-        # list to store warning messages issued somewhere in the simulation
-        self._user_warnings = []
         self.expected_number_of_events = None
 
     def __str__(self):

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1396,13 +1396,15 @@ class Simulation(GateObject):
         ),
     }
 
-    def __init__(self, name="simulation"):
+    def __init__(self, name="simulation", **kwargs):
         """
         Main members are:
         - managers of volumes, physics, sources, actors and filters
         - the Geant4 objects will be only built during initialisation in SimulationEngine
         """
-        super().__init__(name=name)
+        # The Simulation instance should not hold a reference to itself (cycle)
+        kwargs.pop('simulation', None)
+        super().__init__(name=name, **kwargs)
 
         # for debug only
         self.verbose_getstate = False

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1403,7 +1403,7 @@ class Simulation(GateObject):
         - the Geant4 objects will be only built during initialisation in SimulationEngine
         """
         # The Simulation instance should not hold a reference to itself (cycle)
-        kwargs.pop('simulation', None)
+        kwargs.pop("simulation", None)
         super().__init__(name=name, **kwargs)
 
         # list to store warning messages issued somewhere in the simulation
@@ -1697,9 +1697,7 @@ class Simulation(GateObject):
 
         if len(self.warnings) > 0:
             print("*" * 20)
-            print(
-                f"{len(self.warnings)} warnings occurred in this simulation: \n"
-            )
+            print(f"{len(self.warnings)} warnings occurred in this simulation: \n")
             for i, w in enumerate(self.warnings):
                 print(f"{i+1}) " + "-" * 10)
                 print(w)

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1678,6 +1678,8 @@ class Simulation(GateObject):
             # because everything is already in place.
             output = self._run_simulation_engine(False)
 
+        self._user_warnings.extend(output.warnings)
+
         # FIXME workaround
         self.expected_number_of_events = output.expected_number_of_events
 
@@ -1691,6 +1693,17 @@ class Simulation(GateObject):
         # FIXME: MaterialDatabase should become a Manager/Engine with close mechanism
         if self.volume_manager.material_database is None:
             self.volume_manager.material_database = MaterialDatabase()
+
+        if len(self.warnings) > 0:
+            print("*" * 20)
+            print(
+                f"{len(self.warnings)} warnings occurred in this simulation: \n"
+            )
+            for i, w in enumerate(self.warnings):
+                print(f"{i+1}) " + "-" * 10)
+                print(w)
+                print()
+            print("*" * 20)
 
     def voxelize_geometry(
         self,

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1427,6 +1427,7 @@ class Simulation(GateObject):
 
         # list to store warning messages issued somewhere in the simulation
         self._user_warnings = []
+        self.expected_number_of_events = None
 
     def __str__(self):
         s = (

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1463,6 +1463,9 @@ class Simulation(GateObject):
     def warnings(self):
         return self._user_warnings
 
+    def reset_warnings(self):
+        self._user_warnings = []
+
     def to_dictionary(self):
         d = super().to_dictionary()
         d["volume_manager"] = self.volume_manager.to_dictionary()

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1466,6 +1466,12 @@ class Simulation(GateObject):
     def reset_warnings(self):
         self._user_warnings = []
 
+    def warn_user(self, message):
+        # We need this specific implementation because the Simulation does not hold a reference 'simulation',
+        # as required by the base class implementation of warn_user()
+        self._user_warnings.append(message)
+        super().warn_user(message)
+
     def to_dictionary(self):
         d = super().to_dictionary()
         d["volume_manager"] = self.volume_manager.to_dictionary()

--- a/opengate/tests/src/test078_check_userinfo.py
+++ b/opengate/tests/src/test078_check_userinfo.py
@@ -9,6 +9,27 @@ from opengate.tests.utility import (
 from opengate.utility import g4_units
 from opengate.managers import Simulation
 
+
+def set_wrong_attribute(obj, attr):
+    # set a WRONG attribute
+    number_of_warnings_before = getattr(obj, "number_of_warnings")
+    setattr(obj, attr, "nothing")
+    number_of_warnings_after = getattr(obj, "number_of_warnings")
+
+    # check the number of warnings before and after
+    print(
+        f"Number of warnings for {obj.type_name} object {obj.name}: {number_of_warnings_before}"
+    )
+    print(
+        f"Number of warnings for {obj.type_name} object {obj.name}: {number_of_warnings_after}"
+    )
+    b = (number_of_warnings_after - number_of_warnings_before == 1)
+    print_test(
+        b, f"Tried to set a wrong attribute '{attr}'. It should print a single warning"
+    )
+    return b
+
+
 if __name__ == "__main__":
     paths = get_default_test_paths(
         __file__,
@@ -54,18 +75,9 @@ if __name__ == "__main__":
     )
     print()
 
-    # set a WRONG attribute
-    stats.TOTO = "nothing"
-
-    # check the number of warnings (before the run)
-    print(
-        f"(before run) Number of warnings for stats object: {stats.number_of_warnings}"
-    )
-    b = stats.number_of_warnings == 1
-    print_test(
-        b, f"Try to set a wrong attribute 'TOTO', it should print a single warning"
-    )
-    is_ok = is_ok and b
+    is_ok = is_ok and set_wrong_attribute(stats, 'TOTO')
+    is_ok = is_ok and set_wrong_attribute(waterbox, 'mohter')
+    is_ok = is_ok and set_wrong_attribute(sim, 'nthreads')
 
     sim.run(start_new_process=True)
 

--- a/opengate/tests/src/test078_check_userinfo.py
+++ b/opengate/tests/src/test078_check_userinfo.py
@@ -23,7 +23,7 @@ def set_wrong_attribute(obj, attr):
     print(
         f"Number of warnings for {obj.type_name} object {obj.name}: {number_of_warnings_after}"
     )
-    b = (number_of_warnings_after - number_of_warnings_before == 1)
+    b = number_of_warnings_after - number_of_warnings_before == 1
     print_test(
         b, f"Tried to set a wrong attribute '{attr}'. It should print a single warning"
     )
@@ -75,9 +75,9 @@ if __name__ == "__main__":
     )
     print()
 
-    is_ok = is_ok and set_wrong_attribute(stats, 'TOTO')
-    is_ok = is_ok and set_wrong_attribute(waterbox, 'mohter')
-    is_ok = is_ok and set_wrong_attribute(sim, 'nthreads')
+    is_ok = is_ok and set_wrong_attribute(stats, "TOTO")
+    is_ok = is_ok and set_wrong_attribute(waterbox, "mohter")
+    is_ok = is_ok and set_wrong_attribute(sim, "nthreads")
 
     sim.run(start_new_process=True)
 

--- a/opengate/tests/src/test078_check_userinfo.py
+++ b/opengate/tests/src/test078_check_userinfo.py
@@ -7,7 +7,7 @@ from opengate.tests.utility import (
     print_test,
 )
 from opengate.utility import g4_units
-from opengate.managers import Simulation
+import opengate as gate
 
 
 def set_wrong_attribute(obj, attr):
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         __file__,
     )
 
-    sim = Simulation()
+    sim = gate.Simulation()
 
     m = g4_units.m
     cm = g4_units.cm
@@ -48,10 +48,21 @@ if __name__ == "__main__":
     world.size = [3 * m, 3 * m, 3 * m]
     world.material = "G4_AIR"
 
-    waterbox = sim.add_volume("Box", "Waterbox")
+    is_ok = True
+
+    # create the volume without adding it to the simulation
+    waterbox = gate.geometry.volumes.BoxVolume(name="Waterbox")
     waterbox.size = [40 * cm, 40 * cm, 40 * cm]
     waterbox.translation = [0 * cm, 0 * cm, 25 * cm]
     waterbox.material = "G4_WATER"
+    # provoke a warning
+    is_ok = is_ok and set_wrong_attribute(waterbox, "mohter")
+    # now add the volume to the simulation
+    sim.add_volume(waterbox)
+    # a warning about the wrong attribute "mohter" should appear
+    # in the list of warnings at the end of the simulation
+    # because it should be transferred from the object's warning cache
+    # to the simulation's warning cache once the object is added to the simulation
 
     source = sim.add_source("GenericSource", "Default")
     source.particle = "gamma"
@@ -61,7 +72,6 @@ if __name__ == "__main__":
     source.n = 20
 
     # test wrong attributes
-    is_ok = True
     stats = sim.add_actor("SimulationStatisticsActor", "Stats")
     stats.track_types_flag = True
     try:
@@ -76,10 +86,16 @@ if __name__ == "__main__":
     print()
 
     is_ok = is_ok and set_wrong_attribute(stats, "TOTO")
-    is_ok = is_ok and set_wrong_attribute(waterbox, "mohter")
     is_ok = is_ok and set_wrong_attribute(sim, "nthreads")
 
     sim.run(start_new_process=True)
+
+    found_warning_about_waterbox_mohter = False
+    for w in sim.warnings:
+        if "mohter" in w:
+            found_warning_about_waterbox_mohter = True
+            break
+    is_ok = is_ok and found_warning_about_waterbox_mohter
 
     print(
         f"(after run) Number of warnings for stats object: {stats.number_of_warnings}"


### PR DESCRIPTION
This PR significantly improves the recently implemented checks when a user tries to set an attribute. 

* wraps the __init__ method to automatically call __finalize_init__ at the very end of the chain of calls to __init__ (super classes). This is achieved by defining a closure and by looking at the MRO. 
* implements a temporary warning stack in each GateObject that is used to store warning messages as long as the GateObject holds no reference to the simulation. The simulation.setter then registered the accumulated warning to the simulation once the object is added
* the __finalize_init__ implementation in the GateObject base class now uses dir(self) to determine the already known attributes. This also captures properties and attributes define via pybind with def_readwrite, like fFilters. Therefore, no specific __finalize_init__() methods are needed anymore.   

Almost good to go, but let me check some details. 