### PR TITLE
Coincidences fixes

### DIFF
--- a/opengate/actors/coincidences.py
+++ b/opengate/actors/coincidences.py
@@ -475,9 +475,9 @@ def _process_chunk(queue, time_window, allow_intra_volume_coincidences):
         t2 = next_chunk["GlobalTime"]
         t2_min = np.min(t2)
         t2_max = np.max(t2)
-        # Require that the next chunk's time interval is later than
-        # the current chunk's time interval (overlap (t2_min < t1_max) is allowed).
-        if not (t2_min > t1_min and t2_max > t1_max):
+        # Require that the next chunk's time interval starts later than
+        # the start time of the current chunk's time interval.
+        if t2_min <= t1_min:
             raise ChunkSizeTooSmallError
 
     # Find coincidences in the current chunk


### PR DESCRIPTION
@dsarrut @kochebina
Non-monotonicities in the GlobalTime (e.g. because of divergence of GlobalTime in multiple simulation threads) was not properly handled in coincidences.py. This caused the problems that Marcin was running into lately. This has been fixed in this PR. I also fixed code related to writing root output, which was no longer supported since the recent uproot 5.6.7.