### PR TITLE
Remove windows-11-arm support because miniconda3 failed to install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm, macos-15-intel, windows-11-arm]
+        os: [ubuntu-24.04-arm, macos-15-intel]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         exclude:
           - os: macos-15


### PR DESCRIPTION
Remove windows-11-arm support because miniconda3 failed to install on this platform

Run conda-incubator/setup-miniconda@v3
  with:
    miniconda-version: latest
    auto-update-conda: true
    activate-environment: opengate_core
    python-version: 3.13
    auto-activate-base: true
    remove-profiles: true
    conda-solver: libmamba
    clean-patched-environment-file: true
    run-post: true
  env:
    GEANT4_VERSION: v11.3.2
    ITK_VERSION: v5.4.4
    pythonLocation: C:\hostedtoolcache\windows\Python\3.13.8\arm64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.13.8\arm64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.8\arm64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.8\arm64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.8\arm64
Gathering Inputs...
Creating bootstrap condarc file in C:\Users\runneradmin\.condarc...
Ensuring installer...
  Can we use bundled Miniconda?
  Can we download a custom installer by URL?
  Can we download Miniforge?
  Can we download Miniconda?
  ... will download Miniconda.
  Miniconda3-latest-Windows-arm64.exe
Error: Invalid miniconda version!