### PR TITLE
Set ionization potential

### DIFF
--- a/docs/source/user_guide/user_guide_advanced.rst
+++ b/docs/source/user_guide/user_guide_advanced.rst
@@ -188,15 +188,16 @@ This is a simplification of the true physical process.
 
 Material Ionisation Potential
 ===========================================
+The ionisation potential is the energy required to remove an electron to an atom or a molecule. By default, the ionization potential is calculated thanks to the Bragg’s additivity rule.
 Users can modify the `MeanExcitationEnergy` of a material, and therefore the material's ionisation potential, similarly to how described for the `MeanEnergyPerIonPair`.
-Note that changing this value for G4_WATER will not affect the simulation.
+**WARNING:** changing this value for G4_WATER will not affect the simulation, as the default value will be used.
 
 .. code-block:: python
 
     # Provide the location of GateMaterials.db to the volume manager.
     sim.volume_manager.add_material_database(path_to_gate_materials_db)
 
-    # Set the MeanEnergyPerIonPair of the material in the physics manager
+    # Set the MeanExcitationEnergy of the material in the physics manager
     # material_of_interest is the name of the material of interest, which should be defined in GateMaterials.db located at path_to_gate_materials_db
     sim.physics_manager.material_ionisation_potential[material_of_interest] =  75.0 * eV
 

--- a/docs/source/user_guide/user_guide_advanced.rst
+++ b/docs/source/user_guide/user_guide_advanced.rst
@@ -186,3 +186,18 @@ If the user desire to modify the FWHM of the APA deviation, it can be done with 
 **WARNING:** The implementation of APA for `back_to_back` sources is based on assuming that its deviation follows a 2D Gaussian distribution.
 This is a simplification of the true physical process.
 
+Material Ionisation Potential
+===========================================
+Users can modify the `MeanExcitationEnergy` of a material, and therefore the material's ionisation potential, similarly to how described for the `MeanEnergyPerIonPair`.
+Note that changing this value for G4_WATER will not affect the simulation.
+
+.. code-block:: python
+
+    # Provide the location of GateMaterials.db to the volume manager.
+    sim.volume_manager.add_material_database(path_to_gate_materials_db)
+
+    # Set the MeanEnergyPerIonPair of the material in the physics manager
+    # material_of_interest is the name of the material of interest, which should be defined in GateMaterials.db located at path_to_gate_materials_db
+    sim.physics_manager.material_ionisation_potential[material_of_interest] =  75.0 * eV
+
+

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -294,6 +294,7 @@ class PhysicsEngine(EngineBase):
         self.initialize_optical_material_properties()
         self.initialize_optical_surfaces()
         self.initialize_ionisation_options()
+        self.initialize_users_ionisation_potentials()
 
     def initialize_parallel_world_physics(self):
         for (
@@ -464,6 +465,20 @@ class PhysicsEngine(EngineBase):
             )
             ionisation = mat.GetIonisation()
             ionisation.SetMeanEnergyPerIonPair(val)
+
+    @requires_fatal("physics_manager")
+    def initialize_users_ionisation_potentials(self):
+        for (
+            material_name,
+            val,
+        ) in self.physics_manager.material_ionization_potential.items():
+            mat = (
+                self.simulation_engine.simulation.volume_manager.find_or_build_material(
+                    material_name
+                )
+            )
+            ionisation = mat.GetIonisation()
+            ionisation.SetMeanExcitationEnergy(val)
 
 
 class ActionEngine(g4.G4VUserActionInitialization, EngineBase):

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -471,7 +471,7 @@ class PhysicsEngine(EngineBase):
         for (
             material_name,
             val,
-        ) in self.physics_manager.material_ionization_potential.items():
+        ) in self.physics_manager.material_ionisation_potential.items():
             mat = (
                 self.simulation_engine.simulation.volume_manager.find_or_build_material(
                     material_name

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -686,6 +686,12 @@ class PhysicsManager(GateObject):
                 "Mostly used for using acolinearity during annihilation in some materials"
             },
         ),
+        "material_ionization_potential": (
+            Box(),
+            {
+                "doc": "Dict of material_name:energy_value, such that: sim.physics_manager.material_ionization_potential['IEC_PLASTIC'] = 5.0 * eV. "
+            },
+        ),
         # "processes_to_bias": (
         #     Box(
         #         [

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -686,10 +686,10 @@ class PhysicsManager(GateObject):
                 "Mostly used for using acolinearity during annihilation in some materials"
             },
         ),
-        "material_ionization_potential": (
+        "material_ionisation_potential": (
             Box(),
             {
-                "doc": "Dict of material_name:energy_value, such that: sim.physics_manager.material_ionization_potential['IEC_PLASTIC'] = 5.0 * eV. "
+                "doc": "Dict of material_name:energy_value, such that: sim.physics_manager.material_ionisation_potential['IEC_PLASTIC'] = 5.0 * eV. "
             },
         ),
         # "processes_to_bias": (

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -5,12 +5,14 @@ Created on Wed Apr  2 09:48:30 2025
 
 @author: fava
 """
-
-
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.spatial.transform import Rotation
 import opengate as gate
 from opengate.utility import g4_units
 import opengate.tests.utility as utility
 import opengate_core as g4
+
 
 if __name__ == "__main__":
     # units
@@ -34,10 +36,10 @@ if __name__ == "__main__":
     ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
     print(f"Default ionisation potential of {test_material}: {ionisation} eV")
 
-    # set to physics manager
-    sim.physics_manager.material_ionization_potential = materials_Ival_dict
+    sim.physics_manager.material_ionisation_potential = materials_Ival_dict
 
-    sim.run()
+    # run simulation with new value
+    sim.run(True)
 
     # dump ionisation value after modification
     mat = sim.volume_manager.find_or_build_material(test_material)

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -14,28 +14,98 @@ import opengate.tests.utility as utility
 import opengate_core as g4
 
 
+def simuation_IDD():
+    paths = utility.get_default_test_paths(__file__, "gate_test044_pbs")
+
+    # units
+    eV = g4_units.eV
+    MeV = g4_units.MeV
+    cm = g4_units.cm
+    mm = g4_units.mm
+
+    # create simulation object
+    sim = gate.Simulation()
+    sim.volume_manager.add_material_database(paths.gate_data / "HFMaterials2014.db")
+
+    # waterbox
+    phantom = sim.add_volume("Box", "phantom")
+    phantom.size = [10 * cm, 10 * cm, 10 * cm]
+    phantom.translation = [-5 * cm, 0, 0]
+    phantom.material = "G4_WATER"
+    phantom.color = [0, 0, 1, 1]
+
+    test_material_name = "Water"
+    phantom_off = sim.add_volume("Box", "phantom_off")
+    phantom_off.mother = phantom.name
+    phantom_off.size = [100 * mm, 60 * mm, 60 * mm]
+    phantom_off.translation = [0 * mm, 0 * mm, 0 * mm]
+    phantom_off.material = test_material_name
+    phantom_off.color = [0, 0, 1, 1]
+
+    # physics
+    sim.physics_manager.physics_list_name = "QGSP_BIC_EMZ"
+
+    # default source for tests
+    source = sim.add_source("GenericSource", "mysource")
+    source.energy.mono = 1424 * MeV
+    source.particle = "ion 6 12"
+
+    source.position.type = "disc"
+    source.position.rotation = Rotation.from_euler("y", 90, degrees=True).as_matrix()
+    source.position.radius = 4 * mm
+    source.position.translation = [0, 0, 0]
+    source.direction.type = "momentum"
+    source.direction.momentum = [-1, 0, 0]
+    # print(dir(source.energy))
+    source.n = 1e3
+    # source.activity = 100 * kBq
+
+    size = [500, 1, 1]
+    spacing = [0.2 * mm, 60.0 * mm, 60.0 * mm]
+
+    doseActorName_IDD_d = "IDD"
+    doseIDD = sim.add_actor("DoseActor", doseActorName_IDD_d)
+    doseIDD.output_filename = paths.output / ("test087-" + doseActorName_IDD_d + ".mhd")
+    #    print(f'actor: {paths.output / ("test087-" + doseActorName_IDD_d + ".mhd")}')
+    doseIDD.attached_to = phantom_off.name
+    doseIDD.size = size
+    doseIDD.spacing = spacing
+    doseIDD.hit_type = "random"
+    doseIDD.dose.active = True
+
+    return sim, doseIDD
+
+
 if __name__ == "__main__":
     # units
     eV = g4_units.eV
     cm = g4_units.cm
 
-    # create simulation object
-    sim = gate.Simulation()
-
     # overrides for material ionisation potential
-    test_material = "G4_WATER"
-    materials_Ival_dict = {test_material: 75 * eV}
+    test_material = "Water"
+    materials_Ival_dict = {test_material: 60 * eV}
 
-    # add a waterbox
-    wb = sim.add_volume("Box", "box")
-    wb.size = [50 * cm, 50 * cm, 50 * cm]
-    wb.material = test_material
+    sim, dose = simuation_IDD()
 
     # dump ionisation value before modification
     mat = sim.volume_manager.find_or_build_material(test_material)
     ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
     print(f"Default ionisation potential of {test_material}: {ionisation} eV")
 
+    # run simulation with default value for material
+    sim.run(True)
+
+    # get idd
+    idd_pre = np.flip(np.asarray(dose.dose.image), axis=2)
+    x1, d1_pre = utility.get_1D_profile(
+        idd_pre, np.flip(dose.size), dose.spacing, axis="x"
+    )
+    r80_pre, _ = utility.getRange(x1, d1_pre)
+    plt.plot(x1, d1_pre)
+    print(f"Range in water: {r80_pre}")
+
+    # run simulation again, but with modified ionisation potential
+    sim, dose = simuation_IDD()
     sim.physics_manager.material_ionisation_potential = materials_Ival_dict
 
     # run simulation with new value
@@ -46,5 +116,14 @@ if __name__ == "__main__":
     ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
     print(f"New ionisation potential of {test_material}: {ionisation} eV")
 
-    ok = ionisation == materials_Ival_dict[test_material]
+    # get idd
+    idd_after = np.flip(np.asarray(dose.dose.image), axis=2)
+    x1, d1_after = utility.get_1D_profile(
+        idd_after, np.flip(dose.size), dose.spacing, axis="x"
+    )
+    r80_after, _ = utility.getRange(x1, d1_after)
+    plt.plot(x1, d1_after)
+    print(f"Range in water: {r80_after}")
+
+    ok = (r80_pre - r80_after) > dose.spacing[0]
     utility.test_ok(ok)

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Apr  2 09:48:30 2025
+
+@author: fava
+"""
+
+
+import opengate as gate
+from opengate.utility import g4_units
+import opengate.tests.utility as utility
+import opengate_core as g4
+
+if __name__ == "__main__":
+    # units
+    eV = g4_units.eV
+    cm = g4_units.cm
+
+    # create simulation object
+    sim = gate.Simulation()
+
+    # overrides for material ionisation potential
+    test_material = "G4_WATER"
+    materials_Ival_dict = {test_material: 75 * eV}
+
+    # add a waterbox
+    wb = sim.add_volume("Box", "box")
+    wb.size = [50 * cm, 50 * cm, 50 * cm]
+    wb.material = test_material
+
+    # dump ionisation value before modification
+    mat = sim.volume_manager.find_or_build_material(test_material)
+    ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
+    print(f"Default ionisation potential of {test_material}: {ionisation} eV")
+
+    # set to physics manager
+    sim.physics_manager.material_ionization_potential = materials_Ival_dict
+
+    sim.run()
+
+    # dump ionisation value after modification
+    mat = sim.volume_manager.find_or_build_material(test_material)
+    ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
+    print(f"New ionisation potential of {test_material}: {ionisation} eV")
+
+    ok = ionisation == materials_Ival_dict[test_material]
+    utility.test_ok(ok)

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -112,7 +112,6 @@ if __name__ == "__main__":
     sim.run(True)
 
     # dump ionisation value after modification
-    mat = sim.volume_manager.find_or_build_material(test_material)
     ionisation = mat.GetIonisation().GetMeanExcitationEnergy()
     print(f"New ionisation potential of {test_material}: {ionisation} eV")
 

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -25,7 +25,7 @@ def simuation_IDD(test_material):
 
     # create simulation object
     sim = gate.Simulation()
-    sim.number_of_threads = 4
+    # sim.number_of_threads = 4
     sim.volume_manager.add_material_database(paths.gate_data / "HFMaterials2014.db")
 
     # waterbox

--- a/opengate/tests/src/test089_set_ionisation_potential.py
+++ b/opengate/tests/src/test089_set_ionisation_potential.py
@@ -14,7 +14,7 @@ import opengate.tests.utility as utility
 import opengate_core as g4
 
 
-def simuation_IDD():
+def simuation_IDD(test_material):
     paths = utility.get_default_test_paths(__file__, "gate_test044_pbs")
 
     # units
@@ -25,6 +25,7 @@ def simuation_IDD():
 
     # create simulation object
     sim = gate.Simulation()
+    sim.number_of_threads = 4
     sim.volume_manager.add_material_database(paths.gate_data / "HFMaterials2014.db")
 
     # waterbox
@@ -34,12 +35,11 @@ def simuation_IDD():
     phantom.material = "G4_WATER"
     phantom.color = [0, 0, 1, 1]
 
-    test_material_name = "Water"
     phantom_off = sim.add_volume("Box", "phantom_off")
     phantom_off.mother = phantom.name
     phantom_off.size = [100 * mm, 60 * mm, 60 * mm]
     phantom_off.translation = [0 * mm, 0 * mm, 0 * mm]
-    phantom_off.material = test_material_name
+    phantom_off.material = test_material
     phantom_off.color = [0, 0, 1, 1]
 
     # physics
@@ -83,9 +83,9 @@ if __name__ == "__main__":
 
     # overrides for material ionisation potential
     test_material = "Water"
-    materials_Ival_dict = {test_material: 60 * eV}
+    materials_Ival_dict = {test_material: 30 * eV}
 
-    sim, dose = simuation_IDD()
+    sim, dose = simuation_IDD(test_material)
 
     # dump ionisation value before modification
     mat = sim.volume_manager.find_or_build_material(test_material)
@@ -102,10 +102,10 @@ if __name__ == "__main__":
     )
     r80_pre, _ = utility.getRange(x1, d1_pre)
     plt.plot(x1, d1_pre)
-    print(f"Range in water: {r80_pre}")
+    print(f"Range in water: {r80_pre} mm")
 
     # run simulation again, but with modified ionisation potential
-    sim, dose = simuation_IDD()
+    sim, dose = simuation_IDD(test_material)
     sim.physics_manager.material_ionisation_potential = materials_Ival_dict
 
     # run simulation with new value
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     )
     r80_after, _ = utility.getRange(x1, d1_after)
     plt.plot(x1, d1_after)
-    print(f"Range in water: {r80_after}")
+    print(f"Range in water: {r80_after} mm")
 
     ok = (r80_pre - r80_after) > dose.spacing[0]
     utility.test_ok(ok)


### PR DESCRIPTION
Set the ionization potential of a material via sim.physics_manager.material_ionisation_potential. The user can specify a dictionary with key: material and value: mean excitation energy value to set.
**WARNING:** this doesn't change the value for G4_WATER!