### PR TITLE
Add InitializeG4PreInitState step in Actors

### DIFF
--- a/core/opengate_core/opengate_lib/GateVActor.h
+++ b/core/opengate_core/opengate_lib/GateVActor.h
@@ -27,6 +27,9 @@ public:
 
   virtual void AddActions(std::set<std::string> &actions);
 
+  // Called at initialisation in late G4 PreInit state
+  virtual void InitializeG4PreInitState() {}
+
   // Called at initialisation
   virtual void InitializeCpp();
 

--- a/core/opengate_core/opengate_lib/pyGateVActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateVActor.cpp
@@ -79,6 +79,7 @@ void init_GateVActor(py::module &m) {
       //      .def_readonly("fActions", &GateVActor::fActions) // avoid wrapping
       //      this -> problems with pickle
       .def_readwrite("fFilters", &GateVActor::fFilters)
+      .def("InitializeG4PreInitState", &GateVActor::InitializeG4PreInitState)
       .def("InitializeCpp", &GateVActor::InitializeCpp)
       .def("InitializeUserInfo", &GateVActor::InitializeUserInfo)
       .def("AddActions", &GateVActor::AddActions)

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -591,6 +591,13 @@ class ActorEngine(EngineBase):
             actor.close()
         super().close()
 
+    def initialize_preinit(self):
+        for actor in self.actor_manager.sorted_actors:
+            global_log.debug(
+                f"Actor: initialize_preinit [{actor.type_name}] {actor.name}"
+            )
+            actor.InitializeG4PreInitState()
+
     def initialize(self):
         for actor in self.actor_manager.sorted_actors:
             global_log.debug(f"Actor: initialize [{actor.type_name}] {actor.name}")
@@ -1278,6 +1285,9 @@ class SimulationEngine(GateSingletonFatal):
         """
         Build the main geant4 objects and initialize them.
         """
+
+        # From this line, G4 is in G4State_PreInit state
+
         # get log
         log = global_log
 
@@ -1346,6 +1356,9 @@ class SimulationEngine(GateSingletonFatal):
             self.action_engine
         )  # G4 internally calls action_engine.Build()
 
+        # late-G4 PreInit state actor initialisation phase
+        self.actor_engine.initialize_preinit()
+
         # Important: The volumes are constructed
         # when the G4RunManager calls the Construct method of the VolumeEngine,
         # which happens in the InitializeGeometry() method of the
@@ -1359,6 +1372,8 @@ class SimulationEngine(GateSingletonFatal):
             self.g4_RunManager.InitializeWithoutFakeRun()
         else:
             self.g4_RunManager.Initialize()
+
+        # From this line, G4 is in G4State_Idle state
 
         log.info("Simulation: initialize PhysicsEngine after RunManager initialization")
         self.physics_engine.initialize_after_runmanager()


### PR DESCRIPTION
This commit adds the possibility for actors to execute code near the end of the Geant4 PreInit state, before entering in Idle, but after main simulation elements are initialised (physics, …).

This can be used for example to retrieve particle definitions at actor level.

C++ side: `GateVActor` exposes a new virtual function (`void InitializeG4PreInitState()`).
Python side: the `actor_engine` provides `initialize_preinit` called in `initialize` of `SimulationEngine` which calls the C++ side function.