### PR TITLE
Simple refactoring of sources to use GateObject

### DIFF
--- a/opengate/sources/beamsources.py
+++ b/opengate/sources/beamsources.py
@@ -17,6 +17,19 @@ class IonPencilBeamSource(GenericSource):
     Pencil Beam source
     """
 
+    user_info_defaults = {
+        # Position settings
+        'position': (Box({
+            'type': ("disc", {"doc": "Type of position shape"})
+        }), {"doc": "Position settings"}),
+
+        # Direction settings in a Box object
+        'direction': (Box({
+            'partPhSp_x': ([0, 0, 0, 0], {"doc": "Particle phase space in x-direction"}),
+            'partPhSp_y': ([0, 0, 0, 0], {"doc": "Particle phase space in y-direction"})
+        }), {"doc": "Direction settings"})
+    }
+
     type_name = "IonPencilBeamSource"
 
     @staticmethod
@@ -58,6 +71,41 @@ class TreatmentPlanPBSource(SourceBase):
     """
     Treatment Plan source Pencil Beam
     """
+
+    user_info_defaults = {
+        # Initial user info
+        'sorted_spot_generation': (False, {"doc": "Whether to sort spot generation"}),
+        'beam_model': (None, {"doc": "Model of the beam"}),
+        'plan_path': (None, {"doc": "Path for planning"}),
+        'beam_data_dict': (None, {"doc": "Dictionary for beam data"}),
+        'beam_nr': (1, {"doc": "Number of beams"}),
+        'gantry_rot_axis': ("z", {"doc": "Axis of rotation for the gantry"}),
+        'particle': (None, {"doc": "Type of particle"}),
+        'flat_generation': (False, {"doc": "Whether flat generation is enabled"}),
+
+        # Ion information in a Box object
+        'ion': (Box({
+            'Z': (0, {"doc": "Atomic Number"}),
+            'A': (0, {"doc": "Atomic Mass (nn + np + nlambda)"}),
+            'E': (0, {"doc": "Excitation energy (for metastable states)"})
+        }), {"doc": "Ion settings"}),
+
+        # Position information in a Box object
+        'position': (Box({
+            'translation': ([0, 0, 0], {"doc": "Translation vector for position"}),
+            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for position"})
+        }), {"doc": "Position settings"}),
+
+        # User should not set these attributes
+        'positions': ([], {"doc": "List of positions (not user-defined)"}),
+        'rotations': ([], {"doc": "List of rotations (not user-defined)"}),
+        'energies': ([], {"doc": "List of energies (not user-defined)"}),
+        'energy_sigmas': ([], {"doc": "List of energy sigmas (not user-defined)"}),
+        'weights': ([], {"doc": "List of weights (not user-defined)"}),
+        'pdf': ([], {"doc": "Probability density function (not user-defined)"}),
+        'partPhSp_xV': ([], {"doc": "Phase space for x direction (not user-defined)"}),
+        'partPhSp_yV': ([], {"doc": "Phase space for y direction (not user-defined)"})
+    }
 
     type_name = "TreatmentPlanPBSource"
 

--- a/opengate/sources/beamsources.py
+++ b/opengate/sources/beamsources.py
@@ -19,15 +19,26 @@ class IonPencilBeamSource(GenericSource):
 
     user_info_defaults = {
         # Position settings
-        'position': (Box({
-            'type': ("disc", {"doc": "Type of position shape"})
-        }), {"doc": "Position settings"}),
-
+        "position": (
+            Box({"type": ("disc", {"doc": "Type of position shape"})}),
+            {"doc": "Position settings"},
+        ),
         # Direction settings in a Box object
-        'direction': (Box({
-            'partPhSp_x': ([0, 0, 0, 0], {"doc": "Particle phase space in x-direction"}),
-            'partPhSp_y': ([0, 0, 0, 0], {"doc": "Particle phase space in y-direction"})
-        }), {"doc": "Direction settings"})
+        "direction": (
+            Box(
+                {
+                    "partPhSp_x": (
+                        [0, 0, 0, 0],
+                        {"doc": "Particle phase space in x-direction"},
+                    ),
+                    "partPhSp_y": (
+                        [0, 0, 0, 0],
+                        {"doc": "Particle phase space in y-direction"},
+                    ),
+                }
+            ),
+            {"doc": "Direction settings"},
+        ),
     }
 
     type_name = "IonPencilBeamSource"
@@ -74,37 +85,50 @@ class TreatmentPlanPBSource(SourceBase):
 
     user_info_defaults = {
         # Initial user info
-        'sorted_spot_generation': (False, {"doc": "Whether to sort spot generation"}),
-        'beam_model': (None, {"doc": "Model of the beam"}),
-        'plan_path': (None, {"doc": "Path for planning"}),
-        'beam_data_dict': (None, {"doc": "Dictionary for beam data"}),
-        'beam_nr': (1, {"doc": "Number of beams"}),
-        'gantry_rot_axis': ("z", {"doc": "Axis of rotation for the gantry"}),
-        'particle': (None, {"doc": "Type of particle"}),
-        'flat_generation': (False, {"doc": "Whether flat generation is enabled"}),
-
+        "sorted_spot_generation": (False, {"doc": "Whether to sort spot generation"}),
+        "beam_model": (None, {"doc": "Model of the beam"}),
+        "plan_path": (None, {"doc": "Path for planning"}),
+        "beam_data_dict": (None, {"doc": "Dictionary for beam data"}),
+        "beam_nr": (1, {"doc": "Number of beams"}),
+        "gantry_rot_axis": ("z", {"doc": "Axis of rotation for the gantry"}),
+        "particle": (None, {"doc": "Type of particle"}),
+        "flat_generation": (False, {"doc": "Whether flat generation is enabled"}),
         # Ion information in a Box object
-        'ion': (Box({
-            'Z': (0, {"doc": "Atomic Number"}),
-            'A': (0, {"doc": "Atomic Mass (nn + np + nlambda)"}),
-            'E': (0, {"doc": "Excitation energy (for metastable states)"})
-        }), {"doc": "Ion settings"}),
-
+        "ion": (
+            Box(
+                {
+                    "Z": (0, {"doc": "Atomic Number"}),
+                    "A": (0, {"doc": "Atomic Mass (nn + np + nlambda)"}),
+                    "E": (0, {"doc": "Excitation energy (for metastable states)"}),
+                }
+            ),
+            {"doc": "Ion settings"},
+        ),
         # Position information in a Box object
-        'position': (Box({
-            'translation': ([0, 0, 0], {"doc": "Translation vector for position"}),
-            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for position"})
-        }), {"doc": "Position settings"}),
-
+        "position": (
+            Box(
+                {
+                    "translation": (
+                        [0, 0, 0],
+                        {"doc": "Translation vector for position"},
+                    ),
+                    "rotation": (
+                        Rotation.identity().as_matrix(),
+                        {"doc": "Rotation matrix for position"},
+                    ),
+                }
+            ),
+            {"doc": "Position settings"},
+        ),
         # User should not set these attributes
-        'positions': ([], {"doc": "List of positions (not user-defined)"}),
-        'rotations': ([], {"doc": "List of rotations (not user-defined)"}),
-        'energies': ([], {"doc": "List of energies (not user-defined)"}),
-        'energy_sigmas': ([], {"doc": "List of energy sigmas (not user-defined)"}),
-        'weights': ([], {"doc": "List of weights (not user-defined)"}),
-        'pdf': ([], {"doc": "Probability density function (not user-defined)"}),
-        'partPhSp_xV': ([], {"doc": "Phase space for x direction (not user-defined)"}),
-        'partPhSp_yV': ([], {"doc": "Phase space for y direction (not user-defined)"})
+        "positions": ([], {"doc": "List of positions (not user-defined)"}),
+        "rotations": ([], {"doc": "List of rotations (not user-defined)"}),
+        "energies": ([], {"doc": "List of energies (not user-defined)"}),
+        "energy_sigmas": ([], {"doc": "List of energy sigmas (not user-defined)"}),
+        "weights": ([], {"doc": "List of weights (not user-defined)"}),
+        "pdf": ([], {"doc": "Probability density function (not user-defined)"}),
+        "partPhSp_xV": ([], {"doc": "Phase space for x direction (not user-defined)"}),
+        "partPhSp_yV": ([], {"doc": "Phase space for y direction (not user-defined)"}),
     }
 
     type_name = "TreatmentPlanPBSource"

--- a/opengate/sources/gansources.py
+++ b/opengate/sources/gansources.py
@@ -243,37 +243,43 @@ class GANSource(GenericSource):
 
     user_info_defaults = {
         # Additional parameters
-        'pth_filename': (None, {"doc": "Path to the file"}),
-        'position_keys': (None, {"doc": "Keys for positions"}),
-        'backward_distance': (None, {"doc": "Distance for backward propagation"}),
-
+        "pth_filename": (None, {"doc": "Path to the file"}),
+        "position_keys": (None, {"doc": "Keys for positions"}),
+        "backward_distance": (None, {"doc": "Distance for backward propagation"}),
         # Backward propagation settings
-        'backward_force': (False, {"doc": "Force backward propagation if time is not managed by GAN"}),
-
-        'direction_keys': (None, {"doc": "Keys for directions"}),
-        'energy_key': (None, {"doc": "Key for energy"}),
-        'energy_min_threshold': (-1, {"doc": "Minimum energy threshold, -1 means no minimum"}),
-        'energy_max_threshold': (sys.float_info.max, {"doc": "Maximum energy threshold"}),
-
-        'weight_key': (None, {"doc": "Key for weight"}),
-        'time_key': (None, {"doc": "Key for time"}),
-        'relative_timing': (True, {"doc": "Whether timing is relative"}),
-        'batch_size': (10000, {"doc": "Batch size for processing"}),
-        'generator': (None, {"doc": "Generator for samples"}),
-        'verbose_generator': (False, {"doc": "Control verbosity of the generator"}),
-        'use_time': (False, {"doc": "Whether to use time information"}),
-        'use_weight': (False, {"doc": "Whether to use weight information"}),
-
+        "backward_force": (
+            False,
+            {"doc": "Force backward propagation if time is not managed by GAN"},
+        ),
+        "direction_keys": (None, {"doc": "Keys for directions"}),
+        "energy_key": (None, {"doc": "Key for energy"}),
+        "energy_min_threshold": (
+            -1,
+            {"doc": "Minimum energy threshold, -1 means no minimum"},
+        ),
+        "energy_max_threshold": (
+            sys.float_info.max,
+            {"doc": "Maximum energy threshold"},
+        ),
+        "weight_key": (None, {"doc": "Key for weight"}),
+        "time_key": (None, {"doc": "Key for time"}),
+        "relative_timing": (True, {"doc": "Whether timing is relative"}),
+        "batch_size": (10000, {"doc": "Batch size for processing"}),
+        "generator": (None, {"doc": "Generator for samples"}),
+        "verbose_generator": (False, {"doc": "Control verbosity of the generator"}),
+        "use_time": (False, {"doc": "Whether to use time information"}),
+        "use_weight": (False, {"doc": "Whether to use weight information"}),
         # Specific to conditional GAN
-        'cond_image': (None, {"doc": "Conditional image input"}),
-        'compute_directions': (False, {"doc": "Whether to compute directions"}),
-        'cond_debug': (False, {"doc": "Debug mode for conditional GAN"}),
-
+        "cond_image": (None, {"doc": "Conditional image input"}),
+        "compute_directions": (False, {"doc": "Whether to compute directions"}),
+        "cond_debug": (False, {"doc": "Debug mode for conditional GAN"}),
         # For skipped particles
-        'skip_policy': ("SkipEvents", {"doc": "Policy for skipped particles; can also be ZeroEnergy"}),
-
+        "skip_policy": (
+            "SkipEvents",
+            {"doc": "Policy for skipped particles; can also be ZeroEnergy"},
+        ),
         # GPU mode settings
-        'gpu_mode': ("auto", {"doc": "GPU mode: auto, cpu, or gpu"})
+        "gpu_mode": ("auto", {"doc": "GPU mode: auto, cpu, or gpu"}),
     }
 
     type_name = "GANSource"

--- a/opengate/sources/gansources.py
+++ b/opengate/sources/gansources.py
@@ -241,6 +241,41 @@ class GANSource(GenericSource):
     Input is a neural network Generator trained with a GAN
     """
 
+    user_info_defaults = {
+        # Additional parameters
+        'pth_filename': (None, {"doc": "Path to the file"}),
+        'position_keys': (None, {"doc": "Keys for positions"}),
+        'backward_distance': (None, {"doc": "Distance for backward propagation"}),
+
+        # Backward propagation settings
+        'backward_force': (False, {"doc": "Force backward propagation if time is not managed by GAN"}),
+
+        'direction_keys': (None, {"doc": "Keys for directions"}),
+        'energy_key': (None, {"doc": "Key for energy"}),
+        'energy_min_threshold': (-1, {"doc": "Minimum energy threshold, -1 means no minimum"}),
+        'energy_max_threshold': (sys.float_info.max, {"doc": "Maximum energy threshold"}),
+
+        'weight_key': (None, {"doc": "Key for weight"}),
+        'time_key': (None, {"doc": "Key for time"}),
+        'relative_timing': (True, {"doc": "Whether timing is relative"}),
+        'batch_size': (10000, {"doc": "Batch size for processing"}),
+        'generator': (None, {"doc": "Generator for samples"}),
+        'verbose_generator': (False, {"doc": "Control verbosity of the generator"}),
+        'use_time': (False, {"doc": "Whether to use time information"}),
+        'use_weight': (False, {"doc": "Whether to use weight information"}),
+
+        # Specific to conditional GAN
+        'cond_image': (None, {"doc": "Conditional image input"}),
+        'compute_directions': (False, {"doc": "Whether to compute directions"}),
+        'cond_debug': (False, {"doc": "Debug mode for conditional GAN"}),
+
+        # For skipped particles
+        'skip_policy': ("SkipEvents", {"doc": "Policy for skipped particles; can also be ZeroEnergy"}),
+
+        # GPU mode settings
+        'gpu_mode': ("auto", {"doc": "GPU mode: auto, cpu, or gpu"})
+    }
+
     type_name = "GANSource"
 
     @staticmethod

--- a/opengate/sources/generic.py
+++ b/opengate/sources/generic.py
@@ -199,6 +199,15 @@ class SourceBase(UserElement):
     Base class for all source types.
     """
 
+    user_info_defaults = {
+        'mother': (__world_name__, {"doc": "FIXME"}),
+        'start_time': (None, {"doc": "FIXME"}),
+        'end_time': (None, {"doc": "FIXME"}),
+        'n': (0, {"doc": "FIXME"}),
+        'activity': (0, {"doc": "FIXME"}),
+        'half_life': (-1, {"doc": "FIXME"})  # Example: negative value is no half-life
+    }
+
     @staticmethod
     def set_default_user_info(user_info):
         UserElement.set_default_user_info(user_info)
@@ -285,6 +294,66 @@ class GenericSource(SourceBase):
     GenericSource close to the G4 SPS, but a bit simpler.
     The G4 source created by this class is GateGenericSource.
     """
+
+    user_info_defaults = {
+        # Initial user info
+        'particle': ("gamma", {"doc": "FIXME"}),
+        'ion': (Box(), {"doc": "FIXME"}),
+        'weight': (-1, {"doc": "FIXME"}),
+        'weight_sigma': (-1, {"doc": "FIXME"}),
+        'user_particle_life_time': (-1, {"doc": "Negative means by default"}),
+        'tac_times': (None, {"doc": "FIXME"}),
+        'tac_activities': (None, {"doc": "FIXME"}),
+        'direction_relative_to_attached_volume': (False, {"doc": "FIXME"}),
+
+        # Ion info
+        'ion.Z': (0, {"doc": "Z: Atomic Number"}),
+        'ion.A': (0, {"doc": "A: Atomic Mass (nn + np + nlambda)"}),
+        'ion.E': (0, {"doc": "E: Excitation energy (for metastable states)"}),
+
+        # Position info
+        'position': (Box(), {"doc": "FIXME"}),
+        'position.type': ("point", {"doc": "FIXME"}),
+        'position.radius': (0, {"doc": "FIXME"}),
+        'position.sigma_x': (0, {"doc": "FIXME"}),
+        'position.sigma_y': (0, {"doc": "FIXME"}),
+        'position.size': ([0, 0, 0], {"doc": "FIXME"}),
+        'position.translation': ([0, 0, 0], {"doc": "FIXME"}),
+        'position.rotation': (Rotation.identity().as_matrix(), {"doc": "FIXME"}),
+        'position.confine': (None, {"doc": "FIXME"}),
+
+        # Angle (direction)
+        'direction': (Box(), {"doc": "FIXME"}),
+        'direction.type': ("iso", {"doc": "FIXME"}),
+        'direction.theta': ([0, 180 * g4_units.deg], {"doc": "FIXME"}),
+        'direction.phi': ([0, 360 * g4_units.deg], {"doc": "FIXME"}),
+        'direction.momentum': ([0, 0, 1], {"doc": "FIXME"}),
+        'direction.focus_point': ([0, 0, 0], {"doc": "FIXME"}),
+        'direction.sigma': ([0, 0], {"doc": "FIXME"}),
+        'direction.acceptance_angle': (Box(), {"doc": "FIXME"}),
+        'direction.acceptance_angle.skip_policy': ("SkipEvents", {"doc": "Can also be ZeroEnergy"}),
+        'direction.acceptance_angle.volumes': ([], {"doc": "FIXME"}),
+        'direction.acceptance_angle.intersection_flag': (False, {"doc": "FIXME"}),
+        'direction.acceptance_angle.normal_flag': (False, {"doc": "FIXME"}),
+        'direction.acceptance_angle.normal_vector': ([0, 0, 1], {"doc": "FIXME"}),
+        'direction.acceptance_angle.normal_tolerance': (3 * g4_units.deg, {"doc": "FIXME"}),
+        'direction.accolinearity_flag': (False, {"doc": "Only for back_to_back source"}),
+        'direction.histogram_theta_weight': ([], {"doc": "FIXME"}),
+        'direction.histogram_theta_angle': ([], {"doc": "FIXME"}),
+        'direction.histogram_phi_weight': ([], {"doc": "FIXME"}),
+        'direction.histogram_phi_angle': ([], {"doc": "FIXME"}),
+
+        # Energy info
+        'energy': (Box(), {"doc": "FIXME"}),
+        'energy.type': ("mono", {"doc": "FIXME"}),
+        'energy.mono': (0, {"doc": "FIXME"}),
+        'energy.sigma_gauss': (0, {"doc": "FIXME"}),
+        'energy.is_cdf': (False, {"doc": "FIXME"}),
+        'energy.min_energy': (None, {"doc": "FIXME"}),
+        'energy.max_energy': (None, {"doc": "FIXME"}),
+        'energy.histogram_weight': (None, {"doc": "FIXME"}),
+        'energy.histogram_energy': (None, {"doc": "FIXME"})
+    }
 
     type_name = "GenericSource"
 

--- a/opengate/sources/generic.py
+++ b/opengate/sources/generic.py
@@ -200,12 +200,12 @@ class SourceBase(UserElement):
     """
 
     user_info_defaults = {
-        'mother': (__world_name__, {"doc": "FIXME"}),
-        'start_time': (None, {"doc": "FIXME"}),
-        'end_time': (None, {"doc": "FIXME"}),
-        'n': (0, {"doc": "FIXME"}),
-        'activity': (0, {"doc": "FIXME"}),
-        'half_life': (-1, {"doc": "FIXME"})  # Example: negative value is no half-life
+        "mother": (__world_name__, {"doc": "FIXME"}),
+        "start_time": (None, {"doc": "FIXME"}),
+        "end_time": (None, {"doc": "FIXME"}),
+        "n": (0, {"doc": "FIXME"}),
+        "activity": (0, {"doc": "FIXME"}),
+        "half_life": (-1, {"doc": "FIXME"}),  # Example: negative value is no half-life
     }
 
     @staticmethod
@@ -297,62 +297,67 @@ class GenericSource(SourceBase):
 
     user_info_defaults = {
         # Initial user info
-        'particle': ("gamma", {"doc": "FIXME"}),
-        'ion': (Box(), {"doc": "FIXME"}),
-        'weight': (-1, {"doc": "FIXME"}),
-        'weight_sigma': (-1, {"doc": "FIXME"}),
-        'user_particle_life_time': (-1, {"doc": "Negative means by default"}),
-        'tac_times': (None, {"doc": "FIXME"}),
-        'tac_activities': (None, {"doc": "FIXME"}),
-        'direction_relative_to_attached_volume': (False, {"doc": "FIXME"}),
-
+        "particle": ("gamma", {"doc": "FIXME"}),
+        "ion": (Box(), {"doc": "FIXME"}),
+        "weight": (-1, {"doc": "FIXME"}),
+        "weight_sigma": (-1, {"doc": "FIXME"}),
+        "user_particle_life_time": (-1, {"doc": "Negative means by default"}),
+        "tac_times": (None, {"doc": "FIXME"}),
+        "tac_activities": (None, {"doc": "FIXME"}),
+        "direction_relative_to_attached_volume": (False, {"doc": "FIXME"}),
         # Ion info
-        'ion.Z': (0, {"doc": "Z: Atomic Number"}),
-        'ion.A': (0, {"doc": "A: Atomic Mass (nn + np + nlambda)"}),
-        'ion.E': (0, {"doc": "E: Excitation energy (for metastable states)"}),
-
+        "ion.Z": (0, {"doc": "Z: Atomic Number"}),
+        "ion.A": (0, {"doc": "A: Atomic Mass (nn + np + nlambda)"}),
+        "ion.E": (0, {"doc": "E: Excitation energy (for metastable states)"}),
         # Position info
-        'position': (Box(), {"doc": "FIXME"}),
-        'position.type': ("point", {"doc": "FIXME"}),
-        'position.radius': (0, {"doc": "FIXME"}),
-        'position.sigma_x': (0, {"doc": "FIXME"}),
-        'position.sigma_y': (0, {"doc": "FIXME"}),
-        'position.size': ([0, 0, 0], {"doc": "FIXME"}),
-        'position.translation': ([0, 0, 0], {"doc": "FIXME"}),
-        'position.rotation': (Rotation.identity().as_matrix(), {"doc": "FIXME"}),
-        'position.confine': (None, {"doc": "FIXME"}),
-
+        "position": (Box(), {"doc": "FIXME"}),
+        "position.type": ("point", {"doc": "FIXME"}),
+        "position.radius": (0, {"doc": "FIXME"}),
+        "position.sigma_x": (0, {"doc": "FIXME"}),
+        "position.sigma_y": (0, {"doc": "FIXME"}),
+        "position.size": ([0, 0, 0], {"doc": "FIXME"}),
+        "position.translation": ([0, 0, 0], {"doc": "FIXME"}),
+        "position.rotation": (Rotation.identity().as_matrix(), {"doc": "FIXME"}),
+        "position.confine": (None, {"doc": "FIXME"}),
         # Angle (direction)
-        'direction': (Box(), {"doc": "FIXME"}),
-        'direction.type': ("iso", {"doc": "FIXME"}),
-        'direction.theta': ([0, 180 * g4_units.deg], {"doc": "FIXME"}),
-        'direction.phi': ([0, 360 * g4_units.deg], {"doc": "FIXME"}),
-        'direction.momentum': ([0, 0, 1], {"doc": "FIXME"}),
-        'direction.focus_point': ([0, 0, 0], {"doc": "FIXME"}),
-        'direction.sigma': ([0, 0], {"doc": "FIXME"}),
-        'direction.acceptance_angle': (Box(), {"doc": "FIXME"}),
-        'direction.acceptance_angle.skip_policy': ("SkipEvents", {"doc": "Can also be ZeroEnergy"}),
-        'direction.acceptance_angle.volumes': ([], {"doc": "FIXME"}),
-        'direction.acceptance_angle.intersection_flag': (False, {"doc": "FIXME"}),
-        'direction.acceptance_angle.normal_flag': (False, {"doc": "FIXME"}),
-        'direction.acceptance_angle.normal_vector': ([0, 0, 1], {"doc": "FIXME"}),
-        'direction.acceptance_angle.normal_tolerance': (3 * g4_units.deg, {"doc": "FIXME"}),
-        'direction.accolinearity_flag': (False, {"doc": "Only for back_to_back source"}),
-        'direction.histogram_theta_weight': ([], {"doc": "FIXME"}),
-        'direction.histogram_theta_angle': ([], {"doc": "FIXME"}),
-        'direction.histogram_phi_weight': ([], {"doc": "FIXME"}),
-        'direction.histogram_phi_angle': ([], {"doc": "FIXME"}),
-
+        "direction": (Box(), {"doc": "FIXME"}),
+        "direction.type": ("iso", {"doc": "FIXME"}),
+        "direction.theta": ([0, 180 * g4_units.deg], {"doc": "FIXME"}),
+        "direction.phi": ([0, 360 * g4_units.deg], {"doc": "FIXME"}),
+        "direction.momentum": ([0, 0, 1], {"doc": "FIXME"}),
+        "direction.focus_point": ([0, 0, 0], {"doc": "FIXME"}),
+        "direction.sigma": ([0, 0], {"doc": "FIXME"}),
+        "direction.acceptance_angle": (Box(), {"doc": "FIXME"}),
+        "direction.acceptance_angle.skip_policy": (
+            "SkipEvents",
+            {"doc": "Can also be ZeroEnergy"},
+        ),
+        "direction.acceptance_angle.volumes": ([], {"doc": "FIXME"}),
+        "direction.acceptance_angle.intersection_flag": (False, {"doc": "FIXME"}),
+        "direction.acceptance_angle.normal_flag": (False, {"doc": "FIXME"}),
+        "direction.acceptance_angle.normal_vector": ([0, 0, 1], {"doc": "FIXME"}),
+        "direction.acceptance_angle.normal_tolerance": (
+            3 * g4_units.deg,
+            {"doc": "FIXME"},
+        ),
+        "direction.accolinearity_flag": (
+            False,
+            {"doc": "Only for back_to_back source"},
+        ),
+        "direction.histogram_theta_weight": ([], {"doc": "FIXME"}),
+        "direction.histogram_theta_angle": ([], {"doc": "FIXME"}),
+        "direction.histogram_phi_weight": ([], {"doc": "FIXME"}),
+        "direction.histogram_phi_angle": ([], {"doc": "FIXME"}),
         # Energy info
-        'energy': (Box(), {"doc": "FIXME"}),
-        'energy.type': ("mono", {"doc": "FIXME"}),
-        'energy.mono': (0, {"doc": "FIXME"}),
-        'energy.sigma_gauss': (0, {"doc": "FIXME"}),
-        'energy.is_cdf': (False, {"doc": "FIXME"}),
-        'energy.min_energy': (None, {"doc": "FIXME"}),
-        'energy.max_energy': (None, {"doc": "FIXME"}),
-        'energy.histogram_weight': (None, {"doc": "FIXME"}),
-        'energy.histogram_energy': (None, {"doc": "FIXME"})
+        "energy": (Box(), {"doc": "FIXME"}),
+        "energy.type": ("mono", {"doc": "FIXME"}),
+        "energy.mono": (0, {"doc": "FIXME"}),
+        "energy.sigma_gauss": (0, {"doc": "FIXME"}),
+        "energy.is_cdf": (False, {"doc": "FIXME"}),
+        "energy.min_energy": (None, {"doc": "FIXME"}),
+        "energy.max_energy": (None, {"doc": "FIXME"}),
+        "energy.histogram_weight": (None, {"doc": "FIXME"}),
+        "energy.histogram_energy": (None, {"doc": "FIXME"}),
     }
 
     type_name = "GenericSource"

--- a/opengate/sources/phidsources.py
+++ b/opengate/sources/phidsources.py
@@ -32,29 +32,28 @@ class PhotonFromIonDecaySource(GenericSource):
 
     user_info_defaults = {
         # Specific user info
-        'verbose': (False, {"doc": "FIXME"}),
-
+        "verbose": (False, {"doc": "FIXME"}),
         # Binning for the TAC
-        'tac_bins': (200, {"doc": "Number of bins for the TAC"}),
-
+        "tac_bins": (200, {"doc": "Number of bins for the TAC"}),
         # Write log in the given file
-        'dump_log': (None, {"doc": "Log file to dump, if any"}),
-
+        "dump_log": (None, {"doc": "Log file to dump, if any"}),
         # Not user parameters but required before init
-        'ui_sub_sources': ([], {"doc": "Used before init; not a user parameter"}),
-        'daughters': (None, {"doc": "Used before init; not a user parameter"}),
-        'log': ("", {"doc": "Used before init; not a user parameter"}),
-
+        "ui_sub_sources": ([], {"doc": "Used before init; not a user parameter"}),
+        "daughters": (None, {"doc": "Used before init; not a user parameter"}),
+        "log": ("", {"doc": "Used before init; not a user parameter"}),
         # Both are needed but can be disabled for debugging
-        'atomic_relaxation_flag': (True, {"doc": "Controls atomic relaxation"}),
-        'isomeric_transition_flag': (True, {"doc": "Controls isomeric transitions"}),
-
+        "atomic_relaxation_flag": (True, {"doc": "Controls atomic relaxation"}),
+        "isomeric_transition_flag": (True, {"doc": "Controls isomeric transitions"}),
         # Debugging option
-        'debug_first_daughter_only': (False, {"doc": "Enable to debug only the first daughter"}),
-
+        "debug_first_daughter_only": (
+            False,
+            {"doc": "Enable to debug only the first daughter"},
+        ),
         # Gamma lines need to be computed before G4 init
-        'initialize_source_before_g4_engine': (
-        gid_build_all_sub_sources, {"doc": "Ensures gamma lines are computed before G4 initialization"})
+        "initialize_source_before_g4_engine": (
+            gid_build_all_sub_sources,
+            {"doc": "Ensures gamma lines are computed before G4 initialization"},
+        ),
     }
 
     type_name = "PhotonFromIonDecaySource"

--- a/opengate/sources/phidsources.py
+++ b/opengate/sources/phidsources.py
@@ -30,6 +30,33 @@ class PhotonFromIonDecaySource(GenericSource):
     - spectrum energy line for atomic relaxation (fluo)
     """
 
+    user_info_defaults = {
+        # Specific user info
+        'verbose': (False, {"doc": "FIXME"}),
+
+        # Binning for the TAC
+        'tac_bins': (200, {"doc": "Number of bins for the TAC"}),
+
+        # Write log in the given file
+        'dump_log': (None, {"doc": "Log file to dump, if any"}),
+
+        # Not user parameters but required before init
+        'ui_sub_sources': ([], {"doc": "Used before init; not a user parameter"}),
+        'daughters': (None, {"doc": "Used before init; not a user parameter"}),
+        'log': ("", {"doc": "Used before init; not a user parameter"}),
+
+        # Both are needed but can be disabled for debugging
+        'atomic_relaxation_flag': (True, {"doc": "Controls atomic relaxation"}),
+        'isomeric_transition_flag': (True, {"doc": "Controls isomeric transitions"}),
+
+        # Debugging option
+        'debug_first_daughter_only': (False, {"doc": "Enable to debug only the first daughter"}),
+
+        # Gamma lines need to be computed before G4 init
+        'initialize_source_before_g4_engine': (
+        gid_build_all_sub_sources, {"doc": "Ensures gamma lines are computed before G4 initialization"})
+    }
+
     type_name = "PhotonFromIonDecaySource"
 
     @staticmethod

--- a/opengate/sources/phspsources.py
+++ b/opengate/sources/phspsources.py
@@ -250,6 +250,52 @@ class PhaseSpaceSource(SourceBase):
 
     """
 
+    user_info_defaults = {
+        # Initial user info
+        'phsp_file': (None, {"doc": "FIXME"}),
+        'n': (0, {"doc": "FIXME"}),
+        'activity': (0, {"doc": "FIXME"}),
+        'half_life': (-1, {"doc": "Negative value means no half-life"}),
+        'particle': ("", {"doc": "FIXME later as key"}),
+        'entry_start': (None, {"doc": "FIXME"}),
+
+        # Global flag determines if position/direction are relative to the mother volume
+        'global_flag': (False, {"doc": "Global position/direction if True, otherwise relative to mother volume"}),
+        'batch_size': (10000, {"doc": "Batch size for processing"}),
+
+        # Phase space file keys
+        'position_key': ("PrePositionLocal", {"doc": "Branch name for position in the phsp file"}),
+        'position_key_x': (None, {"doc": "FIXME"}),
+        'position_key_y': (None, {"doc": "FIXME"}),
+        'position_key_z': (None, {"doc": "FIXME"}),
+        'direction_key': ("PreDirectionLocal", {"doc": "Branch name for direction in the phsp file"}),
+        'direction_key_x': (None, {"doc": "FIXME"}),
+        'direction_key_y': (None, {"doc": "FIXME"}),
+        'direction_key_z': (None, {"doc": "FIXME"}),
+        'energy_key': ("KineticEnergy", {"doc": "Key for energy in the phsp file"}),
+        'weight_key': ("Weight", {"doc": "Key for weight in the phsp file"}),
+        'PDGCode_key': ("PDGCode", {"doc": "Key for PDG code in the phsp file"}),
+
+        # Source transformation options
+        'translate_position': (False, {"doc": "If True, translates position relative to stored coordinates"}),
+        'rotate_direction': (False, {"doc": "If True, rotates direction relative to stored direction"}),
+
+        # Position and rotation in a Box object
+        'position': (Box({
+            'translation': ([0, 0, 0], {"doc": "Translation vector for the source position"}),
+            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for the source position"})
+        }), {"doc": "Position information"}),
+
+        # Primary generation options
+        'generate_until_next_primary': (False, {"doc": "Generate until next primary"}),
+        'primary_lower_energy_threshold': (0, {"doc": "Lower energy threshold for primary"}),
+        'primary_PDGCode': (0, {"doc": "PDG code for primary particle"}),
+
+        # Verbosity options
+        'verbose': (False, {"doc": "Control verbosity of the process"}),
+        'verbose_batch': (False, {"doc": "Control verbosity for batch processing"})
+    }
+
     type_name = "PhaseSpaceSource"
 
     @staticmethod

--- a/opengate/sources/phspsources.py
+++ b/opengate/sources/phspsources.py
@@ -252,48 +252,73 @@ class PhaseSpaceSource(SourceBase):
 
     user_info_defaults = {
         # Initial user info
-        'phsp_file': (None, {"doc": "FIXME"}),
-        'n': (0, {"doc": "FIXME"}),
-        'activity': (0, {"doc": "FIXME"}),
-        'half_life': (-1, {"doc": "Negative value means no half-life"}),
-        'particle': ("", {"doc": "FIXME later as key"}),
-        'entry_start': (None, {"doc": "FIXME"}),
-
+        "phsp_file": (None, {"doc": "FIXME"}),
+        "n": (0, {"doc": "FIXME"}),
+        "activity": (0, {"doc": "FIXME"}),
+        "half_life": (-1, {"doc": "Negative value means no half-life"}),
+        "particle": ("", {"doc": "FIXME later as key"}),
+        "entry_start": (None, {"doc": "FIXME"}),
         # Global flag determines if position/direction are relative to the mother volume
-        'global_flag': (False, {"doc": "Global position/direction if True, otherwise relative to mother volume"}),
-        'batch_size': (10000, {"doc": "Batch size for processing"}),
-
+        "global_flag": (
+            False,
+            {
+                "doc": "Global position/direction if True, otherwise relative to mother volume"
+            },
+        ),
+        "batch_size": (10000, {"doc": "Batch size for processing"}),
         # Phase space file keys
-        'position_key': ("PrePositionLocal", {"doc": "Branch name for position in the phsp file"}),
-        'position_key_x': (None, {"doc": "FIXME"}),
-        'position_key_y': (None, {"doc": "FIXME"}),
-        'position_key_z': (None, {"doc": "FIXME"}),
-        'direction_key': ("PreDirectionLocal", {"doc": "Branch name for direction in the phsp file"}),
-        'direction_key_x': (None, {"doc": "FIXME"}),
-        'direction_key_y': (None, {"doc": "FIXME"}),
-        'direction_key_z': (None, {"doc": "FIXME"}),
-        'energy_key': ("KineticEnergy", {"doc": "Key for energy in the phsp file"}),
-        'weight_key': ("Weight", {"doc": "Key for weight in the phsp file"}),
-        'PDGCode_key': ("PDGCode", {"doc": "Key for PDG code in the phsp file"}),
-
+        "position_key": (
+            "PrePositionLocal",
+            {"doc": "Branch name for position in the phsp file"},
+        ),
+        "position_key_x": (None, {"doc": "FIXME"}),
+        "position_key_y": (None, {"doc": "FIXME"}),
+        "position_key_z": (None, {"doc": "FIXME"}),
+        "direction_key": (
+            "PreDirectionLocal",
+            {"doc": "Branch name for direction in the phsp file"},
+        ),
+        "direction_key_x": (None, {"doc": "FIXME"}),
+        "direction_key_y": (None, {"doc": "FIXME"}),
+        "direction_key_z": (None, {"doc": "FIXME"}),
+        "energy_key": ("KineticEnergy", {"doc": "Key for energy in the phsp file"}),
+        "weight_key": ("Weight", {"doc": "Key for weight in the phsp file"}),
+        "PDGCode_key": ("PDGCode", {"doc": "Key for PDG code in the phsp file"}),
         # Source transformation options
-        'translate_position': (False, {"doc": "If True, translates position relative to stored coordinates"}),
-        'rotate_direction': (False, {"doc": "If True, rotates direction relative to stored direction"}),
-
+        "translate_position": (
+            False,
+            {"doc": "If True, translates position relative to stored coordinates"},
+        ),
+        "rotate_direction": (
+            False,
+            {"doc": "If True, rotates direction relative to stored direction"},
+        ),
         # Position and rotation in a Box object
-        'position': (Box({
-            'translation': ([0, 0, 0], {"doc": "Translation vector for the source position"}),
-            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for the source position"})
-        }), {"doc": "Position information"}),
-
+        "position": (
+            Box(
+                {
+                    "translation": (
+                        [0, 0, 0],
+                        {"doc": "Translation vector for the source position"},
+                    ),
+                    "rotation": (
+                        Rotation.identity().as_matrix(),
+                        {"doc": "Rotation matrix for the source position"},
+                    ),
+                }
+            ),
+            {"doc": "Position information"},
+        ),
         # Primary generation options
-        'generate_until_next_primary': (False, {"doc": "Generate until next primary"}),
-        'primary_lower_energy_threshold': (0, {"doc": "Lower energy threshold for primary"}),
-        'primary_PDGCode': (0, {"doc": "PDG code for primary particle"}),
-
+        "generate_until_next_primary": (False, {"doc": "Generate until next primary"}),
+        "primary_lower_energy_threshold": (
+            0,
+            {"doc": "Lower energy threshold for primary"},
+        ),
+        "primary_PDGCode": (0, {"doc": "PDG code for primary particle"}),
         # Verbosity options
-        'verbose': (False, {"doc": "Control verbosity of the process"}),
-        'verbose_batch': (False, {"doc": "Control verbosity for batch processing"})
+        "verbose": (False, {"doc": "Control verbosity of the process"}),
+        "verbose_batch": (False, {"doc": "Control verbosity for batch processing"}),
     }
 
     type_name = "PhaseSpaceSource"

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -20,25 +20,39 @@ class VoxelsSource(GenericSource):
 
     user_info_defaults = {
         # Additional options
-        'image': (None, {"doc": "Image data or path"}),
-
+        "image": (None, {"doc": "Image data or path"}),
         # Position information in a Box object
-        'position': (Box({
-            'translation': ([0, 0, 0], {"doc": "Translation vector for the position"}),
-            'confine': (None, {"doc": "Constraints for position confinement"}),
-            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for the position"})
-        }), {"doc": "Position information"}),
-
+        "position": (
+            Box(
+                {
+                    "translation": (
+                        [0, 0, 0],
+                        {"doc": "Translation vector for the position"},
+                    ),
+                    "confine": (None, {"doc": "Constraints for position confinement"}),
+                    "rotation": (
+                        Rotation.identity().as_matrix(),
+                        {"doc": "Rotation matrix for the position"},
+                    ),
+                }
+            ),
+            {"doc": "Position information"},
+        ),
         # Direction settings
-        'direction': (Box({
-            'type': ("iso", {"doc": "Type of direction"})
-        }), {"doc": "Direction settings"}),
-
+        "direction": (
+            Box({"type": ("iso", {"doc": "Type of direction"})}),
+            {"doc": "Direction settings"},
+        ),
         # Energy settings
-        'energy': (Box({
-            'type': ("mono", {"doc": "Type of energy"}),
-            'mono': (0, {"doc": "Mono energy value"})
-        }), {"doc": "Energy settings"})
+        "energy": (
+            Box(
+                {
+                    "type": ("mono", {"doc": "Type of energy"}),
+                    "mono": (0, {"doc": "Mono energy value"}),
+                }
+            ),
+            {"doc": "Energy settings"},
+        ),
     }
 
     type_name = "VoxelsSource"

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -18,6 +18,29 @@ class VoxelsSource(GenericSource):
     Sampled with cumulative distribution functions.
     """
 
+    user_info_defaults = {
+        # Additional options
+        'image': (None, {"doc": "Image data or path"}),
+
+        # Position information in a Box object
+        'position': (Box({
+            'translation': ([0, 0, 0], {"doc": "Translation vector for the position"}),
+            'confine': (None, {"doc": "Constraints for position confinement"}),
+            'rotation': (Rotation.identity().as_matrix(), {"doc": "Rotation matrix for the position"})
+        }), {"doc": "Position information"}),
+
+        # Direction settings
+        'direction': (Box({
+            'type': ("iso", {"doc": "Type of direction"})
+        }), {"doc": "Direction settings"}),
+
+        # Energy settings
+        'energy': (Box({
+            'type': ("mono", {"doc": "Type of energy"}),
+            'mono': (0, {"doc": "Mono energy value"})
+        }), {"doc": "Energy settings"})
+    }
+
     type_name = "VoxelsSource"
 
     @staticmethod


### PR DESCRIPTION
A first "shallow" refactoring of the sources. The sole purpose is to let them become GateObjects so sources can use all the cool features that GateObjects have. Any other structural changes can be done later. 

To start with, I explained chatGPT how to generate user_info_default dictionaries based on the attributes defined in set_default_user_info(). It works quite well and chatGPT was even able to generate some 'doc' entries based on comments in the code. Saved a lot of manual work. 

PR opened in as a draft.  