### PR TITLE
Use cibuildwheel version 3.4.0 for windows

### DIFF
--- a/.github/workflows/actions_build/ci_build_wheel_windows.sh
+++ b/.github/workflows/actions_build/ci_build_wheel_windows.sh
@@ -13,11 +13,7 @@ python --version
 export PATH="/usr/local/miniconda/envs/opengate_core/bin/:$PATH"
 pip install wheel wget colored
 
-if [[ ${MATRIX_PYTHON_VERSION} == "3.14" ]]; then
-    pip install cibuildwheel==3.4.0
-else
-    pip install cibuildwheel==2.21.1
-fi
+pip install cibuildwheel==3.4.0
 
 # For windows 2025, Need to add the certifi CA bundle to avoid SSL errors when downloading dependencies during the build. This is a workaround for cibuildwheel which does not handle this properly on Windows.
 python - << 'EOF'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
         exclude:
           - os: macos-15
             python-version: '3.10'
+          - os: windows-2025
+            python-version: '3.10'
     steps:
     - name: Checkout github repo
       uses: actions/checkout@v6
@@ -98,6 +100,8 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: macos-15
+            python-version: '3.10'
+          - os: windows-2025
             python-version: '3.10'
     steps:
     - name: Checkout github repo
@@ -283,6 +287,8 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: macos-15
+            python-version: '3.10'
+          - os: windows-2025
             python-version: '3.10'
     steps:
     - name: Checkout github repo


### PR DESCRIPTION
With the previous version of cibuildwheel, the build process leads to error. Use the latest