### PR TITLE
Only download the g4 data that are missing

### DIFF
--- a/core/opengate_core/g4DataSetup.py
+++ b/core/opengate_core/g4DataSetup.py
@@ -85,7 +85,7 @@ def download_g4_data(missing_g4_Data=None):
     folder_names_from_tar = set()
 
     if missing_g4_Data is None:
-        data_packages_needed = data_packages
+        data_packages_needed = list(data_packages.values())
     else:
         data_packages_needed = [
             package


### PR DESCRIPTION
Currently, even if only one g4 data folder is missing, all of them are re-downloaded. This PR change this behavior by keeping track of which g4 data is missing and only downloading them. The naming of the variables/methods were adapted to this new behavior.

This is a really small quality of life feature for dev. It is mostly for seldom contributors like me that also have slow internet. I guess we could say that limiting the number of downloads also save electricity and thus our carbon footprint? :P 