### PR TITLE
Fix annihilation typos

### DIFF
--- a/docs/source/user_guide/user_guide_reference_sources_generic_source.rst
+++ b/docs/source/user_guide/user_guide_reference_sources_generic_source.rst
@@ -389,7 +389,7 @@ Probabilities are derived from weights simply by normalizing the weights list.
    spectrum = gate.sources.utility.get_spectrum("Lu177", spectrum_type, database="icrp107")
 
 where ``spectrum_type`` is one of "gamma", "beta-", "beta+", "alpha", "X", "neutron",
-"auger", "IE", "alpha recoil", "anihilation", "fission", "betaD", "b-spectra". From this list,
+"auger", "IE", "alpha recoil", "annihilation", "fission", "betaD", "b-spectra". From this list,
 only b-spectra is histogram based (see next section), the rest are discrete. ``database`` can be "icrp107" or "radar".
 
 ICRP107 data comes from `[ICRP, 2008. Nuclear Decay Data for Dosimetric Calculations. ICRP Publication 107. Ann. ICRP 38] <https://www.icrp.org/publication.asp?id=ICRP%20Publication%20107>`__

--- a/opengate/sources/utility.py
+++ b/opengate/sources/utility.py
@@ -32,7 +32,7 @@ icrp107_emissions = [
     "auger",
     "IE",
     "alpha recoil",
-    "anihilation",
+    "annihilation",
     "fission",
     "betaD",
     "b-spectra",  # beta spectras, both beta+ and beta-
@@ -56,7 +56,7 @@ def get_spectrum(
     spectrum_type : str, optional
         The type of spectrum to retrieve. Default is "gamma". Must be one of
         "gamma", "beta+", "beta-", or "e+". icrp107 allows also one of
-        "alpha", "X", "neutron", "auger", "IE", "alpha recoil", "anihilation", "fission", "betaD", "b-spectra".
+        "alpha", "X", "neutron", "auger", "IE", "alpha recoil", "annihilation", "fission", "betaD", "b-spectra".
         In the case of beta spectras, make use of the
         :py:func:`set_source_energy_spectrum` function instead.
 
@@ -250,7 +250,7 @@ def __get_icrp107_spectrum(rad_name: str, spectrum_type=DEFAULT_SPECTRUM_TYPE) -
         The name of the radionuclide in Gate format, e.g. "Tc99m", "Lu177"
 
     spectrum_type : str
-        The type of spectrum to retrieve. Must be one of "gamma", "beta-", "beta+", "alpha", "X", "neutron", "auger", "IE", "alpha recoil", "anihilation", "fission", "betaD", "b-spectra"
+        The type of spectrum to retrieve. Must be one of "gamma", "beta-", "beta+", "alpha", "X", "neutron", "auger", "IE", "alpha recoil", "annihilation", "fission", "betaD", "b-spectra"
 
     Returns
     -------

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "PyYAML",
         "SimpleITK",
         "spekpy",
-        "icrp107-database",
+        "icrp107-database>=0.0.3",
         "loguru",
     ]
     + install_requires_windows,


### PR DESCRIPTION
Fixes #831, related to [icrp107-database#1](https://github.com/OpenGATE/icrp107-database/pull/1).

Corrected a typo in the icrp107_emissions list in [icrp107_database/utility.py](https://github.com/OpenGATE/icrp107-database/blob/main/icrp107_database/utility.py), which prevented spectrum_type="annihilation" from being recognized.

This update corrects the misspelling of annihilation in the GATE code and documentation.