### PR TITLE
Add support of OFF files for tessellated volumes

### DIFF
--- a/docs/source/developer_guide/developer_guide_notes.rst
+++ b/docs/source/developer_guide/developer_guide_notes.rst
@@ -102,7 +102,7 @@ So, after a long explanation, the key points are:
    release_g4_references() method is called by the class’s close()
    method.
 
-An example may be the implementation of the Tesselated Volume (STL).
+An example may be the implementation of the Tesselated Volume (STL or OFF).
 
 Pybindings in pyG4TriangularFacet.cpp:
 

--- a/docs/source/user_guide/user_guide_reference_volumes.rst
+++ b/docs/source/user_guide/user_guide_reference_volumes.rst
@@ -159,7 +159,7 @@ Reference
 .. autoclass:: opengate.geometry.volumes.TubsVolume
 
 
-Tesselated (STL) volumes
+Tesselated (STL or OFF) volumes
 ------------------------
 
 .. _description-tesselated-volume:
@@ -167,15 +167,17 @@ Tesselated (STL) volumes
 Description
 ~~~~~~~~~~~
 
-It is possible to create a tesselated volume shape based on an Standard
+It is possible to create a tessellated volume shape based on a Standard
 Triangle Language (STL) data file. Such a file contains a mesh of
 triangles for one object. It is a typical output format of Computer
-Aided Design (CAD) software. To create such a volume add a volume of
-type “Tesselated”. Please keep in mind, that no material information is
-provided, it has to be specified by the user. A Tesselated volume
-inherits the the same basic options as other solids described above such
-as translation or rotation. A basic example how to import an STL file
-into a geometry “MyTesselatedVolume” and assign the material G4_WATER to
+Aided Design (CAD) software.
+The Object File Format (OFF) is also supported.
+
+To create such a volume add a volume of type “Tesselated”. Please keep in mind,
+that no material information is provided, it has to be specified by the user. A
+Tesselated volume inherits the same basic options as other solids described
+above such as translation or rotation. A basic example how to import an STL
+file into a geometry “MyTesselatedVolume” and assign the material G4_WATER to
 it can be found below. In order to verify the correct generation of the
 solid, one could look at the volume.
 
@@ -187,6 +189,7 @@ solid, one could look at the volume.
    tes.material = "G4_WATER"
    tes.mother = "world"  # by default
    tes.file_name = "myTesselatedVolume.stl"
+   tes.origin_at_cog = True  # by default
    #to read the volume of the generated solid
    print("volume: ",sim.volume_manager.get_volume(
            "MyTesselatedVolume"
@@ -194,7 +197,7 @@ solid, one could look at the volume.
    #an alternative way read the volume of the generated solid
    print("same volume: ",tes.solid_info.cubic_volume)
 
-See test test067_stl_volume for example.
+See test test067_tesselated_stl_volume or test067_tesselated_off_volume for example.
 
 .. _reference-1:
 

--- a/opengate/geometry/off.py
+++ b/opengate/geometry/off.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+
+def read_file(off_file: str):
+    vertices = []
+    faces = []
+
+    def readline(file):
+        line = ""
+        while line == "":
+            line = file.readline()
+            if not line:
+                raise EOFError("reached EOF prematurely")
+            line = line.strip()
+            if line != "" and line[0] == "#":
+                line = ""
+        return line
+
+    with open(off_file, "r") as file:
+        line = readline(file)
+        if line != "OFF":
+            raise SyntaxError("missing OFF header")
+
+        line = readline(file)
+        v, f, _ = [int(n) for n in line.split(" ")]
+        vertices = [[float(n) for n in readline(file).split(" ")] for i in range(v)]
+        faces = [[int(n) for n in readline(file).split(" ")[1:4]] for i in range(f)]
+
+    return vertices, faces
+
+
+def write_file(off_file: str, vertices, faces):
+    lines = []
+    lines.append("OFF\n")
+    lines.append(f"{len(vertices)} {len(faces)} 0\n")
+    lines.extend([f"{vertex[0]} {vertex[1]} {vertex[2]}\n" for vertex in vertices])
+    lines.extend([f"3 {face[0]} {face[1]} {face[2]}\n" for face in faces])
+
+    with open(off_file, "w+") as f:
+        f.writelines(lines)
+
+
+def vectors_from_vertices_faces(vertices, faces):
+    # TODO triangular faces assumed for now
+    return [[vertices[face[0]], vertices[face[1]], vertices[face[2]]] for face in faces]
+
+
+# adapter to use OFF files like STL files
+# this class replicates parts of stl.mesh.Mesh
+class Mesh:
+    vectors: []
+    cog: []
+
+    def __init__(self, vertices, faces):
+        self.vectors = vectors_from_vertices_faces(vertices, faces)
+        self._update()
+
+    def from_file(off_file: str):
+        vertices, faces = read_file(off_file)
+        return Mesh(vertices, faces)
+
+    def get_mass_properties(self):
+        return [
+            0,  # volume
+            self.cog,  # center of gravity
+            0,  # inertia matrix expressed at the COG
+        ]
+
+    def translate(self, tr):
+        self.vectors = [vector + tr for vector in self.vectors]
+        self._update()
+
+    def _update(self):
+        shape = np.array(self.vectors).shape
+        vertices = np.reshape(self.vectors, (shape[0] * shape[1], shape[2]))
+        self.cog = np.mean(vertices, axis=0)

--- a/opengate/geometry/solids.py
+++ b/opengate/geometry/solids.py
@@ -2,6 +2,7 @@ from box import Box
 from scipy.spatial.transform import Rotation
 import stl
 import logging
+import pathlib
 
 from ..base import GateObject, process_cls, create_gate_object_from_dict
 from ..utility import g4_units
@@ -10,6 +11,7 @@ import opengate_core as g4
 from ..decorators import requires_fatal
 
 from .utility import ensure_is_g4_rotation, ensure_is_g4_translation, vec_np_as_g4
+from . import off
 
 
 logger = logging.getLogger(__name__)
@@ -484,8 +486,18 @@ class TesselatedSolid(SolidBase):
     https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Detector/Geometry/geomSolids.html?highlight=tesselated#tessellated-solids
     """
 
+    file_name: str
+    origin_at_cog: bool
+
     user_info_defaults = {
-        "file_name": ("", {"doc": "Path and file name of the STL file."}),
+        "file_name": (
+            "",
+            {"doc": "Path and file name of the STL or OFF file."},
+        ),
+        "origin_at_cog": (
+            True,
+            {"doc": "Translate the volume so its centre of gravity is at (0, 0, 0)."},
+        ),
     }
 
     def __init__(self, *args, **kwargs):
@@ -499,11 +511,36 @@ class TesselatedSolid(SolidBase):
         super().close()
 
     def read_file(self):
+        ext = pathlib.Path(self.file_name).suffix.lower()
+        if ext == ".stl":
+            return self._read_stl()
+        elif ext == ".off":
+            return self._read_off()
+        else:
+            msg = (
+                f"Error in {self.type_name} called {self.name}. "
+                f"Unknown file type {ext} ({self.file_name}). Aborting."
+            )
+            fatal(msg)
+
+    def _read_stl(self):
         try:
             return stl.mesh.Mesh.from_file(self.file_name)
         except Exception as e:
             msg = (
-                f"Error in {self.type_name} called {self.name}. Could not read the file {self.file_name}. Aborting. "
+                f"Error in {self.type_name} called {self.name}. "
+                f"Could not read the file {self.file_name}. Aborting. "
+                f"The error encountered was: \n{e}"
+            )
+            fatal(msg)
+
+    def _read_off(self):
+        try:
+            return off.Mesh.from_file(self.file_name)
+        except Exception as e:
+            msg = (
+                f"Error in {self.type_name} called {self.name}. "
+                f"Could not read the file {self.file_name}. Aborting. "
                 f"The error encountered was: \n{e}"
             )
             fatal(msg)
@@ -516,13 +553,20 @@ class TesselatedSolid(SolidBase):
 
     def build_solid(self):
         mm = g4_units.mm
+
+        box_mesh = self.read_file()
+
         # translate the mesh to the center of gravity
-        box_mesh = self.translate_mesh_to_center(self.read_file())
+        if self.origin_at_cog:
+            box_mesh = self.translate_mesh_to_center(box_mesh)
+
+        vectors = box_mesh.vectors
+
         # generate the tessellated solid
         tessellated_solid = g4.G4TessellatedSolid(self.name)
         # create an array of facets
         # self.g4_facets = []
-        for vertex in box_mesh.vectors:
+        for vertex in vectors:
             # Create the new facet
             # ABSOLUTE =0
             # RELATIVE =1

--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -703,8 +703,7 @@ class TubsVolume(RepeatableVolume, solids.TubsSolid):
 
 class TesselatedVolume(RepeatableVolume, solids.TesselatedSolid):
     """
-    Volume based on a mesh volume
-    by reading an STL file.
+    Volume based on a mesh volume by reading an STL or OFF file.
     """
 
 

--- a/opengate/tests/src/test067_tesselated_off_volume.py
+++ b/opengate/tests/src/test067_tesselated_off_volume.py
@@ -3,16 +3,14 @@
 
 import opengate as gate
 from opengate.tests import utility
-import stl
 import numpy as np
 import itk
+from opengate.geometry import off
 
 
-def create_test_mesh(file_name="myTesselatedBoxVolume.stl"):
-    my_mesh = create_box_mesh()
-    translate_mesh_to_center(my_mesh)
-    show_mesh_info(my_mesh)
-    store_mesh_to_file(my_mesh, file_name, mode=stl.stl.ASCII)
+def create_test_mesh(file_name="myTesselatedBoxVolume.off"):
+    vertices, faces = create_box_mesh()
+    off.write_file(file_name, vertices, faces)
 
 
 def create_box_mesh():
@@ -57,42 +55,8 @@ def create_box_mesh():
             [0, 5, 4],
         ]
     )
-    # Create the mesh
-    box_mesh = stl.mesh.Mesh(np.zeros(faces.shape[0], dtype=stl.mesh.Mesh.dtype))
-    for i, f in enumerate(faces):
-        for j in range(3):
-            box_mesh.vectors[i][j] = vertices[f[j]]
 
-    # create a mesh from the data#
-    # box_mesh = mesh.Mesh(data.copy())
-    return box_mesh
-
-
-def read_mesh_from_file(file_name):
-    # Using an existing stl file:
-    box_mesh = stl.mesh.Mesh.from_file(file_name)
-    return box_mesh
-
-
-def translate_mesh_to_center(mesh_to_translate):
-    # translate the mesh to the center of gravity
-    cog = mesh_to_translate.get_mass_properties()[1]
-    mesh_to_translate.translate(-cog)
-    return mesh_to_translate
-
-
-def show_mesh_info(mesh_to_use):
-    volume, cog, inertia = mesh_to_use.get_mass_properties()
-    print("volume ", volume)
-    print("center of gravity ", cog)
-    # print("inertia ", inertia)
-    # print("get_unit_normals ", mesh_to_use.get_unit_normals())
-    print("is_closed ", mesh_to_use.is_closed())
-
-
-def store_mesh_to_file(mesh_to_store, file_name, mode=0):
-    dir(mesh_to_store)
-    mesh_to_store.save(file_name, mode=mode)
+    return vertices, faces
 
 
 def create_simulation():
@@ -125,7 +89,8 @@ def create_simulation():
 
     tes = sim.add_volume("Tesselated", name="MyTesselatedVolume")
     tes.material = "G4_WATER"
-    tes.file_name = output_path / "myTesselatedBoxVolume.stl"
+    tes.file_name = output_path / "myTesselatedBoxVolume.off"
+    tes.origin_at_cog = True
 
     # print the list of available volumes types:
     sim.volume_manager.print_volume_types()
@@ -210,13 +175,13 @@ def eval_results(sim):
 
 
 paths = utility.get_default_test_paths(
-    __file__, "test066_stl_volume", output_folder="test067"
+    __file__, "test067_tesselated_off_volume", output_folder="test067"
 )
 
 
 if __name__ == "__main__":
-    print("Generating STL data")
-    create_test_mesh(file_name=paths.output / "myTesselatedBoxVolume.stl")
+    print("Generating OFF data")
+    create_test_mesh(file_name=paths.output / "myTesselatedBoxVolume.off")
     sim = create_simulation()
     print("Running GATE simulation")
     sim.run()

--- a/opengate/tests/src/test067_tesselated_stl_volume.py
+++ b/opengate/tests/src/test067_tesselated_stl_volume.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import opengate as gate
+from opengate.tests import utility
+import stl
+import numpy as np
+import itk
+
+
+def create_test_mesh(file_name="myTesselatedBoxVolume.stl"):
+    my_mesh = create_box_mesh()
+    translate_mesh_to_center(my_mesh)
+    show_mesh_info(my_mesh)
+    store_mesh_to_file(my_mesh, file_name, mode=stl.stl.ASCII)
+
+
+def create_box_mesh():
+    """Create a simple cube mesh of 300x300x300 mm"""
+    # Define the vertices and faces of the box using vectors
+    vertices = np.array(
+        [
+            [0, 0, 0],  # Vertex 0
+            [1, 0, 0],  # Vertex 1
+            [1, 1, 0],  # Vertex 2
+            [0, 1, 0],  # Vertex 3
+            [0, 0, 1],  # Vertex 4
+            [1, 0, 1],  # Vertex 5
+            [1, 1, 1],  # Vertex 6
+            [0, 1, 1],  # Vertex 7
+        ],
+        dtype=np.float64,
+    )
+    # shift to center
+    # vertices -= 0.5
+    # scale vertices from a 1x1x1 mm cube to a 300x300x300 mm cube
+    scale = 300
+    vertices[:, 0] *= scale
+    vertices[:, 1] *= scale
+    vertices[:, 2] *= scale
+    # vertices *= scale
+
+    # Define the faces of the box using vertex indices
+    faces = np.array(
+        [
+            [0, 3, 1],
+            [1, 3, 2],
+            [0, 4, 7],
+            [0, 7, 3],
+            [4, 5, 6],
+            [4, 6, 7],
+            [5, 1, 2],
+            [5, 2, 6],
+            [2, 3, 6],
+            [3, 7, 6],
+            [0, 1, 5],
+            [0, 5, 4],
+        ]
+    )
+    # Create the mesh
+    box_mesh = stl.mesh.Mesh(np.zeros(faces.shape[0], dtype=stl.mesh.Mesh.dtype))
+    for i, f in enumerate(faces):
+        for j in range(3):
+            box_mesh.vectors[i][j] = vertices[f[j]]
+
+    # create a mesh from the data#
+    # box_mesh = mesh.Mesh(data.copy())
+    return box_mesh
+
+
+def read_mesh_from_file(file_name):
+    # Using an existing stl file:
+    box_mesh = stl.mesh.Mesh.from_file(file_name)
+    return box_mesh
+
+
+def translate_mesh_to_center(mesh_to_translate):
+    # translate the mesh to the center of gravity
+    cog = mesh_to_translate.get_mass_properties()[1]
+    mesh_to_translate.translate(-cog)
+    return mesh_to_translate
+
+
+def show_mesh_info(mesh_to_use):
+    volume, cog, inertia = mesh_to_use.get_mass_properties()
+    print("volume ", volume)
+    print("center of gravity ", cog)
+    # print("inertia ", inertia)
+    # print("get_unit_normals ", mesh_to_use.get_unit_normals())
+    print("is_closed ", mesh_to_use.is_closed())
+
+
+def store_mesh_to_file(mesh_to_store, file_name, mode=0):
+    dir(mesh_to_store)
+    mesh_to_store.save(file_name, mode=mode)
+
+
+def create_simulation():
+    output_path = paths.output
+
+    # units
+    m = gate.g4_units.m
+    mm = gate.g4_units.mm
+    cm = gate.g4_units.cm
+    eV = gate.g4_units.eV
+    MeV = gate.g4_units.MeV
+    um = gate.g4_units.um
+
+    # simulation object
+    sim = gate.Simulation()
+
+    #
+    # Visualization
+    sim.visu = False
+    sim.visu_verbose = False
+    sim.random_engine = "MersenneTwister"
+    sim.random_seed = 123456
+    sim.number_of_threads = 1
+    sim.output_dir = output_path
+
+    # geometry
+    world = sim.world
+    world.size = [2 * m, 2 * m, 2 * m]
+    world.material = "G4_Galactic"
+
+    tes = sim.add_volume("Tesselated", name="MyTesselatedVolume")
+    tes.material = "G4_WATER"
+    tes.file_name = output_path / "myTesselatedBoxVolume.stl"
+
+    # print the list of available volumes types:
+    sim.volume_manager.print_volume_types()
+
+    # sources
+    source = sim.add_source("GenericSource", "particle")
+    source.particle = "proton"
+    source.position.type = "point"
+    source.direction.type = "momentum"
+    source.direction.momentum = [0, 0, 1]
+    source.position.translation = [0 * cm, 0 * cm, -30 * cm]
+    source.energy.type = "gauss"
+    source.energy.mono = 60 * MeV
+    source.n = 100
+
+    print(f"The energy is {source.energy.mono / eV} eV")
+
+    # Physics
+    sim.physics_manager.physics_list_name = "QGSP_BIC_EMZ"
+    global_cut = 500 * um
+    sim.physics_manager.global_production_cuts.gamma = global_cut
+    sim.physics_manager.global_production_cuts.electron = global_cut
+    sim.physics_manager.global_production_cuts.positron = global_cut
+    sim.physics_manager.global_production_cuts.proton = global_cut
+
+    # Actors
+    # Statistics Actor
+    stats = sim.add_actor("SimulationStatisticsActor", "Stats")
+    stats.output_filename = "Statistics.txt"
+    stats.track_types_flag = True
+
+    # Dose Actor
+    dose_actor = sim.add_actor("DoseActor", "dose")
+    dose_actor.attached_to = tes
+    # number of voxels per dimension
+    dose_actor.size = [1, 1, 300]
+    # size of the voxels
+    dose_actor.spacing = [30 * cm, 30 * cm, 1 * mm]
+    dose_actor.dose.active = True
+    dose_actor.edep_squared.active = True
+    dose_actor.hit_type = "random"
+    dose_actor.output_filename = "test067_dose.mhd"
+
+    return sim
+
+
+def eval_results(sim):
+    # access to the results
+    eval_Volume = sim.volume_manager.get_volume(
+        "MyTesselatedVolume"
+    ).solid_info.cubic_volume
+    print("volume: ", eval_Volume)
+    volume_is_ok = utility.check_diff_abs(
+        float(eval_Volume), float(27000000.0), tolerance=1e-1, txt="volume"
+    )
+
+    dose = sim.get_actor("dose")
+    image = dose.edep.get_data()
+    np_image = itk.GetArrayFromImage(image)
+    # For 1D images, the array is squeezed
+    np_image = np.squeeze(np_image)
+    # create index array
+    array_1d = np.arange(300)
+    # Check if the lengths of the arrays match
+    if len(array_1d) != len(np_image):
+        raise ValueError("Lengths of the arrays do not match")
+    (
+        r80,
+        tmp,
+    ) = utility.getRange(array_1d, np_image, percentLevel=0.8)
+
+    print("r80: ", r80)
+    r80_is_ok = utility.check_diff_abs(
+        float(r80), float(30.43), tolerance=1e-1, txt="R80"
+    )
+
+    if volume_is_ok and r80_is_ok:
+        is_ok = True
+    else:
+        is_ok = False
+    return is_ok
+
+
+paths = utility.get_default_test_paths(
+    __file__, "test067_tesselated_stl_volume", output_folder="test067"
+)
+
+
+if __name__ == "__main__":
+    print("Generating STL data")
+    create_test_mesh(file_name=paths.output / "myTesselatedBoxVolume.stl")
+    sim = create_simulation()
+    print("Running GATE simulation")
+    sim.run()
+    stats_actor = sim.actor_manager.get_actor("Stats")
+    print(stats_actor)
+    print("Simulation finished")
+    print("Evaluating results")
+    is_ok = eval_results(sim)
+    utility.test_ok(is_ok)

--- a/opengate/tests/src/test089_geometries.py
+++ b/opengate/tests/src/test089_geometries.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     # Image Volume example in test009_voxels.py
     # Boolean Volume example in test016_bool_volumes.py
     # Repeatable Volume example in test017_repeatable.py
-    # Tesselated Volume example in test067_stl_volume.py
+    # Tesselated Volume example in test067_tesselated_stl_volume.py and test067_tesselated_off_volume.py
 
     labels, image = sim.voxelize_geometry(extent="Auto", spacing=(2, 2, 2), margin=1)
     itk.imwrite(image, paths.output / "test089_geometries.mhd")


### PR DESCRIPTION
This PR adds [Object File Format (OFF)](https://en.wikipedia.org/wiki/OFF_(file_format)) to the supported file formats for tessellated volumes (previously only STL).

It also adds an option to these volume to disable the centering on the center of gravity (the current behaviour is kept as default).

The associated test (`test067_tesselated_volume.py`) is split into two:
- `test067_tesselated_stl_volume.py` (the current one);
- `test067_tesselated_off_volume.py`, mainly a copy of the STL one but with an OFF file.