### PR TITLE
Remove installation of setuptools for linux

### DIFF
--- a/.github/workflows/createWheelLinux.sh
+++ b/.github/workflows/createWheelLinux.sh
@@ -9,7 +9,7 @@ export CMAKE_PREFIX_PATH=/software/geant4/bin:/software/itk/bin/:${CMAKE_PREFIX_
 mkdir opengate_core/plugins
 cp -r /lib64/qt5/plugins/platforms opengate_core/plugins
 cp -r /lib64/qt5/plugins/imageformats opengate_core/plugins
-/opt/python/${PYTHONFOLDER}/bin/pip install wget colored setuptools
+/opt/python/${PYTHONFOLDER}/bin/pip install wget colored
 /opt/python/${PYTHONFOLDER}/bin/python setup.py sdist bdist_wheel
 auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux2014_x86_64"
 cp -r /software/wheelhouse /home/

--- a/.github/workflows/createWheelLinux_novis.sh
+++ b/.github/workflows/createWheelLinux_novis.sh
@@ -8,7 +8,7 @@ sed -i 's/name="opengate-core"/name="opengate-core-novis"/' setup.py
 export PATH=/software/cmake/cmake-3.18.2-Linux-x86_64/bin/:${PATH}
 source /software/geant4/bin/geant4make.sh
 export CMAKE_PREFIX_PATH=/software/geant4/bin:/software/itk/bin/:${CMAKE_PREFIX_PATH}
-/opt/python/${PYTHONFOLDER}/bin/pip install wget colored setuptools
+/opt/python/${PYTHONFOLDER}/bin/pip install wget colored
 /opt/python/${PYTHONFOLDER}/bin/python setup.py sdist bdist_wheel
 auditwheel repair /home/core/dist/*.whl -w /software/wheelhouse/ --plat "manylinux2014_x86_64"
 cp -r /software/wheelhouse /home/


### PR DESCRIPTION
setuptools was installed for python 3.12 but with PR#672 it's not necessary anymore