### PR TITLE
fix include position in GateInfo.cpp

### DIFF
--- a/core/opengate_core/opengate_lib/GateInfo.cpp
+++ b/core/opengate_core/opengate_lib/GateInfo.cpp
@@ -10,6 +10,10 @@
 #include <itkVersion.h>
 #include <streambuf>
 
+#ifdef G4VIS_USE_OPENGLQT
+#include <QtGlobal>
+#endif
+
 #ifdef G4MULTITHREADED
 
 #include "G4MTRunManager.hh"
@@ -36,7 +40,6 @@ bool GateInfo::get_G4VIS_USE_OPENGLQT() {
 
 std::string GateInfo::get_QT_VERSION() {
 #ifdef G4VIS_USE_OPENGLQT
-#include <QtGlobal>
   std::ostringstream oss;
   oss << QT_VERSION_MAJOR << "." << QT_VERSION_MINOR << "." << QT_VERSION_PATCH;
   return oss.str();


### PR DESCRIPTION
There was an inclusion (`#include <QtGlobal>`) in a function in `GateInfo.cpp`.