### PR TITLE
Debug autodoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,30 +6,9 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.11"
-#  jobs:
-#    pre_build:
-##      - cat /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py
-#      - cp /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py.bak
-#      - |
-#        { head -n 1 /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py.bak;
-#        echo "import sys";
-#        echo "print(\"DEBUG: sys.path = \", sys.path)";
-#        echo "import cmd";
-#        echo "print(\"DEBUG: cmd.__file__=\", cmd.__file__)";
-#        tail -n +2 /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py.bak; }
-#        > /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/pdb.py
-#      - cp /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/doctest.py /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/doctest.py.bak
-#      - |
-#        { echo "import pdb";
-#        echo "print(\"DEBUG: pdb.__file__=\", pdb.__file__)";
-#        cat /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/doctest.py.bak; }
-#        > /home/docs/.asdf/installs/python/3.11.9/lib/python3.11/doctest.py
-#      - cp /home/docs/checkouts/readthedocs.org/user_builds/opengate-python/envs/fix_autodoc/lib/python3.11/site-packages/sphinx/ext/doctest.py /home/docs/checkouts/readthedocs.org/user_builds/opengate-python/envs/fix_autodoc/lib/python3.11/site-packages/sphinx/ext/doctest.py.bak
-#      - |
-#        { head -n 188 /home/docs/checkouts/readthedocs.org/user_builds/opengate-python/envs/fix_autodoc/lib/python3.11/site-packages/sphinx/ext/doctest.py.bak;
-#        echo "print(\"DEBUG: doctest.__file__=\", doctest.__file__)";
-#        tail -n +189 /home/docs/checkouts/readthedocs.org/user_builds/opengate-python/envs/fix_autodoc/lib/python3.11/site-packages/sphinx/ext/doctest.py.bak; }
-#        > /home/docs/checkouts/readthedocs.org/user_builds/opengate-python/envs/fix_autodoc/lib/python3.11/site-packages/sphinx/ext/doctest.py
+  jobs:
+    pre_build:
+      - cd docs/source && sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
 
 # Build from the docs/ directory with Sphinx
 sphinx:

--- a/autodoctest.py
+++ b/autodoctest.py
@@ -1,3 +1,0 @@
-def test_func_for_autodoc(a):
-    """This is a test docstring."""
-    print(a)

--- a/docs/run_rtd.sh
+++ b/docs/run_rtd.sh
@@ -16,4 +16,5 @@ python -m pip install --upgrade --no-cache-dir sphinx
 python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
 mkdir docs/output
 cd docs/source
+sphinx-build -T -b html -d _build/doctrees -D language=en . ../output/html
 python -m sphinx -T -b html -d _build/doctrees -D language=en . ../output/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,7 +131,7 @@ pygments_style = None
 #
 # html_theme = 'sphinx_rtd_theme'
 html_theme = "pydata_sphinx_theme"
-html_logo = "_static/gate_logo.png"
+# html_logo = "_static/gate_logo.png"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,10 +270,3 @@ epub_exclude_files = ["search.html"]
 # autoapi_type = "python"
 # autoapi_dirs = ["../../opengate", "../../core"]
 # autoapi_ignore = ["*/opengate/tests/src*"]
-
-# Create the doc with sphinx-build instead of python -m sphinx
-if not sys.argv[0].endswith("sphinx-build"):
-    import subprocess
-
-    command = "sphinx-build -T -b html -d _build/doctrees -D language=en . html"
-    subprocess.run(command.split())

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ os.environ["GATEONRTD"] = "1"
 
 # sys.path.append(str(Path(__file__).resolve().parents[1]))
 # print("DEBUG: sys.path = ", sys.path)
-# sys.path.append(str(Path("..", "..").resolve()))
+sys.path.append(str(Path("..", "..").resolve()))
 autodoc_mock_imports = [
     "opengate_core",
     # "colored",
@@ -270,3 +270,10 @@ epub_exclude_files = ["search.html"]
 # autoapi_type = "python"
 # autoapi_dirs = ["../../opengate", "../../core"]
 # autoapi_ignore = ["*/opengate/tests/src*"]
+
+# Create the doc with sphinx-build instead of python -m sphinx
+if not sys.argv[0].endswith("sphinx-build"):
+    import subprocess
+
+    command = "sphinx-build -T -b html -d _build/doctrees -D language=en . html"
+    subprocess.run(command.split())

--- a/docs/source/developer_guide/developer_guide_installation.rst
+++ b/docs/source/developer_guide/developer_guide_installation.rst
@@ -62,10 +62,10 @@ STEP 1 - Geant4 and Qt
 ----------------------
 
 :warning: When using conda, be sure to activate your environment before
-compiling Geant4. The reason is that conda comes with its own compiler
-and you will likely have mismatched libraries, e.g. lib c++, if not all
-installation steps involving compilaton are performed in the same conda
-environment.
+  compiling Geant4. The reason is that conda comes with its own compiler
+  and you will likely have mismatched libraries, e.g. lib c++, if not all
+  installation steps involving compilaton are performed in the same conda
+  environment.
 
 Installing QT is optional. Currently, QT visualisation is not working on
 all architectures.

--- a/docs/source/developer_guide/developer_guide_installation.rst
+++ b/docs/source/developer_guide/developer_guide_installation.rst
@@ -20,15 +20,15 @@ Virtual environment
 -------------------
 
 :warning: It is highly, highly, *highly* recommended to create a python
-environment prior to the installation, for example with
-`venv <https://docs.python.org/3/library/venv.html#module-venv>`__.
+  environment prior to the installation, for example with
+  `venv <https://docs.python.org/3/library/venv.html#module-venv>`__.
 
 :warning: If you use
-`conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#>`__
-instead to create your environment, be sure to instruct conda to install
-python when creating your environment. You do so by adding ‘python’
-after the new environment name. Optionally, you can select a specific
-python version by adding ‘=3.XX’.
+  `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#>`__
+  instead to create your environment, be sure to instruct conda to install
+  python when creating your environment. You do so by adding ‘python’
+  after the new environment name. Optionally, you can select a specific
+  python version by adding ‘=3.XX’.
 
 Example: You can create a new conda environment with Python 3.10
 installed in it via:
@@ -49,8 +49,8 @@ First, clone the unique repository that contains both packages:
    git clone --recurse-submodules https://github.com/OpenGATE/opengate
 
 :warning: When you update, the data for the tests must also be updated,
-use : ``git submodule update --init --recursive``. This also update the
-included subpackages (pybind11, etc).
+  use : ``git submodule update --init --recursive``. This also update the
+  included subpackages (pybind11, etc).
 
 The subpackage ``opengate_core`` depends on the ITK and Geant4
 libraries. Therefore, you first need to download and compile both

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -1,24 +1,21 @@
 Developer guide
 ===============
 
-.. code:: {toctree}
-
+.. toctree::
    :caption: The Basics
    :maxdepth: 2
 
    developer_guide_installation
    developer_guide_contribute
 
-.. code:: {toctree}
-
+.. toctree::
    :caption: Get coding
    :maxdepth: 2
 
    developer_guide_code_structure
    developer_guide_how_to_implement
 
-.. code:: {toctree}
-
+.. toctree::
    :caption: Good to know
    :maxdepth: 2
 

--- a/docs/source/user_guide/user_guide_installation.rst
+++ b/docs/source/user_guide/user_guide_installation.rst
@@ -66,4 +66,4 @@ There are additional command line tools available; see the `addons section <user
 
 - `Exercises <https://gitlab.in2p3.fr/davidsarrut/gate_exercices_2>`_ (initially developed for DQPRM, French medical physics diploma)
 
-- `Exercises <https://drive.google.com/drive/folders/1bcIS5OPLOBzhLo0NvrLJL5IxVQidNYCF>`_ (initially developed for Opengate teaching)
+- `Training <https://drive.google.com/drive/folders/1bcIS5OPLOBzhLo0NvrLJL5IxVQidNYCF>`_ (initially developed for Opengate teaching)

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -20,7 +20,7 @@ The SimulationStatisticsActor actor is a very basic tool that allows counting th
    print(stats)
    print(stats.counts)
 
- In addition, if the flag `track_types_flag` is enabled, the actor will save a dictionary structure with all types of particles that have been created during the simulation, which is available as `stats.counts.track_types`. The start and end time of the whole simulation are  available and speeds are estimated (primary per sec, track per sec, and step per sec).
+In addition, if the flag `track_types_flag` is enabled, the actor will save a dictionary structure with all types of particles that have been created during the simulation, which is available as `stats.counts.track_types`. The start and end time of the whole simulation are  available and speeds are estimated (primary per sec, track per sec, and step per sec).
 
 
 Reference
@@ -307,8 +307,7 @@ The Angular Response Function (ARF) is a method designed to accelerate SPECT sim
 3.	Apply the trained ARF to enhance simulation efficiency.
 
 .. warning::
-
-Ensure that torch and garf (Gate ARF) packages are installed prior to use. Install them with: `pip install torch gaga_phsp garf`
+  Ensure that torch and garf (Gate ARF) packages are installed prior to use. Install them with: `pip install torch gaga_phsp garf`
 
 Step 1: Creating the Training Dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -122,15 +122,15 @@ The names of the attributes align with Geant4 terminology. The list of available
 
 Attributes correspondence with Gate 9.X for Hits and Singles:
 
-+------------------------+-------------------------+
-| Gate 9.X               | Gate 10                 |
-+========================+=========================+
-| edep or energy         | TotalEnergyDeposit       |
-+------------------------+-------------------------+
-| posX/Y/Z of globalPosX/Y/Z | PostPosition_X/Y/Z    |
-+------------------------+-------------------------+
-| time                   | GlobalTime              |
-+------------------------+-------------------------+
++----------------------------+-------------------------+
+| Gate 9.X                   | Gate 10                 |
++============================+=========================+
+| edep or energy             | TotalEnergyDeposit      |
++----------------------------+-------------------------+
+| posX/Y/Z of globalPosX/Y/Z | PostPosition_X/Y/Z      |
++----------------------------+-------------------------+
+| time                       | GlobalTime              |
++----------------------------+-------------------------+
 
 The list of hits can be written to a ROOT file at the end of the simulation. Like in Gate, hits with zero energy are ignored. If zero-energy hits are needed, use a PhaseSpaceActor.
 

--- a/docs/source/user_guide/user_guide_reference_simulation.rst
+++ b/docs/source/user_guide/user_guide_reference_simulation.rst
@@ -72,7 +72,7 @@ If you want to personalize the ``pyvista`` GUI, you can set ``sim.visu_type = "v
 GDML
 ^^^^
 
-.. image:: figures/visu_gdml.png
+.. image:: ../figures/visu_gdml.png
 
 With GDML visualization, you can only view the geometry, not the paths of the particles. It is enabled with ``sim.visu_type = "gdml"``. GDML visualization needs to be enabled in Geant4 with ``GEANT4_USE_GDML=ON`` during the compilation, but you need to have ``xerces-c`` available on your computer (install it with yum, brew, or apt-get, ...).
 

--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -565,7 +565,10 @@ class RepeatableVolume(VolumeBase):
 
 
 class BooleanVolume(RepeatableVolume, solids.BooleanSolid):
-    """Volume resulting from a boolean operation of the solids contained in two volumes."""
+    """
+    Volume resulting from a boolean operation
+    of the solids contained in two volumes.
+    """
 
 
 # Function to handle boolean operations on volumes
@@ -675,7 +678,10 @@ class TubsVolume(RepeatableVolume, solids.TubsSolid):
 
 
 class TesselatedVolume(RepeatableVolume, solids.TesselatedSolid):
-    """Volume based on a mesh volume by reading an STL file."""
+    """
+    Volume based on a mesh volume
+    by reading an STL file.
+    """
 
 
 class RepeatParametrisedVolume(VolumeBase):


### PR DESCRIPTION
For the moment I do not have any explanation but this is what I discover:

On read the docs and on the docker image used by read the docs, the line:
`python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html` leads to a `cmd.Cmd` not found

But the line `sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html` works well without any error.

The difference is in sys.path. In the first case it's:
`['/home/docs/opengate/venv/ib/python3.11/site-packages/sphinx/', '/home/docs/.asdf/installs/python/3.11.9/lib/python311.zip', '/home/docs/.asdf/installs/python/3.11.9/lib/python3.11', '/home/docs/.asdf/installs/python/3.11.9/lib/python3.11/lib-dynload', '/home/docs/opengate/venv/lib/python3.11/site-packages']`

And in the second case:
`['/home/docs/opengate/venv/bin', '/home/docs/.asdf/installs/python/3.11.9/lib/python311.zip', '/home/docs/.asdf/installs/python/3.11.9/lib/python3.11', '/home/docs/.asdf/installs/python/3.11.9/lib/python3.11/lib-dynload', '/home/docs/opengate/venv/lib/python3.11/site-packages']`

In the first case, the folder sphinx/cmd exists leading to the error.

To avoid the error, I force read the docs to use `sphinx-build` first. After that, as the docs was already build, the usual `python -m build` command does not have to do anything.

I also changed some error in the rst files leading to error in the docs

You can see the results here: https://opengate-python.readthedocs.io/en/fix_autodoc/user_guide/user_guide_reference_volumes.html#reference
