### PR TITLE
Fix typo in user_guide_reference_simulation.rst

### DIFF
--- a/docs/source/user_guide/user_guide_reference_simulation.rst
+++ b/docs/source/user_guide/user_guide_reference_simulation.rst
@@ -8,7 +8,7 @@ Random Number Generator
 
 The random number generator used by Geant4 can be set with ``sim.random_engine = "MersenneTwister"``. The default one is "MixMaxRng" and not "MersenneTwister" because it is recommended by Geant4 for multithreading.
 
-You can set the seed of the random number generator with ``self.random_seed = 123456789`` to any number. Fixing the seed means that the results will be identical  if you run the same simulation twice, which can be useful for testing. There are some exceptions to that behavior, for example when using PyTorch-based GAN. By default, it is set to "auto", which means that the seed is randomly chosen.
+You can set the seed of the random number generator with ``sim.random_seed = 123456789`` to any number. Fixing the seed means that the results will be identical  if you run the same simulation twice, which can be useful for testing. There are some exceptions to that behavior, for example when using PyTorch-based GAN. By default, it is set to "auto", which means that the seed is randomly chosen.
 
 Run and timing
 --------------


### PR DESCRIPTION
Fix what I believe to be a really small typo.