### PR TITLE
Reduce contention by allowing simultaneous read access to volume ID map

### DIFF
--- a/core/opengate_core/opengate_lib/GateUniqueVolumeIDManager.cpp
+++ b/core/opengate_core/opengate_lib/GateUniqueVolumeIDManager.cpp
@@ -7,8 +7,9 @@
 
 #include "GateUniqueVolumeIDManager.h"
 #include "GateHelpers.h"
+#include <shared_mutex>
 
-G4Mutex GetVolumeIDMutex = G4MUTEX_INITIALIZER;
+std::shared_mutex GetVolumeIDMutex;
 
 GateUniqueVolumeIDManager *GateUniqueVolumeIDManager::fInstance = nullptr;
 
@@ -22,26 +23,41 @@ GateUniqueVolumeIDManager::GateUniqueVolumeIDManager() = default;
 
 GateUniqueVolumeID::Pointer
 GateUniqueVolumeIDManager::GetVolumeID(const G4VTouchable *touchable) {
-  // This function is potentially called a large number of time (every hit)
-  // It worth it to make it faster if possible (unsure how).
+  // Since this function can be called from different threads,
+  // the map fToVolumeID must be protected against concurrent modifications.
+  // Concurrent reads of fToVolumeID are allowed, however.
 
-  // However, without the mutex, it sef fault sometimes in MT mode.
-  // Maybe due to some race condition around the shared_ptr. I don't know.
-  // With the mutex, no seg fault.
-  G4AutoLock mutex(&GetVolumeIDMutex);
+  // Since this function is potentially called a large number of times (every
+  // hit), locks need to be in place as briefly as possible.
 
   // https://geant4-forum.web.cern.ch/t/identification-of-unique-physical-volumes-with-ids/2568/3
-  // ID
-  auto name = touchable->GetVolume()->GetName();
-  auto id = GateUniqueVolumeID::ComputeArrayID(touchable);
-  // Search if this touchable has already been associated with a unique volume
-  // ID
-  if (fToVolumeID.count({name, id}) == 0) {
-    // It does not exist, so we create it.
-    auto uid = GateUniqueVolumeID::New(touchable);
-    fToVolumeID[{name, id}] = uid;
+  const auto name = touchable->GetVolume()->GetName();
+  const auto id = GateUniqueVolumeID::ComputeArrayID(touchable);
+
+  // Gain read access before checking if the touchable has already
+  // been associated with a unique volume ID.
+  std::shared_lock<std::shared_mutex> readLock(GetVolumeIDMutex);
+  auto it = fToVolumeID.find({name, id});
+  if (it != fToVolumeID.end()) {
+    return it->second;
+  } else {
+    // The volume ID does not exist yet, so we will create it.
+    readLock.unlock();
+    const auto uid = GateUniqueVolumeID::New(touchable);
+    // Before modifying the map, we must obtain exclusive write access.
+    std::unique_lock<std::shared_mutex> writeLock(GetVolumeIDMutex);
+    // There is a chance that another thread has already created the volume ID
+    // in the time interval between unlocking the read lock and locking the
+    // write lock, so we have to check again if the volume ID exists already.
+    it = fToVolumeID.find({name, id});
+    if (it != fToVolumeID.end()) {
+      return it->second;
+    } else {
+      // Add the new ID to the map and return it.
+      fToVolumeID[{name, id}] = uid;
+      return uid;
+    }
   }
-  return fToVolumeID.at({name, id});
 }
 
 std::vector<GateUniqueVolumeID::Pointer>


### PR DESCRIPTION
The method `GateUniqueVolumeIDManager::GetVolumeID` currently requires exclusive access for one thread at a time. But as long as the volume ID map is not modified, it is OK for threads to access it simultaneously. This PR implements a read-write lock to allow for concurrent read access, which can considerably speed up execution in case of multi-threading.