### PR TITLE
Doc dose le tactor

### DIFF
--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -105,7 +105,7 @@ class ActorBase(GateObject):
         "filters_boolean_operator": (
             "and",
             {
-                "doc": "Boolean operator to join the filters of this actor. ",
+                "doc": "Boolean operator to join multiple filters of this actor. ",
                 "allowed_values": (
                     "and",
                     "or",

--- a/opengate/tests/src/test041_dose_actor_dose_to_water_mt.py
+++ b/opengate/tests/src/test041_dose_actor_dose_to_water_mt.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
     dose_actor_IDD_d2w = sim.add_actor("DoseActor", "IDD_d2w")
     dose_actor_IDD_d2w.attached_to = phantom_off
-    dose_actor_IDD_d2w.score_in = "water"
+    dose_actor_IDD_d2w.score_in = "G4_WATER"
     dose_actors.append(dose_actor_IDD_d2w)
 
     dose_actor_water_slab_insert_d = sim.add_actor("DoseActor", "IDD_waterSlab_d")
@@ -109,7 +109,7 @@ if __name__ == "__main__":
 
     dose_actor_water_slab_insert_d2w = sim.add_actor("DoseActor", "IDD_waterSlab_d2w")
     dose_actor_water_slab_insert_d2w.attached_to = water_slab_insert
-    dose_actor_water_slab_insert_d2w.score_in = "water"
+    dose_actor_water_slab_insert_d2w.score_in = "G4_WATER"
     dose_actors.append(dose_actor_water_slab_insert_d2w)
 
     dose_actor_entranceRegiont_d = sim.add_actor("DoseActor", "IDD_entranceRegion_d")
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         "DoseActor", "IDD_entranceRegion_d2w"
     )
     dose_actor_entranceRegiont_d2w.attached_to = entranceRegion
-    dose_actor_entranceRegiont_d2w.score_in = "water"
+    dose_actor_entranceRegiont_d2w.score_in = "G4_WATER"
     dose_actors.append(dose_actor_entranceRegiont_d2w)
 
     # set common properties

--- a/opengate/tests/src/test050_let_actor_letd_mt.py
+++ b/opengate/tests/src/test050_let_actor_letd_mt.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     LETActor_IDD_d2w.size = size
     LETActor_IDD_d2w.spacing = spacing
     LETActor_IDD_d2w.hit_type = "random"
-    LETActor_IDD_d2w.score_in = "water"
+    LETActor_IDD_d2w.score_in = "G4_WATER"
     LETActor_IDD_d2w.averaging_method = "dose_average"
 
     LET_primaries = "LETprimaries"

--- a/opengate/tests/src/test065_dose2water_from_edep2water_ct.py
+++ b/opengate/tests/src/test065_dose2water_from_edep2water_ct.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     dose_postprocess.spacing = [1 * mm, 1 * mm, 1 * mm]
     dose_postprocess.hit_type = "random"
     dose_postprocess.dose.active = True
-    dose_postprocess.score_in = "water"
+    dose_postprocess.score_in = "G4_WATER"
     # OPTION CURRENTLY NOT AVAILABLE
     # dose_postprocess.dose_calc_on_the_fly = (
     #     False  # calc dose as edep/mass after end of simulation
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     dose_in_step.spacing = [1 * mm, 1 * mm, 1 * mm]
     dose_in_step.hit_type = "random"
     dose_in_step.dose.active = True
-    dose_in_step.score_in = "water"
+    dose_in_step.score_in = "G4_WATER"
     # CURRENTLY DEACTIVATED OPTION
     # dose_in_step.dose_calc_on_the_fly = (
     #     False  # calculate dose directly in stepping action


### PR DESCRIPTION
- updated actors documentation
- removed user hook to change "water" to G4_WATER, which would make water a protected material ; I think we can request the users to write "G4_WATER" if they want G4_WATER and water if they want to use the water defined by themselves.