### PR TITLE
I create a clickable link to the Material section

### DIFF
--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section :ref:`user_guide_materials`__
+   e.g. ``G4_WATER``. See section :ref:`user_guide_materials`
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section See section :ref:`user_guide_materials`
+   e.g. ``G4_WATER``. See section See section :ref:`Materials <materials_section>`
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section See section :ref:`Materials <materials_section>`
+   e.g. ``G4_WATER``. See section :ref:`Materials <materials_section>`
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section See section :ref:`Materials <user_guide_materials>`
+   e.g. ``G4_WATER``. See section See section :ref:`user_guide_materials`
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section `Materials <#materials>`__
+   e.g. ``G4_WATER``. See section :ref:`user_guide_materials`__
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -21,7 +21,7 @@ Common parameters are:
    to the reference frame of the mother volume and therefore moves with
    the mother volume.
 -  ``material``: the name of the material that composes the volume,
-   e.g. ``G4_WATER``. See section :ref:`user_guide_materials`
+   e.g. ``G4_WATER``. See section See section :ref:`Materials <user_guide_materials>`
 -  ``translation``: list of 3 numerical values,
    e.g. ``[0, 2*cm, 3*mm]``. It defines the translation of the volume
    with respect to the reference frame of the mother volume. Note: the

--- a/docs/source/user_guide/user_guide_volumes.rst
+++ b/docs/source/user_guide/user_guide_volumes.rst
@@ -179,6 +179,7 @@ Note that the above properties are read-only - you cannot set their
 values.
 
 .. _user_guide_materials:
+
 Materials
 ---------
 

--- a/docs/source/user_guide/user_guide_volumes.rst
+++ b/docs/source/user_guide/user_guide_volumes.rst
@@ -178,7 +178,7 @@ along x, y, z
 Note that the above properties are read-only - you cannot set their
 values.
 
-.. _user_guide_materials:
+.. _materials_section:
 
 Materials
 ---------

--- a/docs/source/user_guide/user_guide_volumes.rst
+++ b/docs/source/user_guide/user_guide_volumes.rst
@@ -178,6 +178,7 @@ along x, y, z
 Note that the above properties are read-only - you cannot set their
 values.
 
+.. _user_guide_materials:
 Materials
 ---------
 


### PR DESCRIPTION
There was a clickable link that led nowhere, so I created a link to the 'Material' section of 'user_guide_volume'.