### PR TITLE
Stopping Actor compatible with filters

### DIFF
--- a/core/opengate_core/opengate_lib/GateProductionAndStoppingActor.cpp
+++ b/core/opengate_core/opengate_lib/GateProductionAndStoppingActor.cpp
@@ -79,6 +79,8 @@ void GateProductionAndStoppingActor::SteppingAction(G4Step *step) {
 }
 void GateProductionAndStoppingActor::PostUserTrackingAction(
     const G4Track *track) {
+  // call mother class first
+  GateVActor::PostUserTrackingAction(track);
   if (fStopImageEnabled) {
     auto step = track->GetStep();
     AddValueToImage(track->GetStep());


### PR DESCRIPTION
The GateVActor PostUserTrackingAction was overwritten by the GateProductionAndStoppingActor. We need to call the mother class function to be able to use the actor with filters.
@yihan-jia