### PR TITLE
Dev fluence actor

### DIFF
--- a/core/opengate_core/opengate_lib/GateFluenceActor.h
+++ b/core/opengate_core/opengate_lib/GateFluenceActor.h
@@ -45,9 +45,13 @@ public:
   bool GetSumTracksFlag() const { return fSumTracksFlag; }
 
   // Set the fluence scoring mode
-  inline void SetFluenceScoringMode(std::string mode) { fFluenceScoringMode = mode; }
+  inline void SetFluenceScoringMode(std::string mode) {
+    fFluenceScoringMode = mode;
+  }
 
-  inline std::string GetFluenceScoringMode() const { return fFluenceScoringMode; }
+  inline std::string GetFluenceScoringMode() const {
+    return fFluenceScoringMode;
+  }
 
   int NbOfEvent = 0;
 
@@ -59,7 +63,8 @@ public:
   Size4DType size_4D;
 
   void GetVoxelPosition(G4Step *step, G4ThreeVector &position, bool &isInside,
-                        Image3DType::IndexType &index, Image3DType::Pointer &image) const;
+                        Image3DType::IndexType &index,
+                        Image3DType::Pointer &image) const;
 
   // The image is accessible on py side (shared by all threads)
   Image3DType::Pointer cpp_fluence_image;
@@ -68,7 +73,8 @@ public:
   // Option: Is the fluence as sum of the tracks to be scored?
   bool fSumTracksFlag{};
 
-  // store the voexl volume for later use (for example to compute dose from fluence)
+  // store the voexl volume for later use (for example to compute dose from
+  // fluence)
   double fVoxelVolume{};
 
 private:

--- a/core/opengate_core/opengate_lib/GateFluenceActor.h
+++ b/core/opengate_core/opengate_lib/GateFluenceActor.h
@@ -39,6 +39,16 @@ public:
 
   inline void SetPhysicalVolumeName(std::string s) { fPhysicalVolumeName = s; }
 
+  // Image type is 3D float by default
+  void SetSumTracksFlag(const bool b) { fSumTracksFlag = b; }
+
+  bool GetSumTracksFlag() const { return fSumTracksFlag; }
+
+  // Set the fluence scoring mode
+  inline void SetFluenceScoringMode(std::string mode) { fFluenceScoringMode = mode; }
+
+  inline std::string GetFluenceScoringMode() const { return fFluenceScoringMode; }
+
   int NbOfEvent = 0;
 
   // Image type is 3D float by default
@@ -47,6 +57,9 @@ public:
   typedef itk::Image<int, 4> ImageInt4DType;
   using Size4DType = Image4DType::SizeType;
   Size4DType size_4D;
+
+  void GetVoxelPosition(G4Step *step, G4ThreeVector &position, bool &isInside,
+                        Image3DType::IndexType &index, Image3DType::Pointer &image) const;
 
   // The image is accessible on py side (shared by all threads)
   Image3DType::Pointer cpp_fluence_image;
@@ -62,6 +75,7 @@ private:
   std::string fPhysicalVolumeName;
   G4ThreeVector fTranslation;
   std::string fHitType;
+  std::string fFluenceScoringMode = "sum_tracks";
 };
 
 #endif // GateFluenceActor_h

--- a/core/opengate_core/opengate_lib/GateFluenceActor.h
+++ b/core/opengate_core/opengate_lib/GateFluenceActor.h
@@ -50,6 +50,13 @@ public:
 
   // The image is accessible on py side (shared by all threads)
   Image3DType::Pointer cpp_fluence_image;
+  Image3DType::Pointer cpp_fluence_sum_tracks_image;
+
+  // Option: Is the fluence as sum of the tracks to be scored?
+  bool fSumTracksFlag{};
+
+  // store the voexl volume for later use (for example to compute dose from fluence)
+  double fVoxelVolume{};
 
 private:
   std::string fPhysicalVolumeName;

--- a/core/opengate_core/opengate_lib/pyGateFluenceActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateFluenceActor.cpp
@@ -39,6 +39,11 @@ void init_GateFluenceActor(py::module &m) {
            &GateFluenceActor::EndOfRunActionMasterThread)
       .def("GetPhysicalVolumeName", &GateFluenceActor::GetPhysicalVolumeName)
       .def("SetPhysicalVolumeName", &GateFluenceActor::SetPhysicalVolumeName)
+      .def("SetSumTracksFlag", &GateFluenceActor::SetSumTracksFlag)
+      .def("GetSumTracksFlag", &GateFluenceActor::GetSumTracksFlag)
+      .def("SetFluenceScoringMode", &GateFluenceActor::SetFluenceScoringMode)
+      .def("GetFluenceScoringMode", &GateFluenceActor::GetFluenceScoringMode)
       .def_readwrite("NbOfEvent", &GateFluenceActor::NbOfEvent)
-      .def_readwrite("cpp_fluence_image", &GateFluenceActor::cpp_fluence_image);
+      .def_readwrite("cpp_fluence_image", &GateFluenceActor::cpp_fluence_image)
+      .def_readwrite("cpp_fluence_sum_tracks_image", &GateFluenceActor::cpp_fluence_sum_tracks_image);
 }

--- a/core/opengate_core/opengate_lib/pyGateFluenceActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateFluenceActor.cpp
@@ -45,5 +45,6 @@ void init_GateFluenceActor(py::module &m) {
       .def("GetFluenceScoringMode", &GateFluenceActor::GetFluenceScoringMode)
       .def_readwrite("NbOfEvent", &GateFluenceActor::NbOfEvent)
       .def_readwrite("cpp_fluence_image", &GateFluenceActor::cpp_fluence_image)
-      .def_readwrite("cpp_fluence_sum_tracks_image", &GateFluenceActor::cpp_fluence_sum_tracks_image);
+      .def_readwrite("cpp_fluence_sum_tracks_image",
+                     &GateFluenceActor::cpp_fluence_sum_tracks_image);
 }

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -1674,7 +1674,9 @@ class FluenceActor(VoxelDepositActor, g4.GateFluenceActor):
             self.user_output.fluence.set_active(True)
             self.user_output.sum_tracks.set_active(False)
         else:
-            fatal(f"FluenceActor: unknown fluence_scoring_mode '{self.fluence_scoring_mode}'")
+            fatal(
+                f"FluenceActor: unknown fluence_scoring_mode '{self.fluence_scoring_mode}'"
+            )
 
         self.SetFluenceScoringMode(self.fluence_scoring_mode)
         # Set the physical volume name on the C++ side
@@ -1685,11 +1687,13 @@ class FluenceActor(VoxelDepositActor, g4.GateFluenceActor):
         if self.user_output.fluence.get_active():
             self.prepare_output_for_run("fluence", run_index)
             self.push_to_cpp_image("fluence", run_index, self.cpp_fluence_image)
-        
+
         if self.user_output.sum_tracks.get_active():
             self.prepare_output_for_run("sum_tracks", run_index)
-            self.push_to_cpp_image("sum_tracks", run_index, self.cpp_fluence_sum_tracks_image)
-        
+            self.push_to_cpp_image(
+                "sum_tracks", run_index, self.cpp_fluence_sum_tracks_image
+            )
+
         g4.GateFluenceActor.BeginOfRunActionMasterThread(self, run_index)
 
     def EndOfRunActionMasterThread(self, run_index):
@@ -1699,14 +1703,16 @@ class FluenceActor(VoxelDepositActor, g4.GateFluenceActor):
             self.user_output.fluence.store_meta_data(
                 run_index, number_of_samples=self.NbOfEvent
             )
-        
+
         if self.user_output.sum_tracks.get_active():
-            self.fetch_from_cpp_image("sum_tracks", run_index, self.cpp_fluence_sum_tracks_image)
+            self.fetch_from_cpp_image(
+                "sum_tracks", run_index, self.cpp_fluence_sum_tracks_image
+            )
             self._update_output_coordinate_system("sum_tracks", run_index)
             self.user_output.sum_tracks.store_meta_data(
                 run_index, number_of_samples=self.NbOfEvent
             )
-        
+
         VoxelDepositActor.EndOfRunActionMasterThread(self, run_index)
         return 0
 


### PR DESCRIPTION
Implemented the first version of the fluence actor as an extension of the original one.
The user can select which actor to use: myFluenceActor.fluence_scoring_mode = "sum_tracks" #(or "fluence").
Part of this scorer was adapted from the dose actor.

TO DO: 
1. systematic comparison with independent Monte Carlo
2. Improve consistency with other scorers
3. Make tests for this scorer