### PR TITLE
Add link to GateDigiAttributeList.cpp in documentation

### DIFF
--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -385,7 +385,7 @@ A PhaseSpaceActor stores any set of particles reaching a given volume during the
    f.particle = "gamma"
    phsp.filters.append(f)
 
-In this example, the PhaseSpaceActor will store all particles reaching the given plane. For each particle, some information will be stored, as shown in the attributes array: energy, position, name, time, etc. The list of available attribute names can be found in the file: `GateDigiAttributeList.cpp`.
+In this example, the PhaseSpaceActor will store all particles reaching the given plane. For each particle, some information will be stored, as shown in the attributes array: energy, position, name, time, etc. The list of available attribute names can be found in the file: `GateDigiAttributeList.cpp <https://github.com/OpenGATE/opengate/blob/master/core/opengate_core/opengate_lib/digitizer/GateDigiAttributeList.cpp>`_.
 
 The output is a ROOT file that contains a tree. It can be analyzed, for example, with `uproot`.
 


### PR DESCRIPTION
Add a link to `GateDigiAttributeList.cpp`, which is a file I often search for and refer to.