### PR TITLE
Add air in GateMaterials.db in contrib

### DIFF
--- a/opengate/contrib/GateMaterials.db
+++ b/opengate/contrib/GateMaterials.db
@@ -68,6 +68,12 @@ Uranium:    S= U   ; Z= 92. ; A= 238.03  g/mole
 Vacuum: d=0.000001 mg/cm3 ; n=1
         +el: name=Hydrogen   ; n=1
 
+Air: d=1.29 mg/cm3 ; n=4 ; state=gas
+        +el: name=Nitrogen;   f=0.755268
+        +el: name=Oxygen;     f=0.231781
+        +el: name=Argon;      f=0.012827
+        +el: name=Carbon;     f=0.000124
+
 Nickel: d=8.908 g/cm3 ; n=1 ; state=solid
         +el: name=auto       ; n=1
 


### PR DESCRIPTION
Air is necessary for some other application eg: pCT