### PR TITLE
Corrected the TAC interpolation function GateGenericSource::UpdateActivityWithTAC

### DIFF
--- a/core/opengate_core/opengate_lib/GateGenericSource.cpp
+++ b/core/opengate_core/opengate_lib/GateGenericSource.cpp
@@ -121,8 +121,8 @@ void GateGenericSource::UpdateActivityWithTAC(const double time) {
   // Move to the lower bin edge for the interpolation
   i -= 1;
 
-      // Last element ?
-      if (i >= fTAC_Times.size() - 1) {
+  // Last element ?
+  if (i >= fTAC_Times.size() - 1) {
     fActivity = fTAC_Activities.back();
     return;
   }


### PR DESCRIPTION
GateGenericSource::UpdateActivityWithTAC in opengate/core/opengate_core/opengate_lib/GateGenericSource.cpp does not interpolate the TAC_activities correctly. There are two issues:

1. The index i is not calculated properly. It is one index too high.
2. The interpolation equation is flipped. w1 and w2 should be swapped.

I corrected both issues.