### PR TITLE
remove source direction histogram weights mandatory 0

### DIFF
--- a/core/opengate_core/opengate_lib/GateGenericSource.cpp
+++ b/core/opengate_core/opengate_lib/GateGenericSource.cpp
@@ -443,34 +443,31 @@ void GateGenericSource::InitializeDirection(py::dict puser_info) {
 
     auto theta_w = DictGetVecDouble(user_info, "histogram_theta_weights");
     auto theta_e = DictGetVecDouble(user_info, "histogram_theta_angles");
-		
-		if (theta_w.size() + 1 != theta_e.size())
-			Fatal(
-				"GenericSource angular distribution type 'histogram' requires "
-				"'histogram_theta_weights' to have exactly one element less than "
-				"'histogram_theta_angles'."
-			);
 
-		/* TODO
-		 * better general solution would be to add a setter_hook Python-side
-		 * on the histogram_theta/phi_weight to prepend a 0
-		 */
-		ang->UserDefAngTheta({theta_e[0], 0, 0});    for (std::size_t i = 1; i < theta_e.size(); i++)
-      ang->UserDefAngTheta({theta_e[i], theta_w[i-1], 0});
+    if (theta_w.size() + 1 != theta_e.size())
+      Fatal("GenericSource angular distribution type 'histogram' requires "
+            "'histogram_theta_weights' to have exactly one element less than "
+            "'histogram_theta_angles'.");
+
+    /* TODO
+     * better general solution would be to add a setter_hook Python-side
+     * on the histogram_theta/phi_weight to prepend a 0
+     */
+    ang->UserDefAngTheta({theta_e[0], 0, 0});
+    for (std::size_t i = 1; i < theta_e.size(); i++)
+      ang->UserDefAngTheta({theta_e[i], theta_w[i - 1], 0});
 
     auto phi_w = DictGetVecDouble(user_info, "histogram_phi_weights");
     auto phi_e = DictGetVecDouble(user_info, "histogram_phi_angles");
 
-		if (phi_w.size() + 1 != phi_e.size())
-			Fatal(
-				"GenericSource angular distribution type 'histogram' requires "
-				"'histogram_phi_weights' to have exactly one element less than "
-				"'histogram_phi_angles'."
-			);
+    if (phi_w.size() + 1 != phi_e.size())
+      Fatal("GenericSource angular distribution type 'histogram' requires "
+            "'histogram_phi_weights' to have exactly one element less than "
+            "'histogram_phi_angles'.");
 
-		ang->UserDefAngPhi({phi_e[0], 0, 0});
+    ang->UserDefAngPhi({phi_e[0], 0, 0});
     for (std::size_t i = 1; i < phi_e.size(); i++)
-      ang->UserDefAngPhi({phi_e[i], phi_w[i-1], 0});
+      ang->UserDefAngPhi({phi_e[i], phi_w[i - 1], 0});
   }
 
   // set the angle acceptance volume if needed

--- a/core/opengate_core/opengate_lib/GateGenericSource.cpp
+++ b/core/opengate_core/opengate_lib/GateGenericSource.cpp
@@ -440,18 +440,37 @@ void GateGenericSource::InitializeDirection(py::dict puser_info) {
 
   if (ang_type == "histogram") {
     ang->SetAngDistType("user");
-    auto theta_w = DictGetVecDouble(user_info, "histogram_theta_weight");
-    auto theta_e = DictGetVecDouble(user_info, "histogram_theta_angle");
-    for (unsigned long i = 0; i < theta_w.size(); i++) {
-      G4ThreeVector x(theta_e[i], theta_w[i], 0);
-      ang->UserDefAngTheta(x);
-    }
-    auto phi_w = DictGetVecDouble(user_info, "histogram_phi_weight");
-    auto phi_e = DictGetVecDouble(user_info, "histogram_phi_angle");
-    for (unsigned long i = 0; i < phi_w.size(); i++) {
-      G4ThreeVector x(phi_e[i], phi_w[i], 0);
-      ang->UserDefAngPhi(x);
-    }
+
+    auto theta_w = DictGetVecDouble(user_info, "histogram_theta_weights");
+    auto theta_e = DictGetVecDouble(user_info, "histogram_theta_angles");
+		
+		if (theta_w.size() + 1 != theta_e.size())
+			Fatal(
+				"GenericSource angular distribution type 'histogram' requires "
+				"'histogram_theta_weights' to have exactly one element less than "
+				"'histogram_theta_angles'."
+			);
+
+		/* TODO
+		 * better general solution would be to add a setter_hook Python-side
+		 * on the histogram_theta/phi_weight to prepend a 0
+		 */
+		ang->UserDefAngTheta({theta_e[0], 0, 0});    for (std::size_t i = 1; i < theta_e.size(); i++)
+      ang->UserDefAngTheta({theta_e[i], theta_w[i-1], 0});
+
+    auto phi_w = DictGetVecDouble(user_info, "histogram_phi_weights");
+    auto phi_e = DictGetVecDouble(user_info, "histogram_phi_angles");
+
+		if (phi_w.size() + 1 != phi_e.size())
+			Fatal(
+				"GenericSource angular distribution type 'histogram' requires "
+				"'histogram_phi_weights' to have exactly one element less than "
+				"'histogram_phi_angles'."
+			);
+
+		ang->UserDefAngPhi({phi_e[0], 0, 0});
+    for (std::size_t i = 1; i < phi_e.size(); i++)
+      ang->UserDefAngPhi({phi_e[i], phi_w[i-1], 0});
   }
 
   // set the angle acceptance volume if needed

--- a/docs/source/user_guide/user_guide_sources.rst
+++ b/docs/source/user_guide/user_guide_sources.rst
@@ -147,11 +147,10 @@ Direction types and Acceptance Angle
    .. code:: python
 
       source.direction.type = "histogram"
-      # Put zero as first value of weight
-      source.direction.histogram_theta_weight = [0, 1]
-      source.direction.histogram_theta_angle = [80 * deg, 100 * deg]
-      source.direction.histogram_phi_weight = [0, 0.3, 0.5, 1, 0.5, 0.3]
-      source.direction.histogram_phi_angle = [
+      source.direction.histogram_theta_weights = [1]
+      source.direction.histogram_theta_angles = [80 * deg, 100 * deg]
+      source.direction.histogram_phi_weights = [0.3, 0.5, 1, 0.5, 0.3]
+      source.direction.histogram_phi_angles = [
          60 * deg,
          70 * deg,
          80 * deg,

--- a/opengate/contrib/carm/siemensciosalpha.py
+++ b/opengate/contrib/carm/siemensciosalpha.py
@@ -110,13 +110,13 @@ class Ciosalpha:
 
         source.direction_relative_to_attached_volume = True
         source.direction.type = "histogram"
-        source.direction.histogram_theta_weight = [0, 1]
-        source.direction.histogram_theta_angle = [85 * deg, 95 * deg]
+        source.direction.histogram_theta_weights = [1]
+        source.direction.histogram_theta_angles = [85 * deg, 95 * deg]
 
         # TODO: Need real values for the anode heel effect
         data = np.load(current_path / "anodeheeleffect.npz")
-        source.direction.histogram_phi_weight = data["weight"]
-        source.direction.histogram_phi_angle = data["angle"]
+        source.direction.histogram_phi_weights = data["weight"]
+        source.direction.histogram_phi_angles = data["angle"]
 
         source.energy.type = "histogram"
         source.energy.histogram_weight = weights

--- a/opengate/sources/generic.py
+++ b/opengate/sources/generic.py
@@ -318,10 +318,10 @@ class GenericSource(SourceBase):
         user_info.direction.acceptance_angle.normal_vector = [0, 0, 1]
         user_info.direction.acceptance_angle.normal_tolerance = 3 * deg
         user_info.direction.accolinearity_flag = False  # only for back_to_back source
-        user_info.direction.histogram_theta_weight = []
-        user_info.direction.histogram_theta_angle = []
-        user_info.direction.histogram_phi_weight = []
-        user_info.direction.histogram_phi_angle = []
+        user_info.direction.histogram_theta_weights = []
+        user_info.direction.histogram_theta_angles = []
+        user_info.direction.histogram_phi_weights = []
+        user_info.direction.histogram_phi_angles = []
 
         # energy
         user_info.energy = Box()

--- a/opengate/tests/src/test010_generic_source_angular_distribution.py
+++ b/opengate/tests/src/test010_generic_source_angular_distribution.py
@@ -54,10 +54,9 @@ if __name__ == "__main__":
     source.position.translation = [0 * cm, 0 * cm, 0 * cm]
     source.direction.type = "histogram"
     # Put zero as first value of weight
-    source.direction.histogram_theta_weight = [0, 1]
-    source.direction.histogram_theta_angle = [80 * deg, 100 * deg]
-    source.direction.histogram_phi_weight = [0, 0.3, 0.5, 1, 0.5, 0.3]
-    source.direction.histogram_phi_angle = [
+    source.direction.histogram_theta_angles = [80 * deg, 100 * deg]
+    source.direction.histogram_theta_weights = [1]
+    source.direction.histogram_phi_angles = [
         60 * deg,
         70 * deg,
         80 * deg,
@@ -65,6 +64,7 @@ if __name__ == "__main__":
         110 * deg,
         120 * deg,
     ]
+    source.direction.histogram_phi_weights = [0.3, 0.5, 1, 0.5, 0.3]
     source.energy.type = "gauss"
     source.energy.mono = 70 * keV
 


### PR DESCRIPTION
Remove the mandatory first value (0) in the histogram weights list for generic source direction.

Added a test for angles/weights sizes (weights size + 1 == angles size).

Renamed histogram_theta/phi_angle and histogram_theta/phi_weight as histogram_theta/phi_angles and histogram_theta/phi_weights to be coherent with other options of the generic source.