### PR TITLE
PR for issue #719

### DIFF
--- a/core/opengate_core/opengate_lib/GateDoseActor.cpp
+++ b/core/opengate_core/opengate_lib/GateDoseActor.cpp
@@ -246,7 +246,19 @@ void GateDoseActor::SteppingAction(G4Step *step) {
 
 void GateDoseActor::EndOfEventAction(const G4Event *event) {
 
-  // flush thread local data into global image (postponed for now)
+  // flush thread local data into global image
+  // reset local data to zero
+  int N_voxels = size_edep[0] * size_edep[1] * size_edep[2];
+  if (fEdepSquaredFlag) {
+    GateDoseActor::FlushSquaredValue(fThreadLocalDataEdep.Get(),
+                                     cpp_edep_squared_image);
+    PrepareLocalDataForRun(fThreadLocalDataEdep.Get(), N_voxels);
+  }
+  if (fDoseSquaredFlag) {
+    GateDoseActor::FlushSquaredValue(fThreadLocalDataDose.Get(),
+                                     cpp_dose_squared_image);
+    PrepareLocalDataForRun(fThreadLocalDataDose.Get(), N_voxels);
+  }
 
   // if the user didn't set uncertainty goal, do nothing
   if (fUncertaintyGoal == 0) {


### PR DESCRIPTION
- Call FlushSquaredValue() explicitly at the beginning of EndOfEventAction(). In fact, there is an implicit flushing implemented in ScoreSquaredValue() triggered in SteppingAction that flushes deposit in a voxel whenever a deposit by a new event is made. Consequently, the deposit made by the last event in any voxel remains unflushed and we must trigger the flushing explicitly. 
- At the same time, once the value is flushed, we must make sure that the voxel in the thread local image is reset to zero. So at the end of FlushSquaredValue(), we must iterate over the image and reset all pixels to zero.  
