### PR TITLE
Proc in vol attribute

### DIFF
--- a/core/opengate_core/opengate_core.cpp
+++ b/core/opengate_core/opengate_core.cpp
@@ -374,6 +374,8 @@ void init_GateDigitizerSpatialBlurringActor(py::module &m);
 
 void init_GateDigitizerEnergyWindowsActor(py::module &m);
 
+void init_GateDigiAttributeProcessDefinedStepInVolumeActor(py::module &m);
+
 void init_GateDigitizerProjectionActor(py::module &m);
 
 void init_GateDigiAttributeManager(py::module &m);
@@ -623,6 +625,7 @@ PYBIND11_MODULE(opengate_core, m) {
   init_GateDigitizerSpatialBlurringActor(m);
   init_GateDigitizerEnergyWindowsActor(m);
   init_GateDigitizerProjectionActor(m);
+  init_GateDigiAttributeProcessDefinedStepInVolumeActor(m);
 
   init_GateARFActor(m);
   init_GateARFTrainingDatasetActor(m);

--- a/core/opengate_core/opengate_lib/GateDoseActor.cpp
+++ b/core/opengate_core/opengate_lib/GateDoseActor.cpp
@@ -266,7 +266,7 @@ void GateDoseActor::EndOfEventAction(const G4Event *event) {
         // fStopRunFlag = true;
         fSourceManager->SetRunTerminationFlag(true);
       } else {
-        // estimate Nevents at which next check should occour
+        // estimate Nevents at which next check should occur
         NbEventsNextCheck = (UncCurrent / fUncertaintyGoal) *
                             (UncCurrent / fUncertaintyGoal) * NbOfEvent *
                             Overshoot;
@@ -370,7 +370,7 @@ void GateDoseActor::ScoreSquaredValue(threadLocalT &data,
     auto v = data.squared_worker_flatimg[index_flat];
     {
       G4AutoLock mutex(&SetPixelMutex);
-      ImageAddValue<Image3DType>(cpp_image, index, v * v);
+      ImageAddValue<Image3DType>(cpp_image, index, v * v); // implicit flush
     }
     // new temp value
     data.squared_worker_flatimg[index_flat] = value;

--- a/core/opengate_core/opengate_lib/GateSourceManager.cpp
+++ b/core/opengate_core/opengate_lib/GateSourceManager.cpp
@@ -247,7 +247,8 @@ void GateSourceManager::PrepareNextSource() const {
       l.fNextSimulationTime = t;
     }
   }
-  // If no next time in the current interval, active source is NULL
+  // If no next time in the current interval,
+  // the next active source is nullptr
 }
 
 void GateSourceManager::CheckForNextRun() const {
@@ -258,7 +259,7 @@ void GateSourceManager::CheckForNextRun() const {
     l.fNextRunId++;
     if (l.fNextRunId >= fSimulationTimes.size()) {
       // Sometimes, the source must clean some data in its own thread, not by
-      // the master thread (for example with a G4SingleParticleSource object)
+      // the master thread (for example, with a G4SingleParticleSource object)
       // The CleanThread method is used for that.
       for (auto *source : fSources) {
         source->CleanWorkerThread();

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeManager.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeManager.cpp
@@ -6,6 +6,7 @@
    -------------------------------------------------- */
 
 #include "GateDigiAttributeManager.h"
+#include "GateDigiAttributeProcessDefinedStepInVolume.h"
 #include "GateTDigiAttribute.h"
 
 GateDigiAttributeManager *GateDigiAttributeManager::fInstance = nullptr;
@@ -21,7 +22,7 @@ GateDigiAttributeManager::GateDigiAttributeManager() {
 }
 
 GateVDigiAttribute *
-GateDigiAttributeManager::GetDigiAttribute(std::string name) {
+GateDigiAttributeManager::GetDigiAttribute(const std::string &name) {
   if (fAvailableDigiAttributes.find(name) == fAvailableDigiAttributes.end()) {
     std::ostringstream oss;
     oss << "Error the attribute named '" << name << "' does not exists. Abort.";
@@ -89,8 +90,11 @@ void GateDigiAttributeManager::DefineDigiAttribute(
 }
 
 GateVDigiAttribute *GateDigiAttributeManager::CopyDigiAttribute(
-    GateVDigiAttribute *att) { // FIXME to move elsewhere !!!!!
+    GateVDigiAttribute *att) { // FIXME to move elsewhere
   GateVDigiAttribute *a = nullptr;
+
+  // FIXME do a real copy, including the inner members !
+
   if (att->GetDigiAttributeType() == 'D') {
     a = new GateTDigiAttribute<double>(att->GetDigiAttributeName());
   }

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeManager.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeManager.h
@@ -9,7 +9,6 @@
 #define GateDigiAttributeManager_h
 
 #include "../GateHelpers.h"
-#include "GateDigiCollection.h"
 #include "GateVDigiAttribute.h"
 #include <pybind11/stl.h>
 
@@ -28,7 +27,7 @@ class GateDigiAttributeManager {
 public:
   static GateDigiAttributeManager *GetInstance();
 
-  GateVDigiAttribute *GetDigiAttribute(std::string name);
+  GateVDigiAttribute *GetDigiAttribute(const std::string &name);
 
   void
   DefineDigiAttribute(std::string name, char type,

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolume.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolume.cpp
@@ -1,0 +1,41 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include "GateDigiAttributeProcessDefinedStepInVolume.h"
+#include "../GateActorManager.h"
+#include "../GateHelpers.h"
+#include "../GateUniqueVolumeID.h"
+#include "GateDigiAttributeManager.h"
+#include "GateTDigiAttribute.h"
+#include <G4RunManager.hh>
+
+GateDigiAttributeProcessDefinedStepInVolume::
+    GateDigiAttributeProcessDefinedStepInVolume(
+        const std::string &att_name,
+        const GateDigiAttributeProcessDefinedStepInVolumeActor *actor)
+    : GateTDigiAttribute<int>(att_name) {
+  // create the lambda function that will be called each step
+  auto l = [=](GateVDigiAttribute *att, G4Step *step) {
+    // we CANNOT use att here (it is a different copy without fActor)
+    const auto i = this->GetProcessDefinedStepInVolume(step);
+    att->FillIValue(i);
+  };
+
+  // define a new attribute
+  auto *m = GateDigiAttributeManager::GetInstance();
+  m->DefineDigiAttribute(att_name, 'I', l);
+
+  // Set the linked actor
+  fActor = actor;
+}
+
+int GateDigiAttributeProcessDefinedStepInVolume::GetProcessDefinedStepInVolume(
+    const G4Step *step) const {
+  // retrieve the nb stored in the att
+  const int n = fActor->GetNumberOfInteractions();
+  return n;
+}

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolume.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolume.h
@@ -1,0 +1,29 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#ifndef GateDigiAttributeProcessDefinedStepInVolume_h
+#define GateDigiAttributeProcessDefinedStepInVolume_h
+
+#include "../GateHelpers.h"
+#include "GateTDigiAttribute.h"
+#include <pybind11/stl.h>
+
+#include "GateDigiAttributeProcessDefinedStepInVolumeActor.h"
+
+class GateDigiAttributeProcessDefinedStepInVolume
+    : public GateTDigiAttribute<int> {
+public:
+  GateDigiAttributeProcessDefinedStepInVolume(
+      const std::string &att_name,
+      const GateDigiAttributeProcessDefinedStepInVolumeActor *actor);
+
+  int GetProcessDefinedStepInVolume(const G4Step *step) const;
+
+  const GateDigiAttributeProcessDefinedStepInVolumeActor *fActor;
+};
+
+#endif // GateDigiAttributeProcessDefinedStepInVolume_h

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolumeActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolumeActor.cpp
@@ -1,0 +1,48 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include "GateDigiAttributeProcessDefinedStepInVolumeActor.h"
+#include "../GateHelpersDict.h"
+#include "GateDigiAttributeProcessDefinedStepInVolume.h"
+#include <G4RunManager.hh>
+#include <G4VProcess.hh>
+
+GateDigiAttributeProcessDefinedStepInVolumeActor::
+    GateDigiAttributeProcessDefinedStepInVolumeActor(py::dict &user_info)
+    : GateVActor(user_info, false) {
+  fActions.insert("BeginOfEventAction");
+  fActions.insert("SteppingAction");
+}
+
+void GateDigiAttributeProcessDefinedStepInVolumeActor::InitializeUserInfo(
+    py::dict &user_info) {
+  GateVActor::InitializeUserInfo(user_info);
+  fProcessName = DictGetStr(user_info, "process_name");
+  fAttribute = new GateDigiAttributeProcessDefinedStepInVolume(GetName(), this);
+}
+
+void GateDigiAttributeProcessDefinedStepInVolumeActor::BeginOfEventAction(
+    const G4Event *event) {
+  fNumberOfInteractions = 0;
+}
+
+int GateDigiAttributeProcessDefinedStepInVolumeActor::GetNumberOfInteractions()
+    const {
+  return fNumberOfInteractions;
+}
+
+void GateDigiAttributeProcessDefinedStepInVolumeActor::SteppingAction(
+    G4Step *step) {
+  // check the process-defined step
+  const auto *p = step->GetPreStepPoint()->GetProcessDefinedStep();
+  if (p == nullptr)
+    return;
+  // Store the interaction
+  if (p->GetProcessName() == fProcessName) {
+    fNumberOfInteractions++;
+  }
+}

--- a/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolumeActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeProcessDefinedStepInVolumeActor.h
@@ -1,0 +1,33 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#ifndef GateDigiAttributeProcessDefinedStepInVolumeActor_h
+#define GateDigiAttributeProcessDefinedStepInVolumeActor_h
+
+#include "../GateHelpers.h"
+#include <pybind11/stl.h>
+
+class GateDigiAttributeProcessDefinedStepInVolume;
+
+class GateDigiAttributeProcessDefinedStepInVolumeActor : public GateVActor {
+public:
+  GateDigiAttributeProcessDefinedStepInVolumeActor(py::dict &user_info);
+
+  void InitializeUserInfo(py::dict &user_info) override;
+
+  void SteppingAction(G4Step *step) override;
+
+  void BeginOfEventAction(const G4Event *event) override;
+
+  int GetNumberOfInteractions() const;
+
+  std::string fProcessName;
+  int fNumberOfInteractions;
+  GateDigiAttributeProcessDefinedStepInVolume *fAttribute;
+};
+
+#endif // GateDigiAttributeProcessDefinedStepInVolumeActor_h

--- a/core/opengate_core/opengate_lib/digitizer/pyGateDigiAttributeProcessDefinedStepInVolumeActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/pyGateDigiAttributeProcessDefinedStepInVolumeActor.cpp
@@ -1,0 +1,22 @@
+/* --------------------------------------------------
+   Copyright (C): OpenGATE Collaboration
+   This software is distributed under the terms
+   of the GNU Lesser General  Public Licence (LGPL)
+   See LICENSE.md for further details
+   -------------------------------------------------- */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "GateDigiAttributeProcessDefinedStepInVolumeActor.h"
+
+void init_GateDigiAttributeProcessDefinedStepInVolumeActor(py::module &m) {
+
+  py::class_<GateDigiAttributeProcessDefinedStepInVolumeActor,
+             std::unique_ptr<GateDigiAttributeProcessDefinedStepInVolumeActor,
+                             py::nodelete>,
+             GateVActor>(m, "GateDigiAttributeProcessDefinedStepInVolumeActor")
+      .def(py::init<py::dict &>());
+}

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -1150,8 +1150,9 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
         "steps_to_store": (
             "entering",
             {
-                "doc": "Define when to store the hits. ",
-                "allowed_values": ["entering", "exiting", "first", "all"],
+                "doc": "Define when to store the hits, can be 'entering', 'exiting', 'first' or 'all'. "
+                "Or several values separated by a space. ",
+                # "allowed_values": ["entering", "exiting", "first", "all"], # can be multiple
             },
         ),
     }

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1,10 +1,8 @@
-import sys
 import copy
 from typing import Optional, List, Union
 from box import Box
 from anytree import RenderTree, LoopError
 import shutil
-import os
 import weakref
 from pathlib import Path
 import io
@@ -115,6 +113,7 @@ from .actors.digitizers import (
     DigitizerEnergyWindowsActor,
     DigitizerHitsCollectionActor,
     PhaseSpaceActor,
+    DigiAttributeProcessDefinedStepInVolumeActor,
 )
 
 particle_names_Gate_to_G4 = {
@@ -154,6 +153,7 @@ actor_types = {
     "DigitizerProjectionActor": DigitizerProjectionActor,
     "DigitizerEnergyWindowsActor": DigitizerEnergyWindowsActor,
     "DigitizerHitsCollectionActor": DigitizerHitsCollectionActor,
+    "DigiAttributeProcessDefinedStepInVolumeActor": DigiAttributeProcessDefinedStepInVolumeActor,
     # biasing
     "BremsstrahlungSplittingActor": BremsstrahlungSplittingActor,
     "GammaFreeFlightActor": GammaFreeFlightActor,

--- a/opengate/tests/src/test093_proc_in_vol_attribute.py
+++ b/opengate/tests/src/test093_proc_in_vol_attribute.py
@@ -1,14 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from opengate.tests.utility import (
-    get_default_test_paths,
-    test_ok,
-    print_test,
-    compare_root3,
-)
-from opengate.utility import g4_units
-from opengate.logger import INFO, DEBUG, RUN, NONE
+from opengate.tests.utility import *
 from opengate.managers import Simulation
 from opengate.actors.digitizers import *
 
@@ -27,6 +20,7 @@ if __name__ == "__main__":
     sim.visu = False
     sim.visu_type = "qt"
     sim.output_dir = paths.output
+    sim.random_seed = 32145987
 
     # add a volume
     waterbox1 = sim.add_volume("Box", "Waterbox1")
@@ -84,10 +78,12 @@ if __name__ == "__main__":
     ]
 
     # not possible:
+    is_ok = True
     try:
         att3.volume_name = "toto"
         att3.process_name = "toto"
-        fatal(f"volume_name and process_name cannot be changed")
+        print(f"volume_name and process_name cannot be changed")
+        is_ok = False
     except Exception as e:
         print("OK, cannot change the volume_name")
 
@@ -104,17 +100,20 @@ if __name__ == "__main__":
     print(phsp.attributes)
     keys = [att1.name, att2.name, att3.name, att4.name]
     n = len(keys)
-    is_ok = compare_root3(
-        ref_root,
-        test_root,
-        "PhaseSpace",
-        "PhaseSpace",
-        keys1=keys,
-        keys2=keys,
-        tols=[0.2, 0.2, 0.1, 0.1] * n,
-        scalings1=[1] * n,
-        scalings2=[1] * n,
-        img=paths.output / "phsp.png",
+    is_ok = (
+        compare_root3(
+            ref_root,
+            test_root,
+            "PhaseSpace",
+            "PhaseSpace",
+            keys1=keys,
+            keys2=keys,
+            tols=[0.05, 0.05, 0.05, 0.05],
+            scalings1=[1] * n,
+            scalings2=[1] * n,
+            img=paths.output / "phsp.png",
+        )
+        and is_ok
     )
 
     test_ok(is_ok)

--- a/opengate/tests/src/test093_proc_in_vol_attribute.py
+++ b/opengate/tests/src/test093_proc_in_vol_attribute.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from opengate.tests.utility import get_default_test_paths, test_ok, print_test
+from opengate.utility import g4_units
+from opengate.logger import INFO, DEBUG, RUN, NONE
+from opengate.managers import Simulation
+
+
+if __name__ == "__main__":
+    paths = get_default_test_paths(__file__, None, "test093")
+
+    # units
+    m = g4_units.m
+    mm = g4_units.mm
+    cm = g4_units.cm
+    keV = g4_units.keV
+
+    # simulation
+    sim = Simulation()
+    sim.progress_bar = True
+    sim.visu = True
+    sim.visu_type = "qt"
+    sim.output_dir = paths.output
+
+    # add a volume
+    waterbox1 = sim.add_volume("Box", "Waterbox1")
+    waterbox1.size = [20 * cm, 20 * cm, 10 * cm]
+    waterbox1.translation = [0 * cm, 0 * cm, 0 * cm]
+    waterbox1.material = "G4_WATER"
+
+    # add a volume
+    waterbox2 = sim.add_volume("Box", "Waterbox2")
+    waterbox2.size = [20 * cm, 20 * cm, 10 * cm]
+    waterbox2.translation = [0 * cm, 0 * cm, -10 * cm]
+    waterbox2.material = "G4_WATER"
+
+    # add a "detector"
+    detector = sim.add_volume("Box", "detector")
+    detector.size = [50 * cm, 50 * cm, 1 * cm]
+    detector.translation = [0 * cm, 0 * cm, 20 * cm]
+    detector.material = "G4_LEAD_OXIDE"
+
+    # source
+    source = sim.add_source("GenericSource", "Default")
+    source.particle = "gamma"
+    source.energy.mono = 100 * keV
+    source.position.type = "sphere"
+    source.position.radius = 20 * mm
+    source.position.translation = [0 * cm, 0 * cm, -30 * cm]
+    source.direction.type = "focused"
+    source.direction.focus_point = [0 * cm, 0 * cm, -25 * cm]
+    source.direction.momentum = [0, 0, -1]
+    source.n = 2000
+
+    # add a stat actor
+    stats = sim.add_actor("SimulationStatisticsActor", "Stats")
+    stats.track_types_flag = True
+
+    # phsp
+    phsp = sim.add_actor("PhaseSpaceActor", "PhaseSpace")
+    phsp.attached_to = detector
+
+    phsp.attributes = ["KineticEnergy", "PrePosition"]
+    # at1 = Attribute("ProcessDefinedStep", "Compton", waterbox.name)
+    # at2 = Attribute("ProcessDefinedStep", "Rayley", waterbox.name)
+    # at3 = Attribute("ProcessDefinedStep", "Rayley", waterbox.name)
+    # phsp.attributes = ["KineticEnergy", "PrePosition", at1, at2, at3]
+
+    phsp.output_filename = "phsp.root"
+    phsp.steps_to_store = "entering"
+
+    # hits collection
+
+    # go
+    sim.run()
+    print(stats)
+
+    is_ok = False
+    test_ok(is_ok)

--- a/opengate/tests/src/test093_proc_in_vol_attribute.py
+++ b/opengate/tests/src/test093_proc_in_vol_attribute.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from opengate.tests.utility import get_default_test_paths, test_ok, print_test
+from opengate.tests.utility import (
+    get_default_test_paths,
+    test_ok,
+    print_test,
+    compare_root3,
+)
 from opengate.utility import g4_units
 from opengate.logger import INFO, DEBUG, RUN, NONE
 from opengate.managers import Simulation
-
+from opengate.actors.digitizers import *
 
 if __name__ == "__main__":
     paths = get_default_test_paths(__file__, None, "test093")
@@ -19,7 +24,7 @@ if __name__ == "__main__":
     # simulation
     sim = Simulation()
     sim.progress_bar = True
-    sim.visu = True
+    sim.visu = False
     sim.visu_type = "qt"
     sim.output_dir = paths.output
 
@@ -37,44 +42,79 @@ if __name__ == "__main__":
 
     # add a "detector"
     detector = sim.add_volume("Box", "detector")
-    detector.size = [50 * cm, 50 * cm, 1 * cm]
+    detector.size = [150 * cm, 150 * cm, 1 * cm]
     detector.translation = [0 * cm, 0 * cm, 20 * cm]
     detector.material = "G4_LEAD_OXIDE"
 
-    # source
-    source = sim.add_source("GenericSource", "Default")
+    # source 1
+    source = sim.add_source("GenericSource", "low_energy")
     source.particle = "gamma"
-    source.energy.mono = 100 * keV
+    source.energy.mono = 50 * keV
     source.position.type = "sphere"
     source.position.radius = 20 * mm
     source.position.translation = [0 * cm, 0 * cm, -30 * cm]
     source.direction.type = "focused"
     source.direction.focus_point = [0 * cm, 0 * cm, -25 * cm]
     source.direction.momentum = [0, 0, -1]
-    source.n = 2000
+    source.n = 50000
 
     # add a stat actor
     stats = sim.add_actor("SimulationStatisticsActor", "Stats")
     stats.track_types_flag = True
 
+    # needed for Rayl !
+    sim.physics_manager.physics_list_name = "G4EmStandardPhysics_option4"
+
     # phsp
     phsp = sim.add_actor("PhaseSpaceActor", "PhaseSpace")
     phsp.attached_to = detector
 
-    phsp.attributes = ["KineticEnergy", "PrePosition"]
-    # at1 = Attribute("ProcessDefinedStep", "Compton", waterbox.name)
-    # at2 = Attribute("ProcessDefinedStep", "Rayley", waterbox.name)
-    # at3 = Attribute("ProcessDefinedStep", "Rayley", waterbox.name)
-    # phsp.attributes = ["KineticEnergy", "PrePosition", at1, at2, at3]
+    att1 = ProcessDefinedStepInVolumeAttribute(sim, "compt", waterbox1.name)
+    att2 = ProcessDefinedStepInVolumeAttribute(sim, "compt", "world")
+    att3 = ProcessDefinedStepInVolumeAttribute(sim, "Rayl", "world")
+    att4 = ProcessDefinedStepInVolumeAttribute(sim, "Rayl", waterbox2.name)
+    phsp.attributes = [
+        "KineticEnergy",
+        "PrePosition",
+        "EventID",
+        att1.name,
+        att2.name,
+        att3.name,
+        att4.name,
+    ]
+
+    # not possible:
+    try:
+        att3.volume_name = "toto"
+        att3.process_name = "toto"
+        fatal(f"volume_name and process_name cannot be changed")
+    except Exception as e:
+        print("OK, cannot change the volume_name")
 
     phsp.output_filename = "phsp.root"
-    phsp.steps_to_store = "entering"
-
-    # hits collection
+    phsp.steps_to_store = "all"
 
     # go
     sim.run()
     print(stats)
 
-    is_ok = False
+    # check
+    ref_root = paths.output_ref / "phsp.root"
+    test_root = paths.output / "phsp.root"
+    print(phsp.attributes)
+    keys = [att1.name, att2.name, att3.name, att4.name]
+    n = len(keys)
+    is_ok = compare_root3(
+        ref_root,
+        test_root,
+        "PhaseSpace",
+        "PhaseSpace",
+        keys1=keys,
+        keys2=keys,
+        tols=[0.2, 0.2, 0.1, 0.1] * n,
+        scalings1=[1] * n,
+        scalings2=[1] * n,
+        img=paths.output / "phsp.png",
+    )
+
     test_ok(is_ok)

--- a/opengate/tests/src/test093_proc_in_vol_attribute.py
+++ b/opengate/tests/src/test093_proc_in_vol_attribute.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
             "PhaseSpace",
             keys1=keys,
             keys2=keys,
-            tols=[0.05, 0.05, 0.05, 0.05],
+            tols=[0.07, 0.07, 0.05, 0.05],
             scalings1=[1] * n,
             scalings2=[1] * n,
             img=paths.output / "phsp.png",


### PR DESCRIPTION
Add a new attribute for phase space or digitizers, that counts the number of interactions in a given volume. 
For example : Compton in a phantom for PET system. 

This is a new type of attribute, which are dynamic : the user can set the process name and the volume name. 
Under the hoods, create an hidden actor to store the counts. 

 ```
 att = ProcessDefinedStepInVolumeAttribute(sim, "compt", waterbox1.name)
 phsp.attributes = [
        "KineticEnergy",
        "PrePosition",
        "EventID",
        att.name ]

```
Still somehow experimental ...
