### PR TITLE
Update engines.py for optical properties in ImageVolumes

### DIFF
--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -420,20 +420,20 @@ class PhysicsEngine(EngineBase):
                         for mat in g4.G4Material.GetMaterialTable: #Loop on all materials created in the simulation
                             if str(mat.GetName())==i: #If material is in voxel_materials
                                 mat_prop = load_optical_properties_from_xml(    
-                                self.physics_manager.optical_properties_file, mat.GetName()
+                                    self.physics_manager.optical_properties_file, mat.GetName()
                                 )
                                 if mat_prop is not None:
                                     self.g4_optical_material_tables[str(mat.GetName())] = (
-                                    create_g4_optical_properties_table(mat_prop)
+                                        create_g4_optical_properties_table(mat_prop)
                                     )
                                     mat.SetMaterialPropertiesTable(
-                                    self.g4_optical_material_tables[str(mat.GetName())]
+                                        self.g4_optical_material_tables[str(mat.GetName())]
                                     )
                                 else:
-                                self.simulation_engine.simulation.warn_user(
-                                f"Could not load the optical material properties for material {mat.GetName()} "
-                                f"found in volume {vol.name} from file {self.physics_manager.optical_properties_file}."
-                                )   
+                                    self.simulation_engine.simulation.warn_user(
+                                        f"Could not load the optical material properties for material {mat.GetName()} "
+                                        f"found in volume {vol.name} from file {self.physics_manager.optical_properties_file}."
+                                    )   
                 material_name = vol.g4_material.GetName()
                 material_properties = load_optical_properties_from_xml(
                     self.physics_manager.optical_properties_file, material_name

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -415,24 +415,24 @@ class PhysicsEngine(EngineBase):
             for (
                 vol
             ) in self.simulation_engine.simulation.volume_manager.volumes.values():
-             if hasattr(vol,"voxel_materials"):  #True if voxelized volume (ImageVolume)
-                for i in np.array(vol.voxel_materials)[:,2]:  #Read all materials contained in voxel_materials
-                    for mat in g4.G4Material.GetMaterialTable: #Loop on all materials created in the simulation
-                        if str(mat.GetName())==i: #If material is in voxel_materials
-                            mat_prop = load_optical_properties_from_xml(    
+                if hasattr(vol,"voxel_materials"):  #True if voxelized volume (ImageVolume)
+                    for i in np.array(vol.voxel_materials)[:,2]:  #Read all materials contained in voxel_materials
+                        for mat in g4.G4Material.GetMaterialTable: #Loop on all materials created in the simulation
+                            if str(mat.GetName())==i: #If material is in voxel_materials
+                                mat_prop = load_optical_properties_from_xml(    
                                 self.physics_manager.optical_properties_file, mat.GetName()
-                            )
-                            if mat_prop is not None:
-                                self.g4_optical_material_tables[str(mat.GetName())] = (
+                                )
+                                if mat_prop is not None:
+                                    self.g4_optical_material_tables[str(mat.GetName())] = (
                                     create_g4_optical_properties_table(mat_prop)
-                                )
-                                mat.SetMaterialPropertiesTable(
+                                    )
+                                    mat.SetMaterialPropertiesTable(
                                     self.g4_optical_material_tables[str(mat.GetName())]
-                                )
-                            else:
+                                    )
+                                else:
                                 self.simulation_engine.simulation.warn_user(
-                                    f"Could not load the optical material properties for material {mat.GetName()} "
-                                    f"found in volume {vol.name} from file {self.physics_manager.optical_properties_file}."
+                                f"Could not load the optical material properties for material {mat.GetName()} "
+                                f"found in volume {vol.name} from file {self.physics_manager.optical_properties_file}."
                                 )   
                 material_name = vol.g4_material.GetName()
                 material_properties = load_optical_properties_from_xml(

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -415,6 +415,25 @@ class PhysicsEngine(EngineBase):
             for (
                 vol
             ) in self.simulation_engine.simulation.volume_manager.volumes.values():
+             if hasattr(vol,"voxel_materials"):  #True if voxelized volume (ImageVolume)
+                for i in np.array(vol.voxel_materials)[:,2]:  #Read all materials contained in voxel_materials
+                    for mat in g4.G4Material.GetMaterialTable: #Loop on all materials created in the simulation
+                        if str(mat.GetName())==i: #If material is in voxel_materials
+                            mat_prop = load_optical_properties_from_xml(    
+                                self.physics_manager.optical_properties_file, mat.GetName()
+                            )
+                            if mat_prop is not None:
+                                self.g4_optical_material_tables[str(mat.GetName())] = (
+                                    create_g4_optical_properties_table(mat_prop)
+                                )
+                                mat.SetMaterialPropertiesTable(
+                                    self.g4_optical_material_tables[str(mat.GetName())]
+                                )
+                            else:
+                                self.simulation_engine.simulation.warn_user(
+                                    f"Could not load the optical material properties for material {mat.GetName()} "
+                                    f"found in volume {vol.name} from file {self.physics_manager.optical_properties_file}."
+                                )   
                 material_name = vol.g4_material.GetName()
                 material_properties = load_optical_properties_from_xml(
                     self.physics_manager.optical_properties_file, material_name


### PR DESCRIPTION
Modified engines.py so optical photons can be transported in voxelized volumes (ImageVolumes). Before that, optical properties were only applied to the default material and not those defined in "voxel_materials", preventing the transport of optical photons in ImageVolumes.