### PR TITLE
remove spurious usages of virtual keyword

### DIFF
--- a/core/opengate_core/opengate_lib/GateARFActor.h
+++ b/core/opengate_core/opengate_lib/GateARFActor.h
@@ -23,13 +23,13 @@ public:
   // Constructor
   explicit GateARFActor(py::dict &user_info);
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Beginning run callback
-  virtual void BeginOfRunAction(const G4Run * /*run*/) override;
+  void BeginOfRunAction(const G4Run * /*run*/) override;
 
   // End run callback
-  virtual void EndOfRunAction(const G4Run * /*run*/) override;
+  void EndOfRunAction(const G4Run * /*run*/) override;
 
   int GetCurrentNumberOfHits() const;
 

--- a/core/opengate_core/opengate_lib/GateARFTrainingDatasetActor.h
+++ b/core/opengate_core/opengate_lib/GateARFTrainingDatasetActor.h
@@ -22,7 +22,7 @@ public:
   // Constructor
   explicit GateARFTrainingDatasetActor(py::dict &user_info);
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Main function called every step in attached volume
   void StartSimulationAction() override;

--- a/core/opengate_core/opengate_lib/GateFluenceActor.h
+++ b/core/opengate_core/opengate_lib/GateFluenceActor.h
@@ -23,17 +23,17 @@ public:
   // Constructor
   GateFluenceActor(py::dict &user_info);
 
-  virtual void InitializeCpp() override;
+  void InitializeCpp() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Function called every step in attached volume
   // This where the scoring takes place
-  virtual void SteppingAction(G4Step *) override;
+  void SteppingAction(G4Step *) override;
 
-  virtual void BeginOfEventAction(const G4Event *event) override;
+  void BeginOfEventAction(const G4Event *event) override;
 
-  virtual void BeginOfRunActionMasterThread(int run_id) override;
+  void BeginOfRunActionMasterThread(int run_id) override;
 
   inline std::string GetPhysicalVolumeName() { return fPhysicalVolumeName; }
 

--- a/core/opengate_core/opengate_lib/GateGenericSource.h
+++ b/core/opengate_core/opengate_lib/GateGenericSource.h
@@ -113,7 +113,7 @@ protected:
 
   virtual void InitializeEnergy(py::dict user_info);
 
-  virtual void UpdateActivity(double time) override;
+  void UpdateActivity(double time) override;
 
   void UpdateEffectiveEventTime(double current_simulation_time,
                                 unsigned long skipped_particle);

--- a/core/opengate_core/opengate_lib/GateLETActor.h
+++ b/core/opengate_core/opengate_lib/GateLETActor.h
@@ -24,21 +24,21 @@ public:
   // Constructor
   GateLETActor(py::dict &user_info);
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
-  virtual void InitializeCpp() override;
+  void InitializeCpp() override;
 
   // Main function called every step in attached volume
-  virtual void SteppingAction(G4Step *) override;
+  void SteppingAction(G4Step *) override;
 
-  virtual void BeginOfEventAction(const G4Event *event) override;
+  void BeginOfEventAction(const G4Event *event) override;
 
   // Called every time a Run starts (all threads)
-  virtual void BeginOfRunAction(const G4Run *run) override;
+  void BeginOfRunAction(const G4Run *run) override;
 
-  virtual void BeginOfRunActionMasterThread(int run_id) override;
+  void BeginOfRunActionMasterThread(int run_id) override;
 
-  virtual void EndSimulationAction() override;
+  void EndSimulationAction() override;
 
   inline std::string GetPhysicalVolumeName() const {
     return fPhysicalVolumeName;

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceActor.h
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceActor.h
@@ -25,9 +25,9 @@ public:
 
   ~GatePhaseSpaceActor() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
-  virtual void InitializeCpp() override;
+  void InitializeCpp() override;
 
   // Called when the simulation start (master thread only)
   void StartSimulationAction() override;

--- a/core/opengate_core/opengate_lib/GateSimulationStatisticsActor.h
+++ b/core/opengate_core/opengate_lib/GateSimulationStatisticsActor.h
@@ -20,30 +20,30 @@ public:
   // explicit GateSimulationStatisticsActor(std::string type_name);
   explicit GateSimulationStatisticsActor(py::dict &user_info);
 
-  virtual ~GateSimulationStatisticsActor();
+  ~GateSimulationStatisticsActor() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Called when the simulation start (master thread only)
-  virtual void StartSimulationAction() override;
+  void StartSimulationAction() override;
 
   // Called when the simulation end (master thread only)
-  virtual void EndSimulationAction() override;
+  void EndSimulationAction() override;
 
   // Called every time a Run starts (all threads)
-  virtual void BeginOfRunAction(const G4Run *run) override;
+  void BeginOfRunAction(const G4Run *run) override;
 
   // Called every time a Run ends (all threads)
-  virtual void EndOfRunAction(const G4Run *run) override;
+  void EndOfRunAction(const G4Run *run) override;
 
   // Called every time the simulation is about to end (all threads)
-  virtual void EndOfSimulationWorkerAction(const G4Run *lastRun) override;
+  void EndOfSimulationWorkerAction(const G4Run *lastRun) override;
 
   // Called every time a Track starts (all threads)
-  virtual void PreUserTrackingAction(const G4Track *track) override;
+  void PreUserTrackingAction(const G4Track *track) override;
 
   // Called every time a batch of step must be processed
-  virtual void SteppingAction(G4Step *) override;
+  void SteppingAction(G4Step *) override;
 
   py::dict GetCounts();
 

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
@@ -53,7 +53,7 @@ public:
   // destructor
   ~GateDigitizerAdderActor() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Called when the simulation start (master thread only)
   void StartSimulationAction() override;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerBlurringActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerBlurringActor.h
@@ -33,7 +33,7 @@ public:
   // destructor
   ~GateDigitizerBlurringActor() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Called every time an Event ends (all threads)
   void EndOfEventAction(const G4Event *event) override;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerEfficiencyActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerEfficiencyActor.cpp
@@ -19,8 +19,6 @@ GateDigitizerEfficiencyActor::GateDigitizerEfficiencyActor(py::dict &user_info)
   fActions.insert("EndOfEventAction");
 }
 
-GateDigitizerEfficiencyActor::~GateDigitizerEfficiencyActor() = default;
-
 void GateDigitizerEfficiencyActor::InitializeUserInput(py::dict &user_info) {
   GateVDigitizerWithOutputActor::InitializeUserInput(user_info);
   // efficiency method

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerEfficiencyActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerEfficiencyActor.h
@@ -29,10 +29,7 @@ public:
   // constructor
   explicit GateDigitizerEfficiencyActor(py::dict &user_info);
 
-  // destructor
-  ~GateDigitizerEfficiencyActor() override;
-
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Called every time an Event ends (all threads)
   void EndOfEventAction(const G4Event *event) override;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerEnergyWindowsActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerEnergyWindowsActor.cpp
@@ -23,8 +23,6 @@ GateDigitizerEnergyWindowsActor::GateDigitizerEnergyWindowsActor(
   fActions.insert("EndSimulationAction");
 }
 
-GateDigitizerEnergyWindowsActor::~GateDigitizerEnergyWindowsActor() = default;
-
 void GateDigitizerEnergyWindowsActor::InitializeUserInput(py::dict &user_info) {
   GateVActor::InitializeUserInput(user_info);
   // options

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerEnergyWindowsActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerEnergyWindowsActor.h
@@ -26,11 +26,9 @@ class GateDigitizerEnergyWindowsActor : public GateVActor {
 public:
   explicit GateDigitizerEnergyWindowsActor(py::dict &user_info);
 
-  virtual ~GateDigitizerEnergyWindowsActor();
+  void InitializeUserInput(py::dict &user_info) override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
-
-  virtual void InitializeCpp() override;
+  void InitializeCpp() override;
 
   // Called when the simulation start (master thread only)
   void StartSimulationAction() override;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerSpatialBlurringActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerSpatialBlurringActor.h
@@ -33,7 +33,7 @@ public:
   // destructor
   ~GateDigitizerSpatialBlurringActor() override;
 
-  virtual void InitializeUserInput(py::dict &user_info) override;
+  void InitializeUserInput(py::dict &user_info) override;
 
   // Called every time a Run starts (all threads)
   void BeginOfRunAction(const G4Run *run) override;

--- a/core/opengate_core/opengate_lib/digitizer/GateTDigiAttribute.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateTDigiAttribute.cpp
@@ -17,8 +17,6 @@ GateTDigiAttribute<T>::GateTDigiAttribute(std::string vname)
   Fatal("GateTDigiAttribute constructor must be specialized for this type");
 }
 
-template <class T> GateTDigiAttribute<T>::~GateTDigiAttribute() {}
-
 template <class T>
 void GateTDigiAttribute<T>::InitDefaultProcessHitsFunction() {
   // By default, "do nothing" in the process hit function

--- a/core/opengate_core/opengate_lib/digitizer/GateTDigiAttribute.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateTDigiAttribute.h
@@ -17,41 +17,39 @@ template <class T> class GateTDigiAttribute : public GateVDigiAttribute {
 public:
   explicit GateTDigiAttribute(std::string vname);
 
-  ~GateTDigiAttribute() override;
+  int GetSize() const override;
 
-  virtual int GetSize() const override;
+  std::vector<double> &GetDValues() override;
 
-  virtual std::vector<double> &GetDValues() override;
+  std::vector<int> &GetIValues() override;
 
-  virtual std::vector<int> &GetIValues() override;
+  std::vector<std::string> &GetSValues() override;
 
-  virtual std::vector<std::string> &GetSValues() override;
+  std::vector<G4ThreeVector> &Get3Values() override;
 
-  virtual std::vector<G4ThreeVector> &Get3Values() override;
-
-  virtual std::vector<GateUniqueVolumeID::Pointer> &GetUValues() override;
+  std::vector<GateUniqueVolumeID::Pointer> &GetUValues() override;
 
   const std::vector<T> &GetValues() const;
 
-  virtual void FillToRoot(size_t index) const override;
+  void FillToRoot(size_t index) const override;
 
-  virtual void FillDValue(double v) override;
+  void FillDValue(double v) override;
 
-  virtual void FillSValue(std::string v) override;
+  void FillSValue(std::string v) override;
 
-  virtual void FillIValue(int v) override;
+  void FillIValue(int v) override;
 
-  virtual void Fill3Value(G4ThreeVector v) override;
+  void Fill3Value(G4ThreeVector v) override;
 
-  virtual void FillUValue(GateUniqueVolumeID::Pointer v) override;
+  void FillUValue(GateUniqueVolumeID::Pointer v) override;
 
-  virtual void Fill(GateVDigiAttribute *input, size_t index) override;
+  void Fill(GateVDigiAttribute *input, size_t index) override;
 
-  virtual void FillDigiWithEmptyValue() override;
+  void FillDigiWithEmptyValue() override;
 
-  virtual void Clear() override;
+  void Clear() override;
 
-  virtual std::string Dump(int i) const override;
+  std::string Dump(int i) const override;
 
 protected:
   struct threadLocal_t {


### PR DESCRIPTION
This PR removes several usages of the `virtual` keyword.

For those who would want to know why:
[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override)

By default, if `B` inherits `A` and both provide a member function `f`, calling it through a reference of type `A` or a pointer of type `A*` which actually refers to a `B` (or holds the address of a `B` for the pointer case) will cause the version from class `A` to be used.
Adding `virtual` changes the behaviour to make it so it calls the member function of class `B`.

Making `f` virtual in `A` makes it `virtual` in all inheriting class, so it is not necessary to specify the `virtual` keyword except in class `A`.
However, to indicate in subclasses that a function is `virtual` to the human, before C++11 it was only possible to either add a comment or put the `virtual` keyword anyway.
Since C++11, a new keyword exists: `override`.
It can only be used on member functions that are `virtual`, so the compiler will check that for us (it helps avoiding spelling/type/constness mistakes).

Putting both `virtual` and `override` on the same member function declaration breaks the effect of `override` because even if the function does not exist or is not virtual in the parent class, it will compile as it is marked virtual.

TL; DR: any member function must be marked either `virtual` or `override` (or none), never both.