### PR TITLE
Update user_guide_reference_actors.rst

### DIFF
--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -102,8 +102,9 @@ Adding following lines
 
 .. code-block:: python
 
-   dose_act_obj.user_output.dose.active True
-   dose_act_obj.user_output.dose_uncertainty.active True
+   dose_act_obj.dose.active = True
+   dose_act_obj.dose_uncertainty.active = True
+   dose_act_obj.edep_uncertainty.active = True
 
 to the dose actor object will trigger an additional image scoring the dose. The uncertainty tag will additionally provide an uncertainty image for each of the scoring quantities. Set user_output.edep.active False to disable the edep computation and only return the dose.
 


### PR DESCRIPTION
Correct the typo that enables the export of the dose map and the uncertainty of the DoseActor.