### PR TITLE
Debug current simulation time

### DIFF
--- a/core/opengate_core/opengate_lib/GateSourceManager.cpp
+++ b/core/opengate_core/opengate_lib/GateSourceManager.cpp
@@ -214,6 +214,8 @@ void GateSourceManager::PrepareRunToStart(int run_id) {
   l.fCurrentTimeInterval = fSimulationTimes[run_id];
   // set the current time
   l.fCurrentSimulationTime = l.fCurrentTimeInterval.first;
+  // init the next time as the end of the interval by default
+  l.fNextSimulationTime = l.fCurrentTimeInterval.second;
   // reset abort run flag to false
   fRunTerminationFlag = false;
   // Prepare the run for all sources
@@ -252,6 +254,7 @@ void GateSourceManager::PrepareNextSource() const {
 
 void GateSourceManager::CheckForNextRun() const {
   auto &l = fThreadLocalData.Get();
+  l.fStartNewRun = false;
   if (l.fNextActiveSource == nullptr || fRunTerminationFlag) {
     G4RunManager::GetRunManager()->AbortRun(true); // FIXME true or false ?
     l.fStartNewRun = true;


### PR DESCRIPTION
Be sure to initialize the fNextSimulationTime to the end of the time interval Be sure to set fStartNewRun to false by default

It avoids to simulate new Particles even if the nex time is out of time interval

https://github.com/OpenGATE/opengate/issues/830