### PR TITLE
GateInternalActions

### DIFF
--- a/core/opengate_core/opengate_core.cpp
+++ b/core/opengate_core/opengate_core.cpp
@@ -290,6 +290,8 @@ void init_GateWeightedEdepActor(py::module &);
 
 void init_GateActorManager(py::module &);
 
+void init_GateInternalActions(py::module &m);
+
 // Gate filters
 void init_GateVFilter(py::module &);
 
@@ -567,6 +569,7 @@ PYBIND11_MODULE(opengate_core, m) {
   init_GateVActor(m);
   init_GateWeightedEdepActor(m);
   init_GateActorManager(m);
+  init_GateInternalActions(m);
   init_GateVFilter(m);
   init_GateParticleFilter(m);
   init_GatePrimaryScatterFilter(m);

--- a/core/opengate_core/opengate_lib/GateInternalActions.cpp
+++ b/core/opengate_core/opengate_lib/GateInternalActions.cpp
@@ -1,0 +1,1 @@
+#include "GateInternalActions.h"

--- a/core/opengate_core/opengate_lib/GateInternalActions.h
+++ b/core/opengate_core/opengate_lib/GateInternalActions.h
@@ -1,0 +1,18 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#ifndef CORE_OPENGATE_LIB_GATEINTERNALACTIONS_H
+#define CORE_OPENGATE_LIB_GATEINTERNALACTIONS_H
+
+#include "GateVActor.h"
+
+class GateInternalActions : public GateVActor {
+public:
+  using GateVActor::GateVActor;
+};
+
+#endif

--- a/core/opengate_core/opengate_lib/pyGateInternalActions.cpp
+++ b/core/opengate_core/opengate_lib/pyGateInternalActions.cpp
@@ -1,0 +1,20 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "GateInternalActions.h"
+
+void init_GateInternalActions(py::module &m) {
+  py::class_<GateInternalActions,
+             std::unique_ptr<GateInternalActions, py::nodelete>, GateVActor>(
+      m, "GateInternalActions")
+      .def(py::init<py::dict &>());
+}

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -1,6 +1,7 @@
 from box import Box
 from functools import wraps
 
+import opengate_core as g4
 from ..definitions import __world_name__
 from ..exception import fatal, GateImplementationError
 from ..base import GateObject, process_cls
@@ -611,4 +612,27 @@ class ActorBase(GateObject):
         pass
 
 
+class InternalActions(ActorBase, g4.GateInternalActions):
+    """ """
+
+    def __init__(self, *args, **kwargs):
+        ActorBase.__init__(self, *args, **kwargs)
+        self.__initcpp__()
+
+    def __initcpp__(self):
+        g4.GateInternalActions.__init__(self, self.user_info)
+
+    def initialize(self):
+        ActorBase.initialize(self)
+        self.InitializeUserInfo(self.user_info)
+        self.InitializeCpp()
+
+    def StartSimulationAction(self):
+        g4.GateInternalActions.StartSimulationAction(self)
+
+    def EndSimulationAction(self):
+        g4.GateInternalActions.EndSimulationAction(self)
+
+
 process_cls(ActorBase)
+process_cls(InternalActions)

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -75,7 +75,7 @@ from .geometry.volumes import (
     VolumeTreeRoot,
 )
 from .actors.filters import get_filter_class, FilterBase, filter_classes
-from .actors.base import ActorBase
+from .actors.base import ActorBase, InternalActions
 
 from .actors.doseactors import (
     DoseActor,
@@ -369,6 +369,8 @@ class ActorManager(GateObject):
         # dictionary of actor objects. Do not fill manually. Use add_actor() method.
         self.actors = {}
 
+        self._add_internal_actions()
+
     def __str__(self):
         s = "The actor manager contains the following actors: \n"
         s += self.dump_actors()
@@ -473,6 +475,11 @@ class ActorManager(GateObject):
                 f"{self.dump_actor_types()}."
             )
         return cls(name=name, simulation=self.simulation)
+
+    def _add_internal_actions(self):
+        name = "_gate_internal_actions"
+        self.internal_actions = InternalActions(name=name, simulation=self.simulation)
+        self.add_actor(self.internal_actions, name)
 
 
 class PhysicsListManager(GateObject):


### PR DESCRIPTION
This PR adds a pseudo-actor, `GateInternalActions`, automatically added as `_gate_internal_actions`.
This currently does nothing but it will be used to implement Geant4-DNA chemistry, in order to trigger the chemistry stage in `NewStage`.

I make this mainly to check whether this way is accepted or not, and if so I can also include it with the (future) PR for chemistry and not have it merged here.