### PR TITLE
Dynamic voxel source

### DIFF
--- a/core/opengate_core/opengate_lib/GateDoseActor.cpp
+++ b/core/opengate_core/opengate_lib/GateDoseActor.cpp
@@ -454,7 +454,11 @@ double GateDoseActor::CalculateSPR(G4Step *step) {
       G4NistManager::Instance()->FindOrBuildMaterial(fScoreInMaterial);
   if (p == G4Gamma::Gamma())
     p = G4Electron::Electron();
-  auto &emc = fThreadLocalDataEdep.Get().emcalc;
+  auto &local = fThreadLocalDataEdep.Get();
+  if (!local.emcalc) {
+    local.emcalc = std::make_unique<G4EmCalculator>();
+  }
+  auto &emc = *local.emcalc;
   dedx_currstep = emc.ComputeTotalDEDX(energy, p, current_material, dedx_cut);
   dedx_material = emc.ComputeTotalDEDX(energy, p, material, dedx_cut);
   if (dedx_currstep != 0 || dedx_material != 0) {

--- a/core/opengate_core/opengate_lib/GateDoseActor.h
+++ b/core/opengate_core/opengate_lib/GateDoseActor.h
@@ -14,6 +14,7 @@
 #include "GateSPRCache.h"
 #include "GateVActor.h"
 #include "itkImage.h"
+#include <memory>
 
 namespace py = pybind11;
 
@@ -108,7 +109,7 @@ public:
   Image3DType::SizeType size_edep{};
 
   struct threadLocalT {
-    G4EmCalculator emcalc;
+    std::unique_ptr<G4EmCalculator> emcalc;
     std::vector<double> squared_worker_flatimg;
     std::vector<int> lastid_worker_flatimg;
   };

--- a/core/opengate_core/opengate_lib/GateFluenceActor.h
+++ b/core/opengate_core/opengate_lib/GateFluenceActor.h
@@ -9,7 +9,6 @@
 #define GateFluenceActor_h
 
 #include "G4Cache.hh"
-#include "G4EmCalculator.hh"
 #include "G4VPrimitiveScorer.hh"
 #include "GateVActor.h"
 #include "digitizer/GateDigiAttributeLastProcessDefinedStepInVolumeActor.h"
@@ -74,7 +73,6 @@ public:
   Image3DType::SizeType size_region{};
 
   struct threadLocalT {
-    G4EmCalculator emcalc;
     std::vector<double> squared_worker_flatimg;
     std::vector<int> lastid_worker_flatimg;
   };

--- a/core/opengate_core/opengate_lib/GateWeightedEdepActor.cpp
+++ b/core/opengate_core/opengate_lib/GateWeightedEdepActor.cpp
@@ -114,13 +114,16 @@ G4double GateWeightedEdepActor::GetMeanEnergy(G4Step *step) {
 G4double GateWeightedEdepActor::GetCurrentDEDX(G4Step *step) {
   double dedx_cut = DBL_MAX;
   auto &l = fThreadLocalData.Get();
+  if (!l.emcalc) {
+    l.emcalc = std::make_unique<G4EmCalculator>();
+  }
   const G4ParticleDefinition *p = step->GetTrack()->GetParticleDefinition();
   if (p == G4Gamma::Gamma()) {
     p = G4Electron::Electron();
   }
 
   auto *current_material = step->GetPreStepPoint()->GetMaterial();
-  auto dedx_currstep = l.emcalc.ComputeElectronicDEDX(
+  auto dedx_currstep = l.emcalc->ComputeElectronicDEDX(
                            l.energy_mean, p, current_material, dedx_cut) /
                        CLHEP::MeV * CLHEP::mm;
   if (std::isnan(dedx_currstep)) {
@@ -132,6 +135,9 @@ G4double GateWeightedEdepActor::GetCurrentDEDX(G4Step *step) {
 G4double GateWeightedEdepActor::GetSPROtherMaterial(G4Step *step) {
   double dedx_cut = DBL_MAX;
   auto &l = fThreadLocalData.Get();
+  if (!l.emcalc) {
+    l.emcalc = std::make_unique<G4EmCalculator>();
+  }
   const G4ParticleDefinition *p = step->GetTrack()->GetParticleDefinition();
   if (p == G4Gamma::Gamma()) {
     p = G4Electron::Electron();
@@ -141,8 +147,8 @@ G4double GateWeightedEdepActor::GetSPROtherMaterial(G4Step *step) {
   // std::cout<< "l.materialToScoreIn: " << l.materialToScoreIn << std::endl;
 
   auto dedx_other_material =
-      l.emcalc.ComputeElectronicDEDX(l.energy_mean, p, l.materialToScoreIn,
-                                     dedx_cut) /
+      l.emcalc->ComputeElectronicDEDX(l.energy_mean, p, l.materialToScoreIn,
+                                      dedx_cut) /
       CLHEP::MeV * CLHEP::mm;
 
   // std::cout<< "dedx_other_material" << dedx_other_material << std::endl;

--- a/core/opengate_core/opengate_lib/GateWeightedEdepActor.h
+++ b/core/opengate_core/opengate_lib/GateWeightedEdepActor.h
@@ -15,6 +15,7 @@
 #include "GateHelpersImage.h"
 #include "GateVActor.h"
 #include "itkImage.h"
+#include <memory>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
@@ -86,7 +87,7 @@ protected:
   bool fScoreInOtherMaterial = false;
 
   struct threadLocalT {
-    G4EmCalculator emcalc;
+    std::unique_ptr<G4EmCalculator> emcalc;
     G4Material *materialToScoreIn;
     G4double energy_mean;
     G4double dedx_currstep;

--- a/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
+++ b/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
@@ -1,0 +1,522 @@
+Dynamic parametrisations
+========================
+
+Overview
+--------
+
+Dynamic parametrisations are the mechanism used in GATE to change the state of
+an object from one ``G4Run`` to the next. Typical examples are:
+
+- moving a volume by changing its translation,
+- rotating a volume,
+- changing the image of an ``ImageVolume``,
+- changing the activity image of a ``VoxelSource``.
+
+The user-facing logic is run-based: a simulation defines
+``run_timing_intervals``, and a dynamic object provides one value per run for
+every dynamic parameter. The framework then applies the appropriate state at
+the beginning of each run.
+
+
+General architecture
+--------------------
+
+The dynamic system has four main building blocks:
+
+1. a dynamic object,
+2. one or more changers,
+3. a hidden dynamic actor,
+4. engine-side wiring which creates and registers that actor.
+
+
+Dynamic objects
+~~~~~~~~~~~~~~~
+
+Objects which support dynamic parametrisations inherit from
+``DynamicGateObject`` in ``opengate/base.py``.
+
+This base class provides:
+
+- the read-only ``dynamic_params`` user info entry,
+- the ``is_dynamic`` property,
+- the ``dynamic_user_info`` property,
+- the ``add_dynamic_parametrisation()`` method,
+- validation against ``simulation.run_timing_intervals``,
+- the ``create_changers()`` hook.
+
+The central idea is that only parameters explicitly declared as dynamic are
+accepted as dynamic user input. A parameter becomes dynamic when its
+``user_info_defaults`` entry contains ``"dynamic": True``.
+
+For example, in a class definition:
+
+.. code-block:: python
+
+   user_info_defaults = {
+       "image": (
+           None,
+           {
+               "doc": "Path to the image file",
+               "is_input_file": True,
+               "dynamic": True,
+           },
+       )
+   }
+
+When the user calls:
+
+.. code-block:: python
+
+   obj.add_dynamic_parametrisation(image=[value_run_0, value_run_1, ...])
+
+``DynamicGateObject`` stores that information in ``dynamic_params``.
+
+
+Processing of dynamic parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``DynamicGateObject.add_dynamic_parametrisation()`` performs a few useful tasks:
+
+- it filters the provided keyword arguments so that only truly dynamic user
+  parameters remain in the dynamic payload,
+- any extra keys are moved to ``extra_params``,
+- callable values are evaluated against
+  ``simulation.run_timing_intervals``,
+- each parametrisation is stored under a generated or user-provided name.
+
+The consistency check is performed by
+``check_if_dynamic_params_match_run_timing_intervals()``. It ensures that every
+dynamic vector has the same length as the simulation's list of timing
+intervals.
+
+
+The ``auto_changer`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dynamic parametrisations also support the special option ``auto_changer``.
+
+This option is handled centrally by ``DynamicGateObject.process_dynamic_parametrisation()``
+in the base class. It is not something each dynamic class needs to reimplement.
+
+The default is:
+
+.. code-block:: python
+
+   auto_changer=True
+
+This means:
+
+- store the dynamic parametrisation as usual,
+- and when ``create_changers()`` is called, use the default changer logic
+  provided by the class.
+
+In other words, ``auto_changer=True`` means "use the changer provided by this
+class".
+
+Examples:
+
+- ``ImageVolume.create_changers()`` creates a ``VolumeImageChanger`` for a
+  dynamic ``image`` parametrisation,
+- ``VoxelSource.create_changers()`` creates a
+  ``SourceActivityImageChanger`` for a dynamic source image.
+
+If the user sets:
+
+.. code-block:: python
+
+   auto_changer=False
+
+the dynamic values are still stored in ``dynamic_params``, but the class should
+not automatically create its default changer for that parametrisation. This is
+meant for advanced use cases where the user wants to provide a custom changer
+manually.
+
+A concrete example can be found in
+``opengate/tests/src/geometry/test071_custom_geometry_changer.py``. That test
+shows how to:
+
+- derive a custom changer from ``GeometryChanger``,
+- create a ``DynamicGeometryActor`` manually,
+- add the custom changers to ``dynamic_geometry_actor.changers``.
+
+The more elaborate example
+``opengate/tests/src/actors/test030_dose_motion_dynamic_param_custom.py`` uses
+the same idea for custom translation and rotation changers.
+
+
+Changers
+~~~~~~~~
+
+Changers are small helper objects responsible for applying one concrete change
+at runtime.
+
+Examples already present in the code base are:
+
+- ``VolumeTranslationChanger``
+- ``VolumeRotationChanger``
+- ``VolumeImageChanger``
+- ``SourceActivityImageChanger``
+
+All changers inherit from ``ChangerBase`` in
+``opengate/actors/dynamicactors.py``. There are two specialized branches:
+
+- ``GeometryChanger`` for volumes,
+- ``SourceChanger`` for sources.
+
+Each changer has an ``apply_change(run_id)`` method. This method is called at
+the beginning of every run and is responsible for applying the state
+corresponding to that run.
+
+The ``attached_to`` user parameter of changers is handled like other GateObject
+parameters and becomes a generated property when ``process_cls()`` is called on
+the changer class.
+
+
+Dynamic actors
+~~~~~~~~~~~~~~
+
+The actual runtime update is performed by hidden actors:
+
+- ``DynamicGeometryActor``
+- ``DynamicSourceActor``
+
+Both derive from ``DynamicActorBase`` in
+``opengate/actors/dynamicactors.py`` and register the Geant4 hook
+``BeginOfRunActionMasterThread``.
+
+At the beginning of each run, the actor loops over its list of changers and
+calls ``apply_change(run_id)``.
+
+For geometry, ``DynamicGeometryActor`` may temporarily open and close the
+geometry around the update. For sources, ``DynamicSourceActor`` simply forwards
+the run id to its changers.
+
+
+Engine-side wiring
+~~~~~~~~~~~~~~~~~~
+
+The engines create the hidden dynamic actors automatically.
+
+For volumes:
+
+- ``VolumeEngine.initialize_dynamic_parametrisations()``
+- iterates over ``volume_manager.dynamic_volumes``
+- validates their dynamic parameter lengths
+- creates a ``DynamicGeometryActor`` if needed
+- collects changers from ``volume.create_changers()``
+
+For sources:
+
+- ``SourceEngine.initialize_dynamic_parametrisations()``
+- iterates over ``source_manager.dynamic_sources``
+- validates their dynamic parameter lengths
+- creates a ``DynamicSourceActor`` if needed
+- collects changers from ``source.create_changers()``
+
+So the usual pattern is:
+
+1. mark a user parameter as dynamic,
+2. let the object expose changers via ``create_changers()``,
+3. let the engine instantiate the corresponding hidden actor.
+
+
+Examples in the existing code base
+----------------------------------
+
+Dynamic geometry
+~~~~~~~~~~~~~~~~
+
+``VolumeBase`` supports dynamic translation and rotation. ``ImageVolume`` adds
+support for a dynamic ``image`` parameter.
+
+The ``ImageVolume`` implementation is a good example of a full dynamic object:
+
+- ``image`` is declared with ``dynamic=True``,
+- ``create_changers()`` builds a ``VolumeImageChanger``,
+- the changer switches the label image at run boundaries,
+- ``DynamicGeometryActor`` applies the change in
+  ``BeginOfRunActionMasterThread``.
+
+
+Dynamic voxel source
+~~~~~~~~~~~~~~~~~~~~
+
+``VoxelSource`` supports a dynamic ``image`` parameter for the activity map.
+
+The implementation follows the same pattern:
+
+- ``image`` is declared dynamic,
+- ``VoxelSource.create_changers()`` creates a
+  ``SourceActivityImageChanger``,
+- the changer calls ``VoxelSource.update_activity_image(...)``,
+- the source reloads the image, updates geometry information, and recomputes
+  its CDFs,
+- ``DynamicSourceActor`` applies the change at the beginning of each run.
+
+
+How to make a parameter dynamic
+-------------------------------
+
+This section describes the minimal steps needed to make a parameter dynamic in a
+new object type.
+
+
+1. Inherit from ``DynamicGateObject``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the class is not already dynamic, make it inherit from ``DynamicGateObject``
+or from a parent class which already does so.
+
+This gives the class access to:
+
+- ``add_dynamic_parametrisation()``
+- ``dynamic_params``
+- ``create_changers()``
+
+
+2. Mark the parameter as dynamic in ``user_info_defaults``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the ``user_info_defaults`` entry of the parameter, add:
+
+.. code-block:: python
+
+   "dynamic": True
+
+Example:
+
+.. code-block:: python
+
+   user_info_defaults = {
+       "my_parameter": (
+           default_value,
+           {
+               "doc": "Description of the parameter.",
+               "dynamic": True,
+           },
+       )
+   }
+
+Without this flag, ``add_dynamic_parametrisation(my_parameter=...)`` will not
+store the parameter as dynamic input.
+
+
+3. Implement the runtime change in ``apply_change()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The actual runtime entry point is the changer method:
+
+.. code-block:: python
+
+   def apply_change(self, run_id):
+       ...
+
+This method is called by the hidden dynamic actor at the beginning of each run.
+Its job is to apply the state corresponding to ``run_id``.
+
+There are two common patterns:
+
+- the changer performs the update directly,
+- the changer delegates to a dedicated update method on the object side.
+
+Two concrete examples from the current code base:
+
+Volume-side example: direct update in the changer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For dynamic translations and rotations, the update is performed directly inside
+the changer. The changer resolves the target physical volume and applies the
+new Geant4 transform for the current run.
+
+For example, ``VolumeTranslationChanger.apply_change()`` does:
+
+.. code-block:: python
+
+   def apply_change(self, run_id):
+       if self.g4_physical_volume is None:
+           self.g4_physical_volume = self.attached_to_volume.get_g4_physical_volume(
+               self.repetition_index
+           )
+       self.g4_physical_volume.SetTranslation(self.g4_translations[run_id])
+
+This is a good pattern when the change is local and simple:
+
+- prepare Geant4-compatible values in ``initialize()``,
+- resolve the target G4 object lazily,
+- apply the run-specific value directly in ``apply_change(run_id)``.
+
+Source-side example: delegate to an object update method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For ``VoxelSource``, changing the dynamic ``image`` parameter is heavier than a
+simple assignment because the source sampling machinery depends on the image
+content. In that case, the changer delegates to a method implemented on the
+object itself.
+
+``SourceActivityImageChanger.apply_change()`` does:
+
+.. code-block:: python
+
+   def apply_change(self, run_id):
+       self.attached_to_source.update_activity_image(self.activity_images[run_id])
+
+The actual work is then performed by
+``VoxelSource.update_activity_image(filename)``, which:
+
+- loads the new ITK image,
+- updates the image transform information used by the C++ position generator,
+- recomputes the cumulative distribution functions.
+
+Conceptually:
+
+.. code-block:: python
+
+   def update_activity_image(self, filename):
+       self._current_itk_image = itk.imread(ensure_filename_is_str(filename))
+       self.set_transform_from_user_info()
+       self.cumulative_distribution_functions()
+
+This is a good pattern when the update requires more than a simple runtime
+assignment, for example:
+
+- loading a new image,
+- refreshing derived metadata,
+- rebuilding cached lookup tables or CDFs,
+- pushing image information to C++ objects.
+
+
+4. Implement or extend ``create_changers()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``create_changers()`` is where the object translates stored dynamic
+parametrisations into changer instances.
+
+Typical pattern:
+
+.. code-block:: python
+
+   def create_changers(self):
+       changers = super().create_changers()
+       for dp in self.dynamic_params.values():
+           if dp["extra_params"]["auto_changer"] is True:
+               if "my_parameter" in dp:
+                   changers.append(
+                       MyParameterChanger(
+                           name=f"{self.name}_my_parameter_changer_{len(changers)}",
+                           attached_to=self,
+                           simulation=self.simulation,
+                           values=dp["my_parameter"],
+                       )
+                   )
+       return changers
+
+If ``auto_changer`` is set to ``False``, the user is responsible for creating
+and wiring the changer manually.
+
+
+5. Implement the changer class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The changer should inherit from either ``GeometryChanger`` or ``SourceChanger``
+when possible, or from ``ChangerBase`` if neither fits.
+
+Minimal example:
+
+.. code-block:: python
+
+   class MyParameterChanger(GeometryChanger):
+       user_info_defaults = {
+           "values": (
+               None,
+               {
+                   "doc": "One value per run.",
+               },
+           ),
+       }
+
+       def apply_change(self, run_id):
+           self.attached_to_volume.update_my_parameter(self.values[run_id])
+
+
+6. Call ``process_cls()`` on the new class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Like other GateObject-derived classes, changer classes must be processed by the
+class factory mechanism:
+
+.. code-block:: python
+
+   process_cls(MyParameterChanger)
+
+This step creates the GateObject-style properties from ``user_info_defaults``.
+Without it, parameters such as ``attached_to`` or ``values`` will not behave as
+expected.
+
+
+7. Make sure the relevant engine knows how to instantiate the hidden actor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your object is a volume or a source and you reuse the existing
+``DynamicGeometryActor`` or ``DynamicSourceActor``, no new engine logic is
+needed beyond returning changers from ``create_changers()``.
+
+If you introduce a new family of dynamic objects, you will need the equivalent
+of:
+
+- a manager property like ``dynamic_sources`` or ``dynamic_volumes``,
+- an engine method which validates dynamic parameter lengths,
+- creation of a hidden actor,
+- collection of changers from the dynamic objects.
+
+
+Common pitfalls
+---------------
+
+Initialization order
+~~~~~~~~~~~~~~~~~~~~
+
+Be careful with checks which run before ``G4RunManager.Initialize()``.
+
+For example, actor initialization currently happens before geometry
+construction. If a check touches geometry- or image-dependent properties too
+early, it may observe a partially initialized object. A concrete example is a
+check on an attached ``ImageVolume`` which touches image-derived properties
+before ``ImageVolume.construct()`` has loaded the input image.
+
+
+Validation
+~~~~~~~~~~
+
+Do not forget to validate the number of dynamic values against
+``run_timing_intervals``. The framework already provides this through
+``check_if_dynamic_params_match_run_timing_intervals()``, but the relevant
+engine must call it.
+
+
+Keep the changer small
+~~~~~~~~~~~~~~~~~~~~~~
+
+The changer should usually only:
+
+- resolve the target object,
+- pick the value corresponding to ``run_id``,
+- call a well-defined update method on that object.
+
+Heavy logic is usually better kept in the object itself.
+
+
+Summary
+-------
+
+To make a parameter dynamic:
+
+1. make sure the object is a ``DynamicGateObject``,
+2. mark the parameter with ``dynamic=True``,
+3. implement the runtime update logic on the object,
+4. expose one or more changers via ``create_changers()``,
+5. process the changer class with ``process_cls()``,
+6. rely on the engine to create a hidden dynamic actor which applies the
+   changes at ``BeginOfRunActionMasterThread``.
+
+This architecture keeps the user-facing API simple while keeping the runtime
+logic generic and reusable.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -14,6 +14,7 @@ Developer guide
 
    developer_guide_code_structure
    developer_guide_how_to_implement
+   developer_guide_dynamic_parametrisations
 
 .. toctree::
    :caption: Good to know

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -18,6 +18,7 @@ User Guide
    user_guide_volumes
    user_guide_physics
    user_guide_sources
+   user_guide_dynamic_parametrisations
    user_guide_actors
    user_guide_fields
 

--- a/docs/source/user_guide/user_guide_dynamic_parametrisations.rst
+++ b/docs/source/user_guide/user_guide_dynamic_parametrisations.rst
@@ -1,0 +1,239 @@
+Dynamic parametrisations
+========================
+
+Dynamic parametrisations provide a user-facing way to change parts of a
+simulation from one run to the next. They are used for dynamic geometry, such
+as moving or rotating volumes, and also for dynamic sources, such as a
+``VoxelSource`` whose activity image changes over time.
+
+The key idea is simple:
+
+- a simulation is split into several internal runs,
+- each run corresponds to one time interval,
+- a dynamic object provides one value per run for each dynamic parameter.
+
+
+Run timing intervals
+--------------------
+
+The temporal structure of a dynamic simulation is defined by
+``sim.run_timing_intervals``.
+
+Example:
+
+.. code-block:: python
+
+   sec = gate.g4_units.s
+
+   sim.run_timing_intervals = [
+       (0.0 * sec, 0.5 * sec),
+       (0.5 * sec, 1.0 * sec),
+       (1.5 * sec, 2.0 * sec),
+   ]
+
+Each tuple corresponds to one Geant4 run. The intervals do not need to be
+continuous: gaps are allowed.
+
+For dynamic parametrisations, the important rule is:
+
+- if there are ``N`` run timing intervals, there must be ``N`` values for each
+  dynamic parameter.
+
+
+General user interface
+----------------------
+
+Dynamic objects use the method:
+
+.. code-block:: python
+
+   obj.add_dynamic_parametrisation(...)
+
+The arguments of this method are the dynamic parameters and their values for
+each run.
+
+For example, a translation evolving over three runs could be specified as:
+
+.. code-block:: python
+
+   box.add_dynamic_parametrisation(
+       translation=[
+           [0 * mm, 0 * mm, 0 * mm],
+           [5 * mm, 0 * mm, 0 * mm],
+           [10 * mm, 0 * mm, 0 * mm],
+       ]
+   )
+
+The same interface is used for other dynamic parameters, such as rotation or
+image.
+
+
+Dynamic geometry
+----------------
+
+Moving a volume
+~~~~~~~~~~~~~~~
+
+Volumes can be moved dynamically by providing one translation per run:
+
+.. code-block:: python
+
+   import opengate as gate
+
+   sim = gate.Simulation()
+   mm = gate.g4_units.mm
+   sec = gate.g4_units.s
+
+   sim.run_timing_intervals = [
+       (0.0 * sec, 1.0 * sec),
+       (1.0 * sec, 2.0 * sec),
+       (2.0 * sec, 3.0 * sec),
+   ]
+
+   box = sim.add_volume("Box", "moving_box")
+   box.size = [50 * mm, 50 * mm, 50 * mm]
+   box.material = "G4_WATER"
+
+   box.add_dynamic_parametrisation(
+       translation=[
+           [0 * mm, 0 * mm, 0 * mm],
+           [10 * mm, 0 * mm, 0 * mm],
+           [20 * mm, 0 * mm, 0 * mm],
+       ]
+   )
+
+Rotating a volume
+~~~~~~~~~~~~~~~~~
+
+Rotations follow the same pattern. One rotation matrix is provided per run:
+
+.. code-block:: python
+
+   from scipy.spatial.transform import Rotation
+
+   rot0 = Rotation.from_euler("z", 0, degrees=True).as_matrix()
+   rot1 = Rotation.from_euler("z", 20, degrees=True).as_matrix()
+   rot2 = Rotation.from_euler("z", 40, degrees=True).as_matrix()
+
+   box.add_dynamic_parametrisation(
+       rotation=[rot0, rot1, rot2]
+   )
+
+Translation and rotation can also be combined in a single dynamic
+parametrisation.
+
+
+Dynamic image volumes
+---------------------
+
+``ImageVolume`` also supports a dynamic ``image`` parameter. This allows, for
+example, the use of a 4D CT where the image changes from run to run.
+
+.. code-block:: python
+
+   patient = sim.add_volume("Image", "patient")
+   patient.image = "ct_0.mhd"
+   patient.material = "G4_AIR"
+   patient.voxel_materials = [[0, 10000, "G4_WATER"]]
+
+   patient.add_dynamic_parametrisation(
+       image=[
+           "ct_0.mhd",
+           "ct_1.mhd",
+           "ct_2.mhd",
+       ]
+   )
+
+This uses the same interface as dynamic translations and rotations: one value
+per run.
+
+
+Dynamic voxel source
+--------------------
+
+``VoxelSource`` supports a dynamic ``image`` parameter for the activity map.
+This means that the source distribution can change from one run to the next
+while keeping the same source object.
+
+Example:
+
+.. code-block:: python
+
+   source = sim.add_source("VoxelSource", "vox_source")
+   source.attached_to = patient.name
+   source.particle = "alpha"
+   source.image = "activity_0.mhd"
+   source.direction.type = "iso"
+   source.energy.mono = 1 * MeV
+   source.n = [2000, 2000, 2000]
+
+   source.add_dynamic_parametrisation(
+       image=[
+           "activity_0.mhd",
+           "activity_1.mhd",
+           "activity_2.mhd",
+       ]
+   )
+
+This follows the same user interface as the dynamic image of an
+``ImageVolume``.
+
+
+Aligning activity and CT images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the activity image and the CT image share the same image coordinate
+system, the voxel source should usually be translated so that both image centers
+match in the GATE convention.
+
+This can be done with:
+
+.. code-block:: python
+
+   source.position.translation = gate.image.get_translation_between_images_center(
+       patient.image, "activity_0.mhd"
+   )
+
+See also the voxel source reference page for additional details on image
+alignment.
+
+
+Automatic changers
+------------------
+
+In the normal user workflow, no extra setup is needed beyond
+``add_dynamic_parametrisation(...)``. For supported dynamic parameters, GATE
+creates and configures the required runtime changer automatically.
+
+So for most users, dynamic parametrisations are simply:
+
+1. define ``sim.run_timing_intervals``,
+2. call ``add_dynamic_parametrisation(...)``,
+3. provide one value per run.
+
+Advanced users can also create custom changers manually, but this is typically
+not needed for standard moving-geometry or dynamic-voxel-source use cases.
+
+
+Per-run output
+--------------
+
+When a simulation contains dynamic components, it is often useful to retrieve
+actor outputs separately for each run.
+
+Many outputs support this with:
+
+.. code-block:: python
+
+   actor_output.keep_data_per_run = True
+
+This is particularly useful to inspect how a moving geometry or changing source
+affects the result from one run to the next.
+
+
+See also
+--------
+
+- :doc:`user_guide_reference_simulation`
+- :doc:`user_guide_reference_volumes`
+- :doc:`user_guide_reference_sources_voxel_source`

--- a/docs/source/user_guide/user_guide_dynamic_parametrisations.rst
+++ b/docs/source/user_guide/user_guide_dynamic_parametrisations.rst
@@ -155,6 +155,12 @@ Dynamic voxel source
 This means that the source distribution can change from one run to the next
 while keeping the same source object.
 
+The image is used as a relative spatial activity distribution for position
+sampling. Scaling all voxel values by the same constant does not change the
+total emitted activity; it leaves the same normalized spatial distribution.
+The total source strength is controlled separately by ``activity``,
+``half_life``, TAC parameters, or ``n``.
+
 Example:
 
 .. code-block:: python

--- a/docs/source/user_guide/user_guide_reference_simulation.rst
+++ b/docs/source/user_guide/user_guide_reference_simulation.rst
@@ -15,6 +15,10 @@ Run and timing
 
 The simulation can be split into several runs, each of them with a given time duration. This is used for example for simulations with a dynamic geometry, e.g. a rotating gantry or a breathing patient. Gaps between the intervals are allowed. By default, the simulation has only one run with a duration of 1 second.
 
+See also :doc:`user_guide_dynamic_parametrisations` for the user-facing dynamic
+parametrisation interface used by moving geometries, dynamic image volumes, and
+dynamic voxel sources.
+
 Splitting a simulation into multiple runs is faster than executing a simulation multiple times because Geant4 is initialized only once at the beginning.
 
 In the following example, we define 3 runs, the first has a duration of half a second and starts at 0, the 2nd run goes from 0.5 to 1 second. The 3rd run starts later at 1.5 seconds and lasts 1 second.

--- a/docs/source/user_guide/user_guide_reference_sources_voxel_source.rst
+++ b/docs/source/user_guide/user_guide_reference_sources_voxel_source.rst
@@ -27,6 +27,10 @@ voxel is chosen from this distribution, the location of the particle
 inside the voxel is performed uniformly. In the given example, 4 kBq of
 electrons of 140 keV will be generated.
 
+The activity image can also be made dynamic from one run to the next with
+``source.add_dynamic_parametrisation(image=[...])``. See
+:doc:`user_guide_dynamic_parametrisations`.
+
 Like all objects, by default, the source is located according to the
 coordinate system of its attached_to volume. For example, if the attached_to
 volume is a box, it will be the center of the box. If it is a voxelized

--- a/docs/source/user_guide/user_guide_reference_sources_voxel_source.rst
+++ b/docs/source/user_guide/user_guide_reference_sources_voxel_source.rst
@@ -27,6 +27,12 @@ voxel is chosen from this distribution, the location of the particle
 inside the voxel is performed uniformly. In the given example, 4 kBq of
 electrons of 140 keV will be generated.
 
+The voxel image is therefore used as a relative spatial activity
+distribution for position sampling. Scaling all voxel values by the same
+constant does not change the total emitted activity; it leaves the same
+normalized spatial distribution. The total source strength is controlled
+separately by ``activity``, ``half_life``, or ``n``.
+
 The activity image can also be made dynamic from one run to the next with
 ``source.add_dynamic_parametrisation(image=[...])``. See
 :doc:`user_guide_dynamic_parametrisations`.

--- a/docs/source/user_guide/user_guide_sources.rst
+++ b/docs/source/user_guide/user_guide_sources.rst
@@ -65,3 +65,7 @@ Geant4 creates primary particles *ex nihilo*, i.e. out of nothing anywhere in th
     source2.attached_to = my_gantry
 
 Whenver the volume ``my_gantry`` moves, the source will move with it.
+
+If you want the source itself to change from run to run, for example by using a
+different activity image in a ``VoxelSource``, see
+:doc:`user_guide_dynamic_parametrisations`.

--- a/opengate/actors/actoroutput.py
+++ b/opengate/actors/actoroutput.py
@@ -135,7 +135,7 @@ class BaseUserInterfaceToActorOutput:
         e.g. which=2 for run index 2 (run indices start at 0).
         """
         kwargs.update(self._kwargs_for_interface_calls)
-        return self._user_output.get_data(**kwargs)
+        return self._user_output.get_data(which=which, **kwargs)
 
     @property
     def write_to_disk(self):

--- a/opengate/actors/dataitems.py
+++ b/opengate/actors/dataitems.py
@@ -10,6 +10,7 @@ from ..image import (
     divide_itk_images,
     multiply_itk_images,
     scale_itk_image,
+    copy_itk_image,
     create_3d_image,
     write_itk_image,
     get_info_from_image,
@@ -241,8 +242,10 @@ class ItkImageDataItem(DataItem):
         return itk.array_view_from_image(self.image)
 
     def inplace_merge_with(self, other):
+        if other.data is None:
+            return self
         if self.data is None:
-            self.set_data(other.data)
+            self.set_data(copy_itk_image(other.data))
             self.number_of_samples = other.number_of_samples
         else:
             self.__iadd__(other)
@@ -767,10 +770,8 @@ class QuotientMeanItkImage(QuotientItkImage):
 
 
 def merge_data(list_of_data):
-    merged_data = type(list_of_data[0])(
-        list_of_data[0].belongs_to, data=list_of_data[0].data
-    )
-    for d in list_of_data[1:]:
+    merged_data = type(list_of_data[0])(list_of_data[0].belongs_to)
+    for d in list_of_data:
         merged_data.inplace_merge_with(d)
     return merged_data
 

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -172,9 +172,9 @@ class SourceChanger(ChangerBase):
             return None
 
     @property
-    @requires_fatal("volume_manager")
+    @requires_fatal("source_manager")
     def attached_to_source(self):
-        return self.source_manager[self.attached_to]
+        return self.source_manager.get_source(self.attached_to)
 
 
 class VolumeImageChanger(GeometryChanger):
@@ -326,8 +326,13 @@ class SourceActivityImageChanger(SourceChanger):
         self.attached_to_source.update_activity_image(self.activity_images[run_id])
 
 
+process_cls(DynamicActorBase)
 process_cls(DynamicGeometryActor)
+process_cls(DynamicSourceActor)
+process_cls(ChangerBase)
 process_cls(GeometryChanger)
+process_cls(SourceChanger)
 process_cls(VolumeImageChanger)
 process_cls(VolumeTranslationChanger)
 process_cls(VolumeRotationChanger)
+process_cls(SourceActivityImageChanger)

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -60,6 +60,21 @@ class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
             gm.CloseGeometry(self.simulation.dyn_geom_optimise, False, None)
 
 
+class DynamicSourceActor(DynamicActorBase, g4.GateVActor):
+
+    def initialize(self):
+        ActorBase.initialize(self)
+        for c in self.source_changers:
+            if c.source_manager is None:
+                c.source_manager = self.simulation.source_manager
+            c.initialize()
+
+    def BeginOfRunActionMasterThread(self, run_id):
+        # FIXME: check if source engine needs to be informed
+        for c in self.source_changers:
+            c.apply_change(run_id)
+
+
 def _setter_hook_attached_to(self, value):
     # try to pick up the simulation from the attached_to volume
     try:
@@ -147,6 +162,19 @@ class GeometryChanger(ChangerBase):
         return self.volume_manager.get_volume(self.attached_to)
 
 
+class SourceChanger(ChangerBase):
+
+    @property
+    def source_manager(self):
+        if self.simulation is not None:
+            return self.simulation.source_manager
+        else:
+            return None
+
+    @property
+    @requires_fatal("volume_manager")
+    def attached_to_source(self):
+        return self.source_manager[self.attached_to]
 
 
 class VolumeImageChanger(GeometryChanger):
@@ -278,6 +306,24 @@ class VolumeRotationChanger(GeometryChanger):
                 self.repetition_index
             )
         self.g4_physical_volume.SetRotationHepRep3x3(self.g4_rotations[run_id])
+
+
+class SourceActivityImageChanger(SourceChanger): 
+
+        # hints for IDE
+    activity_images: Optional[list]
+
+    user_info_defaults = {
+        "activity_images": (
+            None,
+            {
+                "doc": "List of activity map file names corresponding to the run timing intervals. ",
+            },
+        ),
+    }
+
+    def apply_change(self, run_id):
+        self.attached_to_source.update_activity_image(self.activity_images[run_id])
 
 
 process_cls(DynamicGeometryActor)

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -42,7 +42,7 @@ class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
 
     def initialize(self):
         ActorBase.initialize(self)
-        for c in self.geometry_changers:
+        for c in self.changers:
             if c.volume_manager is None:
                 c.volume_manager = self.simulation.volume_manager
             c.initialize()
@@ -54,7 +54,7 @@ class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
             gm.RequestParallelOptimisation(False, False)
             # OpenGeometry (G4VPhysicalVolume *vol=0)
             gm.OpenGeometry(None)
-        for c in self.geometry_changers:
+        for c in self.changers:
             c.apply_change(run_id)
         if self.simulation.dyn_geom_open_close:
             # CloseGeometry: pOptimise=true, verbose=false, G4VPhysicalVolume *vol=0
@@ -65,14 +65,14 @@ class DynamicSourceActor(DynamicActorBase, g4.GateVActor):
 
     def initialize(self):
         ActorBase.initialize(self)
-        for c in self.source_changers:
+        for c in self.changers:
             if c.source_manager is None:
                 c.source_manager = self.simulation.source_manager
             c.initialize()
 
     def BeginOfRunActionMasterThread(self, run_id):
         # FIXME: check if source engine needs to be informed
-        for c in self.source_changers:
+        for c in self.changers:
             c.apply_change(run_id)
 
 

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -37,6 +37,7 @@ class DynamicActorBase(ActorBase, g4.GateVActor):
     def initialize(self):
         ActorBase.initialize(self)
 
+
 class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
 
     def initialize(self):
@@ -144,7 +145,6 @@ class ChangerBase(GateObject):
             f"You are trying to call the method in the base class {type(self)}, "
             f"but it is only available in classes inheriting from it. "
         )
-
 
 
 class GeometryChanger(ChangerBase):
@@ -308,9 +308,9 @@ class VolumeRotationChanger(GeometryChanger):
         self.g4_physical_volume.SetRotationHepRep3x3(self.g4_rotations[run_id])
 
 
-class SourceActivityImageChanger(SourceChanger): 
+class SourceActivityImageChanger(SourceChanger):
 
-        # hints for IDE
+    # hints for IDE
     activity_images: Optional[list]
 
     user_info_defaults = {

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -9,12 +9,12 @@ from .base import ActorBase
 from ..decorators import requires_fatal
 
 
-class DynamicGeometryActor(ActorBase, g4.GateVActor):
+class DynamicActorBase(ActorBase, g4.GateVActor):
 
     def __init__(self, *args, **kwargs):
         kwargs["attached_to"] = __world_name__
         ActorBase.__init__(self, *args, **kwargs)
-        self.geometry_changers = []
+        self.changers = []
         self.__initcpp__()
 
     def __initcpp__(self):
@@ -22,17 +22,22 @@ class DynamicGeometryActor(ActorBase, g4.GateVActor):
         self.AddActions({"BeginOfRunActionMasterThread"})
 
     def close(self):
-        for c in self.geometry_changers:
+        for c in self.changers:
             c.close()
-        self.geometry_changers = []
+        self.changers = []
         super().close()
 
     def to_dictionary(self):
         return_dict = super().to_dictionary()
-        return_dict["geometry_changers"] = dict(
-            [(v.name, v.to_dictionary()) for v in self.geometry_changers]
+        return_dict["changers"] = dict(
+            [(v.name, v.to_dictionary()) for v in self.changers]
         )
         return return_dict
+
+    def initialize(self):
+        ActorBase.initialize(self)
+
+class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
 
     def initialize(self):
         ActorBase.initialize(self)
@@ -78,7 +83,7 @@ def _setter_hook_attached_to(self, value):
         return value
 
 
-class GeometryChanger(GateObject):
+class ChangerBase(GateObject):
 
     # hints for IDE
     attached_to: Optional[str]
@@ -115,6 +120,20 @@ class GeometryChanger(GateObject):
         if simulation is not None:
             self.simulation = simulation
 
+    def initialize(self):
+        # dummy implementation - nothing to do in the general case
+        pass
+
+    def apply_change(self, run_id):
+        raise NotImplementedError(
+            f"You are trying to call the method in the base class {type(self)}, "
+            f"but it is only available in classes inheriting from it. "
+        )
+
+
+
+class GeometryChanger(ChangerBase):
+
     @property
     def volume_manager(self):
         if self.simulation is not None:
@@ -127,15 +146,7 @@ class GeometryChanger(GateObject):
     def attached_to_volume(self):
         return self.volume_manager.get_volume(self.attached_to)
 
-    def initialize(self):
-        # dummy implementation - nothing to do in the general case
-        pass
 
-    def apply_change(self, run_id):
-        raise NotImplementedError(
-            f"You are trying to call the method in the base class {type(self)}, "
-            f"but it is only available in classes inheriting from it. "
-        )
 
 
 class VolumeImageChanger(GeometryChanger):

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -117,6 +117,19 @@ class SourceEngine(EngineBase):
             self.simulation_engine.simulation.actor_manager.sorted_actors
         )
 
+    def initialize_dynamic_parametrisations(self):
+        dynamic_sources = self.source_manager.dynamic_sources
+        for s in self.source_manager.dynamic_sources:
+            s.check_if_dynamic_params_match_run_timing_intervals()
+        if len(dynamic_sources) > 0:
+            dynamic_source_actor = self.simulation_engine.simulation.add_actor(
+                "DynamicSourceActor", "dynamic_source_actor"
+            )
+            dynamic_source_actor.priority = 1
+            for s in self.source_manager.dynamic_sources:
+                dynamic_source_actor.source_changers.extend(s.create_changers())
+
+
     def create_master_source_manager(self):
         # create the master source for the masterThread
         self.g4_master_source_manager = self.create_g4_thread_source_manager(

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -84,6 +84,10 @@ class SourceEngine(EngineBase):
         # FIXME: Why is this separate dictionary needed? Would be better to access the source manager directly
         self.source_manager_options = Box()
 
+    @property
+    def source_manager(self): 
+        return self.simulation_engine.simulation.source_manager
+
     def close(self):
         if self.verbose_close:
             warning("Closing SourceEngine")

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -85,7 +85,7 @@ class SourceEngine(EngineBase):
         self.source_manager_options = Box()
 
     @property
-    def source_manager(self): 
+    def source_manager(self):
         return self.simulation_engine.simulation.source_manager
 
     def close(self):
@@ -128,7 +128,6 @@ class SourceEngine(EngineBase):
             dynamic_source_actor.priority = 1
             for s in self.source_manager.dynamic_sources:
                 dynamic_source_actor.source_changers.extend(s.create_changers())
-
 
     def create_master_source_manager(self):
         # create the master source for the masterThread

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -108,6 +108,7 @@ class SourceEngine(EngineBase):
         #        "No source: no particle will be generated"
         #    )
         self.progress_bar = progress_bar
+        self.initialize_dynamic_parametrisations()
 
     def initialize_actors(self):
         """

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -662,6 +662,11 @@ class ActorEngine(EngineBase):
         super().close()
 
     def initialize(self):
+        # TODO: Split actor initialization into before/after G4RunManager initialization phases.
+        # Some early checks currently run before geometry construction and can touch
+        # image-dependent properties too soon. For example, DoseActor.check_user_input()
+        # may access attached_to_volume.native_translation/native_rotation while the
+        # attached ImageVolume has not loaded its input image yet.
         for actor in self.actor_manager.sorted_actors:
             logger.debug(f"Actor: initialize [{actor.type_name}] {actor.name}")
             # self.simulation_engine.action_engine.register_all_actions(actor)

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -128,7 +128,7 @@ class SourceEngine(EngineBase):
             )
             dynamic_source_actor.priority = 1
             for s in self.source_manager.dynamic_sources:
-                dynamic_source_actor.source_changers.extend(s.create_changers())
+                dynamic_source_actor.changers.extend(s.create_changers())
 
     def create_master_source_manager(self):
         # create the master source for the masterThread
@@ -878,7 +878,7 @@ class VolumeEngine(g4.G4VUserDetectorConstruction, EngineBase):
             )
             dynamic_geometry_actor.priority = 0
             for vol in self.volume_manager.dynamic_volumes:
-                dynamic_geometry_actor.geometry_changers.extend(vol.create_changers())
+                dynamic_geometry_actor.changers.extend(vol.create_changers())
 
     def Construct(self):
         """

--- a/opengate/image.py
+++ b/opengate/image.py
@@ -368,6 +368,10 @@ def scale_itk_image(img, scale):
     return img2
 
 
+def copy_itk_image(img):
+    return itk.image_duplicator(img)
+
+
 def divide_itk_images(
     img1_numerator, img2_denominator, filterVal=0, replaceFilteredVal=0
 ):

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -337,6 +337,10 @@ class SourceManager(GateObject):
             )
             return None  # to avoid warning
 
+    @property
+    def dynamic_sources(self):
+        return [source for source in self.sources.values() if source.is_dynamic]
+
     def add_source(self, source, name):
         new_source = None
         if isinstance(source, str):

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -96,7 +96,7 @@ from .actors.pgactors import (
     VoxelizedPromptGammaAnalogActor,
 )
 
-from .actors.dynamicactors import DynamicGeometryActor
+from .actors.dynamicactors import DynamicGeometryActor, DynamicSourceActor
 from .actors.arfactors import ARFActor, ARFTrainingDatasetActor
 from .actors.miscactors import (
     SimulationStatisticsActor,
@@ -155,6 +155,7 @@ actor_types = {
     "KillAccordingProcessesActor": KillAccordingProcessesActor,
     "DepositedChargeActor": DepositedChargeActor,
     "DynamicGeometryActor": DynamicGeometryActor,
+    "DynamicSourceActor": DynamicSourceActor,
     "ARFActor": ARFActor,
     "ARFTrainingDatasetActor": ARFTrainingDatasetActor,
     # digit

--- a/opengate/sources/base.py
+++ b/opengate/sources/base.py
@@ -1,13 +1,13 @@
 import numpy as np
 
 from ..actors.base import _setter_hook_attached_to
-from ..base import GateObject, process_cls
+from ..base import GateObject, DynamicGateObject, process_cls
 from ..utility import g4_units
 from ..definitions import __world_name__
 from ..exception import fatal, warning
 
 
-class SourceBase(GateObject):
+class SourceBase(DynamicGateObject):
     """
     Base class for all source types.
     """

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -29,7 +29,6 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
                 "(will be automatically normalized to sum=1)",
                 "is_input_file": True,
                 "dynamic": True,
-
             },
         )
     }
@@ -90,7 +89,7 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
         pg = self.GetSPSVoxelPosDistribution()
         pg.SetCumulativeDistributionFunction(cdf_z, cdf_y, cdf_x)
 
-    def update_activity_image(self, filename): 
+    def update_activity_image(self, filename):
         # read source image
         self.itk_image = itk.imread(ensure_filename_is_str(self.image))
 
@@ -99,7 +98,6 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
 
         # create Cumulative Distribution Function
         self.cumulative_distribution_functions()
-
 
     def initialize(self, run_timing_intervals):
         self.update_activity_image(self.image)

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -7,8 +7,9 @@ from ..image import (
     update_image_py_to_cpp,
     compute_image_3D_CDF,
 )
-from ..utility import ensure_filename_is_str
+from ..utility import ensure_filename_is_str, warning
 from ..base import process_cls
+from ..actors.dynamicactors import SourceActivityImageChanger
 
 
 class VoxelSource(GenericSource, g4.GateVoxelSource):
@@ -27,6 +28,8 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
                 "doc": "Filename of the image of the 3D activity distribution "
                 "(will be automatically normalized to sum=1)",
                 "is_input_file": True,
+                "dynamic": True,
+
             },
         )
     }
@@ -39,6 +42,25 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
 
     def __initcpp__(self):
         g4.GateVoxelSource.__init__(self)
+
+    def create_changers(self):
+        changers = super().create_changers()
+        for dp in self.dynamic_params.values():
+            if dp["extra_params"]["auto_changer"] is True:
+                if "image" in dp:
+                    new_changer = SourceActivityImageChanger(
+                        name=f"{self.name}_source_activity_changer_{len(changers)}",
+                        activity_images=dp["image"],
+                        attached_to=self,
+                        simulation=self.simulation,
+                    )
+                    changers.append(new_changer)
+            else:
+                self.warning(
+                    f"You need to manually create a changer for dynamic parametrisation {dp} "
+                    f"of source '{self.name}'."
+                )
+        return changers
 
     def set_transform_from_user_info(self):
         # get source image information
@@ -68,7 +90,7 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
         pg = self.GetSPSVoxelPosDistribution()
         pg.SetCumulativeDistributionFunction(cdf_z, cdf_y, cdf_x)
 
-    def initialize(self, run_timing_intervals):
+    def update_activity_image(self, filename): 
         # read source image
         self.itk_image = itk.imread(ensure_filename_is_str(self.image))
 
@@ -77,6 +99,10 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
 
         # create Cumulative Distribution Function
         self.cumulative_distribution_functions()
+
+
+    def initialize(self, run_timing_intervals):
+        self.update_activity_image(self.image)
 
         # FIXME -> check other option in position not used here
 

--- a/opengate/sources/voxelsources.py
+++ b/opengate/sources/voxelsources.py
@@ -3,7 +3,7 @@ import itk
 import opengate_core as g4
 from .generic import GenericSource
 from ..image import (
-    read_image_info,
+    get_info_from_image,
     update_image_py_to_cpp,
     compute_image_3D_CDF,
 )
@@ -37,7 +37,7 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
         self.__initcpp__()
         super().__init__(self, *args, **kwargs)
         # the loaded image
-        self.itk_image = None
+        self._current_itk_image = None
 
     def __initcpp__(self):
         g4.GateVoxelSource.__init__(self)
@@ -62,12 +62,11 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
         return changers
 
     def set_transform_from_user_info(self):
-        # get source image information
-        src_info = read_image_info(str(self.image))
+        src_info = get_info_from_image(self._current_itk_image)
         # get the pointer to SPSVoxelPosDistribution
         pg = self.GetSPSVoxelPosDistribution()
         # update cpp image info (no need to allocate)
-        update_image_py_to_cpp(self.itk_image, pg.cpp_edep_image, False)
+        update_image_py_to_cpp(self._current_itk_image, pg.cpp_edep_image, False)
         # set spacing
         pg.cpp_edep_image.set_spacing(src_info.spacing)
         # set origin (half size + translation and half-pixel shift)
@@ -83,7 +82,7 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
         Compute the Cumulative Distribution Function of the image
         Composed of: CDF_Z = 1D, CDF_Y = 2D, CDF_X = 3D
         """
-        cdf_x, cdf_y, cdf_z = compute_image_3D_CDF(self.itk_image)
+        cdf_x, cdf_y, cdf_z = compute_image_3D_CDF(self._current_itk_image)
 
         # set CDF to the position generator
         pg = self.GetSPSVoxelPosDistribution()
@@ -91,7 +90,7 @@ class VoxelSource(GenericSource, g4.GateVoxelSource):
 
     def update_activity_image(self, filename):
         # read source image
-        self.itk_image = itk.imread(ensure_filename_is_str(self.image))
+        self._current_itk_image = itk.imread(ensure_filename_is_str(filename))
 
         # compute position
         self.set_transform_from_user_info()

--- a/opengate/tests/src/actors/test030_dose_motion_dynamic_param_custom.py
+++ b/opengate/tests/src/actors/test030_dose_motion_dynamic_param_custom.py
@@ -170,8 +170,8 @@ if __name__ == "__main__":
     # add a DynamicGeometryActor to the simulation
     dyn_geo_actor = sim.add_actor("DynamicGeometryActor", name="dyn_geo_actor")
     # ... and add the changers to the actor
-    dyn_geo_actor.geometry_changers.append(translation_changer)
-    dyn_geo_actor.geometry_changers.append(rotation_changer)
+    dyn_geo_actor.changers.append(translation_changer)
+    dyn_geo_actor.changers.append(rotation_changer)
 
     # start simulation
     sim.run()

--- a/opengate/tests/src/geometry/test071_custom_geometry_changer.py
+++ b/opengate/tests/src/geometry/test071_custom_geometry_changer.py
@@ -62,8 +62,8 @@ if __name__ == "__main__":
     # create a DynamicGeometryActor and add the changers to it
     # you only need one of them and
     dyngeoactor = sim.add_actor("DynamicGeometryActor", name="dyngeoactor")
-    dyngeoactor.geometry_changers.append(my_changer_for_sphere)
-    dyngeoactor.geometry_changers.append(my_changer_for_box)
+    dyngeoactor.changers.append(my_changer_for_sphere)
+    dyngeoactor.changers.append(my_changer_for_box)
 
     source = sim.add_source("GenericSource", "proton_source")
     source.energy.mono = 100 * MeV

--- a/opengate/tests/src/source/test097_dynamic_voxel_source.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source.py
@@ -117,9 +117,7 @@ if __name__ == "__main__":
         ct.image, source_image_1_path
     )
     source.energy.mono = 1 * MeV
-    source.add_dynamic_parametrisation(
-        image=[source_image_1_path, source_image_2_path]
-    )
+    source.add_dynamic_parametrisation(image=[source_image_1_path, source_image_2_path])
 
     changer = SourceActivityImageChanger(
         name="source_activity_image_changer",
@@ -146,7 +144,9 @@ if __name__ == "__main__":
 
     run_0_image = dose.edep.get_data(which=0)
     run_1_image = dose.edep.get_data(which=1)
-    plot_run_dose_planes(run_0_image, run_1_image, paths.output / "test097_dose_planes.png")
+    plot_run_dose_planes(
+        run_0_image, run_1_image, paths.output / "test097_dose_planes.png"
+    )
     run_0_primary_dose = run_0_image.GetPixel(run_0_primary_peak_xyz)
     run_0_secondary_dose = run_0_image.GetPixel(run_0_secondary_peak_xyz)
     run_1_primary_dose = run_1_image.GetPixel(run_1_primary_peak_xyz)

--- a/opengate/tests/src/source/test097_dynamic_voxel_source.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import itk
+import numpy as np
+
+import opengate as gate
+from opengate.actors.dynamicactors import SourceActivityImageChanger
+from opengate.tests import utility
+
+
+def create_activity_image(reference_image, peak_weights, output_path):
+    array = np.zeros_like(itk.array_view_from_image(reference_image), dtype=np.float32)
+    for peak_index, weight in peak_weights.items():
+        array[peak_index] = weight
+    image = itk.image_from_array(array)
+    image.CopyInformation(reference_image)
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+def create_reference_image(output_path):
+    array = np.zeros((10, 10, 10), dtype=np.float32)
+    image = itk.image_from_array(array)
+    image.SetSpacing([1.0, 1.0, 1.0])
+    image.SetOrigin([0.0, 0.0, 0.0])
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test097")
+
+    sim = gate.Simulation()
+    sim.g4_verbose = False
+    sim.visu = False
+    sim.number_of_threads = 1
+    sim.random_seed = 123456
+    sim.output_dir = paths.output
+
+    m = gate.g4_units.m
+    mm = gate.g4_units.mm
+    MeV = gate.g4_units.MeV
+    sec = gate.g4_units.s
+
+    sim.volume_manager.add_material_database(paths.data / "GateMaterials.db")
+    sim.world.size = [1 * m, 1 * m, 1 * m]
+
+    ct_image_path = paths.output / "ct_image.mhd"
+    ct_itk = create_reference_image(ct_image_path)
+
+    ct = sim.add_volume("Image", "ct")
+    ct.image = str(ct_image_path)
+    ct.material = "G4_AIR"
+    ct.voxel_materials = [[0, 10, "G4_WATER"]]
+
+    ct_info = gate.image.read_image_info(ct.image)
+
+    source_image_1_path = paths.output / "dynamic_source_1.mhd"
+    source_image_2_path = paths.output / "dynamic_source_2.mhd"
+    run_0_primary_peak = (5, 5, 2)
+    run_0_secondary_peak = (5, 2, 2)
+    run_1_primary_peak = (5, 5, 7)
+    run_1_secondary_peak = (5, 2, 7)
+    run_0_expected_ratio = 3.0
+    run_1_expected_ratio = 4.0
+    create_activity_image(
+        ct_itk,
+        {
+            run_0_primary_peak: run_0_expected_ratio,
+            run_0_secondary_peak: 1.0,
+        },
+        source_image_1_path,
+    )
+    create_activity_image(
+        ct_itk,
+        {
+            run_1_primary_peak: run_1_expected_ratio,
+            run_1_secondary_peak: 1.0,
+        },
+        source_image_2_path,
+    )
+
+    source = sim.add_source("VoxelSource", "vox_source")
+    source.attached_to = ct.name
+    source.particle = "alpha"
+    source.n = [2000, 2000]
+    source.image = str(source_image_1_path)
+    source.direction.type = "iso"
+    source.position.translation = gate.image.get_translation_between_images_center(
+        ct.image, source_image_1_path
+    )
+    source.energy.mono = 1 * MeV
+    source.add_dynamic_parametrisation(
+        image=[source_image_1_path, source_image_2_path]
+    )
+
+    changer = SourceActivityImageChanger(
+        name="source_activity_image_changer",
+        activity_images=[source_image_1_path, source_image_2_path],
+        attached_to=source,
+        simulation=sim,
+    )
+
+    dose = sim.add_actor("DoseActor", "dose")
+    dose.attached_to = ct.name
+    dose.size = ct_info.size
+    dose.spacing = ct_info.spacing
+    dose.output_coordinate_system = "attached_to_image"
+    dose.edep.keep_data_per_run = True
+
+    sim.add_actor("SimulationStatisticsActor", "stats")
+
+    sim.physics_manager.physics_list_name = "QGSP_BERT_EMZ"
+    sim.physics_manager.enable_decay = False
+    sim.physics_manager.global_production_cuts.all = 1 * mm
+    sim.run_timing_intervals = [(0, 0.5 * sec), (0.5 * sec, 1 * sec)]
+
+    sim.run()
+
+    run_0 = itk.array_view_from_image(dose.edep.get_data(which=0))
+    run_1 = itk.array_view_from_image(dose.edep.get_data(which=1))
+    run_0_peak = np.unravel_index(np.argmax(run_0), run_0.shape)
+    run_1_peak = np.unravel_index(np.argmax(run_1), run_1.shape)
+    run_0_primary_dose = run_0[run_0_primary_peak]
+    run_0_secondary_dose = run_0[run_0_secondary_peak]
+    run_1_primary_dose = run_1[run_1_primary_peak]
+    run_1_secondary_dose = run_1[run_1_secondary_peak]
+    run_0_ratio = run_0_primary_dose / run_0_secondary_dose
+    run_1_ratio = run_1_primary_dose / run_1_secondary_dose
+    ratio_tolerance = 0.6
+
+    is_ok = True
+    utility.print_test(
+        changer.attached_to == source.name,
+        f"Changer attached_to property resolves to source name: {changer.attached_to}",
+    )
+    is_ok = changer.attached_to == source.name and is_ok
+
+    utility.print_test(
+        run_0_peak == run_0_primary_peak,
+        f"Run 0 peak at {run_0_peak}, expected {run_0_primary_peak}",
+    )
+    is_ok = run_0_peak == run_0_primary_peak and is_ok
+
+    utility.print_test(
+        run_1_peak == run_1_primary_peak,
+        f"Run 1 peak at {run_1_peak}, expected {run_1_primary_peak}",
+    )
+    is_ok = run_1_peak == run_1_primary_peak and is_ok
+
+    utility.print_test(
+        abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance,
+        f"Run 0 dose ratio {run_0_ratio:.2f}, expected {run_0_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.print_test(
+        abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance,
+        f"Run 1 dose ratio {run_1_ratio:.2f}, expected {run_1_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.test_ok(is_ok)

--- a/opengate/tests/src/source/test097_dynamic_voxel_source.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source.py
@@ -120,6 +120,9 @@ if __name__ == "__main__":
     source.energy.mono = 1 * MeV
     source.add_dynamic_parametrisation(image=[source_image_1_path, source_image_2_path])
 
+    # Explicit manual changer creation is only used here to test the changer API.
+    # Normal user scripts should rely on add_dynamic_parametrisation(...), which
+    # auto-creates the SourceActivityImageChanger.
     changer = SourceActivityImageChanger(
         name="source_activity_image_changer",
         activity_images=[source_image_1_path, source_image_2_path],

--- a/opengate/tests/src/source/test097_dynamic_voxel_source.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import itk
+import matplotlib.pyplot as plt
 import numpy as np
 
 import opengate as gate
@@ -9,10 +10,14 @@ from opengate.actors.dynamicactors import SourceActivityImageChanger
 from opengate.tests import utility
 
 
+def xyz_to_zyx(index_xyz):
+    return tuple(reversed(index_xyz))
+
+
 def create_activity_image(reference_image, peak_weights, output_path):
     array = np.zeros_like(itk.array_view_from_image(reference_image), dtype=np.float32)
-    for peak_index, weight in peak_weights.items():
-        array[peak_index] = weight
+    for peak_index_xyz, weight in peak_weights.items():
+        array[xyz_to_zyx(peak_index_xyz)] = weight
     image = itk.image_from_array(array)
     image.CopyInformation(reference_image)
     itk.imwrite(image, str(output_path))
@@ -26,6 +31,28 @@ def create_reference_image(output_path):
     image.SetOrigin([0.0, 0.0, 0.0])
     itk.imwrite(image, str(output_path))
     return image
+
+
+def plot_run_dose_planes(run_0_image, run_1_image, output_path):
+    run_0_array = itk.array_view_from_image(run_0_image)
+    run_1_array = itk.array_view_from_image(run_1_image)
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4), constrained_layout=True)
+    plane_index = 5
+    images = [
+        axes[0].imshow(run_0_array[plane_index, :, :], origin="lower"),
+        axes[1].imshow(run_1_array[plane_index, :, :], origin="lower"),
+    ]
+    titles = ["Run 0 dose, z=5", "Run 1 dose, z=5"]
+
+    for ax, image, title in zip(axes, images, titles):
+        ax.set_title(title)
+        ax.set_xlabel("x index")
+        ax.set_ylabel("y index")
+        fig.colorbar(image, ax=ax)
+
+    fig.savefig(output_path)
+    plt.close(fig)
 
 
 if __name__ == "__main__":
@@ -53,30 +80,29 @@ if __name__ == "__main__":
     ct.image = str(ct_image_path)
     ct.material = "G4_AIR"
     ct.voxel_materials = [[0, 10, "G4_WATER"]]
-
     ct_info = gate.image.read_image_info(ct.image)
 
     source_image_1_path = paths.output / "dynamic_source_1.mhd"
     source_image_2_path = paths.output / "dynamic_source_2.mhd"
-    run_0_primary_peak = (5, 5, 2)
-    run_0_secondary_peak = (5, 2, 2)
-    run_1_primary_peak = (5, 5, 7)
-    run_1_secondary_peak = (5, 2, 7)
+    run_0_primary_peak_xyz = (2, 5, 5)
+    run_0_secondary_peak_xyz = (2, 2, 5)
+    run_1_primary_peak_xyz = (7, 5, 5)
+    run_1_secondary_peak_xyz = (7, 2, 5)
     run_0_expected_ratio = 3.0
     run_1_expected_ratio = 4.0
     create_activity_image(
         ct_itk,
         {
-            run_0_primary_peak: run_0_expected_ratio,
-            run_0_secondary_peak: 1.0,
+            run_0_primary_peak_xyz: run_0_expected_ratio,
+            run_0_secondary_peak_xyz: 1.0,
         },
         source_image_1_path,
     )
     create_activity_image(
         ct_itk,
         {
-            run_1_primary_peak: run_1_expected_ratio,
-            run_1_secondary_peak: 1.0,
+            run_1_primary_peak_xyz: run_1_expected_ratio,
+            run_1_secondary_peak_xyz: 1.0,
         },
         source_image_2_path,
     )
@@ -118,14 +144,15 @@ if __name__ == "__main__":
 
     sim.run()
 
-    run_0 = itk.array_view_from_image(dose.edep.get_data(which=0))
-    run_1 = itk.array_view_from_image(dose.edep.get_data(which=1))
-    run_0_peak = np.unravel_index(np.argmax(run_0), run_0.shape)
-    run_1_peak = np.unravel_index(np.argmax(run_1), run_1.shape)
-    run_0_primary_dose = run_0[run_0_primary_peak]
-    run_0_secondary_dose = run_0[run_0_secondary_peak]
-    run_1_primary_dose = run_1[run_1_primary_peak]
-    run_1_secondary_dose = run_1[run_1_secondary_peak]
+    run_0_image = dose.edep.get_data(which=0)
+    run_1_image = dose.edep.get_data(which=1)
+    plot_run_dose_planes(run_0_image, run_1_image, paths.output / "test097_dose_planes.png")
+    run_0_primary_dose = run_0_image.GetPixel(run_0_primary_peak_xyz)
+    run_0_secondary_dose = run_0_image.GetPixel(run_0_secondary_peak_xyz)
+    run_1_primary_dose = run_1_image.GetPixel(run_1_primary_peak_xyz)
+    run_1_secondary_dose = run_1_image.GetPixel(run_1_secondary_peak_xyz)
+    run_0_other_primary_dose = run_0_image.GetPixel(run_1_primary_peak_xyz)
+    run_1_other_primary_dose = run_1_image.GetPixel(run_0_primary_peak_xyz)
     run_0_ratio = run_0_primary_dose / run_0_secondary_dose
     run_1_ratio = run_1_primary_dose / run_1_secondary_dose
     ratio_tolerance = 0.6
@@ -138,26 +165,26 @@ if __name__ == "__main__":
     is_ok = changer.attached_to == source.name and is_ok
 
     utility.print_test(
-        run_0_peak == run_0_primary_peak,
-        f"Run 0 peak at {run_0_peak}, expected {run_0_primary_peak}",
+        run_0_primary_dose > 5.0 * run_0_other_primary_dose,
+        f"Run 0 primary voxel dose {run_0_primary_dose:.2f} dominates inactive run 1 voxel {run_0_other_primary_dose:.2f}",
     )
-    is_ok = run_0_peak == run_0_primary_peak and is_ok
+    is_ok = run_0_primary_dose > 5.0 * run_0_other_primary_dose and is_ok
 
     utility.print_test(
-        run_1_peak == run_1_primary_peak,
-        f"Run 1 peak at {run_1_peak}, expected {run_1_primary_peak}",
+        run_1_primary_dose > 5.0 * run_1_other_primary_dose,
+        f"Run 1 primary voxel dose {run_1_primary_dose:.2f} dominates inactive run 0 voxel {run_1_other_primary_dose:.2f}",
     )
-    is_ok = run_1_peak == run_1_primary_peak and is_ok
+    is_ok = run_1_primary_dose > 5.0 * run_1_other_primary_dose and is_ok
 
     utility.print_test(
         abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance,
-        f"Run 0 dose ratio {run_0_ratio:.2f}, expected {run_0_expected_ratio:.2f}",
+        f"Run 0 dose ratio at xyz {run_0_primary_peak_xyz}/{run_0_secondary_peak_xyz}: {run_0_ratio:.2f}, expected {run_0_expected_ratio:.2f}",
     )
     is_ok = abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance and is_ok
 
     utility.print_test(
         abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance,
-        f"Run 1 dose ratio {run_1_ratio:.2f}, expected {run_1_expected_ratio:.2f}",
+        f"Run 1 dose ratio at xyz {run_1_primary_peak_xyz}/{run_1_secondary_peak_xyz}: {run_1_ratio:.2f}, expected {run_1_expected_ratio:.2f}",
     )
     is_ok = abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance and is_ok
 

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_half_life.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_half_life.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+
+import itk
+import matplotlib.pyplot as plt
+import numpy as np
+
+import opengate as gate
+from opengate.actors.dynamicactors import SourceActivityImageChanger
+from opengate.tests import utility
+
+
+def xyz_to_zyx(index_xyz):
+    return tuple(reversed(index_xyz))
+
+
+def create_activity_image(reference_image, peak_weights, output_path):
+    array = np.zeros_like(itk.array_view_from_image(reference_image), dtype=np.float32)
+    for peak_index_xyz, weight in peak_weights.items():
+        array[xyz_to_zyx(peak_index_xyz)] = weight
+    image = itk.image_from_array(array)
+    image.CopyInformation(reference_image)
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+def create_reference_image(output_path):
+    array = np.zeros((10, 10, 10), dtype=np.float32)
+    image = itk.image_from_array(array)
+    image.SetSpacing([1.0, 1.0, 1.0])
+    image.SetOrigin([0.0, 0.0, 0.0])
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+def world_positions_to_voxel_indices(positions_xyz, image_info, source_translation):
+    source_origin = (
+        -image_info.size / 2.0 * image_info.spacing
+        + np.array(source_translation, dtype=float)
+        + image_info.spacing / 2.0
+    )
+    indices = np.floor((positions_xyz - source_origin) / image_info.spacing + 0.5)
+    return indices.astype(int)
+
+
+def count_indices(indices_xyz):
+    return Counter(map(tuple, indices_xyz))
+
+
+def plot_event_positions_and_decay(
+    run_0_positions_xyz,
+    run_1_positions_xyz,
+    run_0_decay_times_sec,
+    run_1_decay_times_sec,
+    fit_x_0,
+    fit_y_0,
+    fit_x_1,
+    fit_y_1,
+    output_path,
+):
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4), constrained_layout=True)
+
+    axes[0].scatter(run_0_positions_xyz[:, 0], run_0_positions_xyz[:, 1], s=2)
+    axes[0].set_title("Run 0 event positions")
+    axes[0].set_xlabel("x [mm]")
+    axes[0].set_ylabel("y [mm]")
+    axes[0].set_aspect("equal", adjustable="box")
+
+    axes[1].scatter(run_1_positions_xyz[:, 0], run_1_positions_xyz[:, 1], s=2)
+    axes[1].set_title("Run 1 event positions")
+    axes[1].set_xlabel("x [mm]")
+    axes[1].set_ylabel("y [mm]")
+    axes[1].set_aspect("equal", adjustable="box")
+
+    axes[2].hist(
+        run_0_decay_times_sec, bins="auto", density=True, alpha=0.6, label="run 0"
+    )
+    axes[2].hist(
+        run_1_decay_times_sec, bins="auto", density=True, alpha=0.6, label="run 1"
+    )
+    axes[2].plot(fit_x_0, fit_y_0, label="fit run 0")
+    axes[2].plot(fit_x_1, fit_y_1, label="fit run 1")
+    axes[2].set_title("Event times by run")
+    axes[2].set_xlabel("time [s]")
+    axes[2].set_ylabel("density")
+    axes[2].legend()
+
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+def plot_decay_fit(
+    all_event_times_sec,
+    all_bin_edges,
+    fit_x_0,
+    fit_y_0,
+    fit_x_1,
+    fit_y_1,
+    nominal_x,
+    nominal_y,
+    output_path,
+):
+    fig, ax = plt.subplots(1, 1, figsize=(9, 4), constrained_layout=True)
+    ax.hist(all_event_times_sec, bins=all_bin_edges, alpha=0.7, label="events")
+    ax.plot(fit_x_0, fit_y_0, label="fit run 0", linewidth=2)
+    ax.plot(fit_x_1, fit_y_1, label="fit run 1", linewidth=2)
+    ax.plot(nominal_x, nominal_y, label="nominal decay", linewidth=2, linestyle="--")
+    ax.set_title("Event times with run-wise fits and nominal decay")
+    ax.set_xlabel("time [s]")
+    ax.set_ylabel("counts")
+    ax.legend()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test097")
+
+    sim = gate.Simulation()
+    sim.g4_verbose = False
+    sim.visu = False
+    sim.number_of_threads = 1
+    sim.random_seed = 123456
+    sim.output_dir = paths.output
+
+    m = gate.g4_units.m
+    mm = gate.g4_units.mm
+    keV = gate.g4_units.keV
+    Bq = gate.g4_units.Bq
+    sec = gate.g4_units.s
+
+    sim.volume_manager.add_material_database(paths.data / "GateMaterials.db")
+    sim.world.size = [1 * m, 1 * m, 1 * m]
+
+    ct_image_path = paths.output / "ct_image.mhd"
+    ct_itk = create_reference_image(ct_image_path)
+
+    ct = sim.add_volume("Image", "ct")
+    ct.image = str(ct_image_path)
+    ct.material = "G4_AIR"
+    ct.voxel_materials = [[0, 10, "G4_WATER"]]
+    ct.load_input_image()
+
+    source_image_1_path = paths.output / "dynamic_source_1.mhd"
+    source_image_2_path = paths.output / "dynamic_source_2.mhd"
+    run_0_primary_peak_xyz = (2, 5, 5)
+    run_0_secondary_peak_xyz = (2, 2, 5)
+    run_1_primary_peak_xyz = (7, 5, 5)
+    run_1_secondary_peak_xyz = (7, 2, 5)
+    run_0_expected_ratio = 3.0
+    run_1_expected_ratio = 4.0
+    create_activity_image(
+        ct_itk,
+        {
+            run_0_primary_peak_xyz: run_0_expected_ratio,
+            run_0_secondary_peak_xyz: 1.0,
+        },
+        source_image_1_path,
+    )
+    create_activity_image(
+        ct_itk,
+        {
+            run_1_primary_peak_xyz: run_1_expected_ratio,
+            run_1_secondary_peak_xyz: 1.0,
+        },
+        source_image_2_path,
+    )
+    source_info = gate.image.read_image_info(str(source_image_1_path))
+
+    source = sim.add_source("VoxelSource", "vox_source")
+    source.attached_to = ct.name
+    source.particle = "gamma"
+    source.activity = 50000 * Bq
+    source.half_life = 2 * sec
+    source.image = str(source_image_1_path)
+    source.direction.type = "iso"
+    source.position.translation = gate.image.get_translation_between_images_center(
+        ct.image, source_image_1_path
+    )
+    source.energy.mono = 140 * keV
+    source.add_dynamic_parametrisation(image=[source_image_1_path, source_image_2_path])
+
+    # Explicit manual changer creation is only used here to test the changer API.
+    # Normal user scripts should rely on add_dynamic_parametrisation(...), which
+    # auto-creates the SourceActivityImageChanger.
+    changer = SourceActivityImageChanger(
+        name="source_activity_image_changer",
+        activity_images=[source_image_1_path, source_image_2_path],
+        attached_to=source,
+        simulation=sim,
+    )
+
+    stats = sim.add_actor("SimulationStatisticsActor", "stats")
+    stats.track_types_flag = True
+
+    phsp = sim.add_actor("PhaseSpaceActor", "phsp")
+    phsp.attributes = ["EventPosition", "GlobalTime", "RunID"]
+    phsp.steps_to_store = "first"
+    phsp.output_filename = "test097_dynamic_voxel_source_half_life.root"
+
+    sim.physics_manager.physics_list_name = "QGSP_BERT_EMZ"
+    sim.physics_manager.enable_decay = False
+    sim.physics_manager.global_production_cuts.all = 1 * mm
+    sim.run_timing_intervals = [(0, 2.5 * sec), (3.0 * sec, 5.5 * sec)]
+
+    sim.run()
+
+    root_data, _ = utility.open_root_as_np(phsp.get_output_path(), "phsp")
+    event_times_sec = root_data["GlobalTime"] / sec
+    run_ids = root_data["RunID"]
+    event_positions_xyz = np.column_stack(
+        (
+            root_data["EventPosition_X"],
+            root_data["EventPosition_Y"],
+            root_data["EventPosition_Z"],
+        )
+    )
+    event_indices_xyz = world_positions_to_voxel_indices(
+        event_positions_xyz, source_info, source.position.translation
+    )
+
+    run_0_mask = run_ids == 0
+    run_1_mask = run_ids == 1
+    run_0_indices = event_indices_xyz[run_0_mask]
+    run_1_indices = event_indices_xyz[run_1_mask]
+    run_0_positions = event_positions_xyz[run_0_mask]
+    run_1_positions = event_positions_xyz[run_1_mask]
+    run_0_event_times_sec = event_times_sec[run_0_mask]
+    run_1_event_times_sec = event_times_sec[run_1_mask]
+    run_0_counts = count_indices(run_0_indices)
+    run_1_counts = count_indices(run_1_indices)
+
+    run_0_primary_counts = run_0_counts[run_0_primary_peak_xyz]
+    run_0_secondary_counts = run_0_counts[run_0_secondary_peak_xyz]
+    run_1_primary_counts = run_1_counts[run_1_primary_peak_xyz]
+    run_1_secondary_counts = run_1_counts[run_1_secondary_peak_xyz]
+    run_0_other_primary_counts = run_0_counts[run_1_primary_peak_xyz]
+    run_1_other_primary_counts = run_1_counts[run_0_primary_peak_xyz]
+
+    run_0_ratio = run_0_primary_counts / run_0_secondary_counts
+    run_1_ratio = run_1_primary_counts / run_1_secondary_counts
+    ratio_tolerance = 0.7
+
+    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = utility.fit_exponential_decay(
+        run_0_event_times_sec, 0.0, 2.5
+    )
+    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = utility.fit_exponential_decay(
+        run_1_event_times_sec, 3.0, 5.5
+    )
+    expected_half_life_sec = source.half_life / sec
+    half_life_run_0_relative_error = (
+        abs(fitted_half_life_run_0_sec - expected_half_life_sec) / expected_half_life_sec
+    )
+    half_life_run_1_relative_error = (
+        abs(fitted_half_life_run_1_sec - expected_half_life_sec) / expected_half_life_sec
+    )
+    half_life_difference_relative_error = (
+        abs(fitted_half_life_run_0_sec - fitted_half_life_run_1_sec) / expected_half_life_sec
+    )
+    half_life_tolerance = 0.10
+
+    combined_counts, combined_bin_edges = np.histogram(event_times_sec, bins="auto")
+    combined_bin_width = np.mean(np.diff(combined_bin_edges))
+    fit_y_0 = fit_y_0_density * len(run_0_event_times_sec) * combined_bin_width
+    fit_y_1 = fit_y_1_density * len(run_1_event_times_sec) * combined_bin_width
+
+    nominal_x = np.linspace(0.0, 5.5, 300)
+    nominal_decay_constant = np.log(2.0) / expected_half_life_sec
+    nominal_y = (
+        source.activity / Bq * np.exp(-nominal_decay_constant * nominal_x) * combined_bin_width
+    )
+
+    plot_event_positions_and_decay(
+        run_0_positions,
+        run_1_positions,
+        run_0_event_times_sec,
+        run_1_event_times_sec,
+        fit_x_0,
+        fit_y_0_density,
+        fit_x_1,
+        fit_y_1_density,
+        paths.output / "test097_dynamic_voxel_source_half_life.png",
+    )
+    plot_decay_fit(
+        event_times_sec,
+        combined_bin_edges,
+        fit_x_0,
+        fit_y_0,
+        fit_x_1,
+        fit_y_1,
+        nominal_x,
+        nominal_y,
+        paths.output / "test097_dynamic_voxel_source_half_life_decay.png",
+    )
+
+    is_ok = True
+    utility.print_test(
+        changer.attached_to == source.name,
+        f"Changer attached_to property resolves to source name: {changer.attached_to}",
+    )
+    is_ok = changer.attached_to == source.name and is_ok
+
+    utility.print_test(
+        stats.counts.runs == len(sim.run_timing_intervals),
+        f"Stats runs count {stats.counts.runs} matches number of timing intervals",
+    )
+    is_ok = stats.counts.runs == len(sim.run_timing_intervals) and is_ok
+
+    utility.print_test(
+        run_0_other_primary_counts == 0,
+        f"Run 0 contains no events in inactive run 1 primary voxel: {run_0_other_primary_counts}",
+    )
+    is_ok = run_0_other_primary_counts == 0 and is_ok
+
+    utility.print_test(
+        run_1_other_primary_counts == 0,
+        f"Run 1 contains no events in inactive run 0 primary voxel: {run_1_other_primary_counts}",
+    )
+    is_ok = run_1_other_primary_counts == 0 and is_ok
+
+    utility.print_test(
+        abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance,
+        f"Run 0 event-count ratio at xyz {run_0_primary_peak_xyz}/{run_0_secondary_peak_xyz}: {run_0_ratio:.2f}, expected {run_0_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.print_test(
+        abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance,
+        f"Run 1 event-count ratio at xyz {run_1_primary_peak_xyz}/{run_1_secondary_peak_xyz}: {run_1_ratio:.2f}, expected {run_1_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.print_test(
+        half_life_run_0_relative_error < half_life_tolerance,
+        f"Run 0 half life {expected_half_life_sec:.2f} sec vs fitted {fitted_half_life_run_0_sec:.2f} sec",
+    )
+    is_ok = half_life_run_0_relative_error < half_life_tolerance and is_ok
+
+    utility.print_test(
+        half_life_run_1_relative_error < half_life_tolerance,
+        f"Run 1 half life {expected_half_life_sec:.2f} sec vs fitted {fitted_half_life_run_1_sec:.2f} sec",
+    )
+    is_ok = half_life_run_1_relative_error < half_life_tolerance and is_ok
+
+    utility.print_test(
+        half_life_difference_relative_error < half_life_tolerance,
+        f"Run 0/1 fitted half lives agree: {fitted_half_life_run_0_sec:.2f} sec vs {fitted_half_life_run_1_sec:.2f} sec",
+    )
+    is_ok = half_life_difference_relative_error < half_life_tolerance and is_ok
+
+    utility.test_ok(is_ok)

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_half_life.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_half_life.py
@@ -243,21 +243,24 @@ if __name__ == "__main__":
     run_1_ratio = run_1_primary_counts / run_1_secondary_counts
     ratio_tolerance = 0.7
 
-    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = utility.fit_exponential_decay(
-        run_0_event_times_sec, 0.0, 2.5
+    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = (
+        utility.fit_exponential_decay(run_0_event_times_sec, 0.0, 2.5)
     )
-    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = utility.fit_exponential_decay(
-        run_1_event_times_sec, 3.0, 5.5
+    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = (
+        utility.fit_exponential_decay(run_1_event_times_sec, 3.0, 5.5)
     )
     expected_half_life_sec = source.half_life / sec
     half_life_run_0_relative_error = (
-        abs(fitted_half_life_run_0_sec - expected_half_life_sec) / expected_half_life_sec
+        abs(fitted_half_life_run_0_sec - expected_half_life_sec)
+        / expected_half_life_sec
     )
     half_life_run_1_relative_error = (
-        abs(fitted_half_life_run_1_sec - expected_half_life_sec) / expected_half_life_sec
+        abs(fitted_half_life_run_1_sec - expected_half_life_sec)
+        / expected_half_life_sec
     )
     half_life_difference_relative_error = (
-        abs(fitted_half_life_run_0_sec - fitted_half_life_run_1_sec) / expected_half_life_sec
+        abs(fitted_half_life_run_0_sec - fitted_half_life_run_1_sec)
+        / expected_half_life_sec
     )
     half_life_tolerance = 0.10
 
@@ -269,7 +272,10 @@ if __name__ == "__main__":
     nominal_x = np.linspace(0.0, 5.5, 300)
     nominal_decay_constant = np.log(2.0) / expected_half_life_sec
     nominal_y = (
-        source.activity / Bq * np.exp(-nominal_decay_constant * nominal_x) * combined_bin_width
+        source.activity
+        / Bq
+        * np.exp(-nominal_decay_constant * nominal_x)
+        * combined_bin_width
     )
 
     plot_event_positions_and_decay(

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
@@ -56,12 +56,12 @@ def plot_run_dose_planes(run_0_image, run_1_image, output_path):
 
 
 if __name__ == "__main__":
-    paths = utility.get_default_test_paths(__file__, output_folder="test097")
+    paths = utility.get_default_test_paths(__file__, output_folder="test097_mt")
 
     sim = gate.Simulation()
     sim.g4_verbose = False
     sim.visu = False
-    sim.number_of_threads = 1
+    sim.number_of_threads = 2
     sim.random_seed = 123456
     sim.output_dir = paths.output
 
@@ -80,8 +80,8 @@ if __name__ == "__main__":
     ct.image = str(ct_image_path)
     ct.material = "G4_AIR"
     ct.voxel_materials = [[0, 10, "G4_WATER"]]
-    ct_info = gate.image.read_image_info(ct.image)
     ct.load_input_image()
+    ct_info = gate.image.read_image_info(ct.image)
 
     source_image_1_path = paths.output / "dynamic_source_1.mhd"
     source_image_2_path = paths.output / "dynamic_source_2.mhd"
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     dose.output_coordinate_system = "attached_to_image"
     dose.edep.keep_data_per_run = True
 
-    sim.add_actor("SimulationStatisticsActor", "stats")
+    stats = sim.add_actor("SimulationStatisticsActor", "stats")
 
     sim.physics_manager.physics_list_name = "QGSP_BERT_EMZ"
     sim.physics_manager.enable_decay = False
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     run_0_image = dose.edep.get_data(which=0)
     run_1_image = dose.edep.get_data(which=1)
     plot_run_dose_planes(
-        run_0_image, run_1_image, paths.output / "test097_dose_planes.png"
+        run_0_image, run_1_image, paths.output / "test097_dynamic_voxel_source_mt_dose_planes.png"
     )
     run_0_primary_dose = run_0_image.GetPixel(run_0_primary_peak_xyz)
     run_0_secondary_dose = run_0_image.GetPixel(run_0_secondary_peak_xyz)
@@ -156,7 +156,7 @@ if __name__ == "__main__":
     run_1_other_primary_dose = run_1_image.GetPixel(run_0_primary_peak_xyz)
     run_0_ratio = run_0_primary_dose / run_0_secondary_dose
     run_1_ratio = run_1_primary_dose / run_1_secondary_dose
-    ratio_tolerance = 0.6
+    ratio_tolerance = 0.8
 
     is_ok = True
     utility.print_test(
@@ -164,6 +164,15 @@ if __name__ == "__main__":
         f"Changer attached_to property resolves to source name: {changer.attached_to}",
     )
     is_ok = changer.attached_to == source.name and is_ok
+
+    utility.print_test(
+        stats.counts.runs == sim.number_of_threads * len(sim.run_timing_intervals),
+        f"Stats runs count {stats.counts.runs} matches threads x timing intervals",
+    )
+    is_ok = (
+        stats.counts.runs == sim.number_of_threads * len(sim.run_timing_intervals)
+        and is_ok
+    )
 
     utility.print_test(
         run_0_primary_dose > 5.0 * run_0_other_primary_dose,

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
@@ -146,7 +146,9 @@ if __name__ == "__main__":
     run_0_image = dose.edep.get_data(which=0)
     run_1_image = dose.edep.get_data(which=1)
     plot_run_dose_planes(
-        run_0_image, run_1_image, paths.output / "test097_dynamic_voxel_source_mt_dose_planes.png"
+        run_0_image,
+        run_1_image,
+        paths.output / "test097_dynamic_voxel_source_mt_dose_planes.png",
     )
     run_0_primary_dose = run_0_image.GetPixel(run_0_primary_peak_xyz)
     run_0_secondary_dose = run_0_image.GetPixel(run_0_secondary_peak_xyz)

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_mt.py
@@ -120,6 +120,9 @@ if __name__ == "__main__":
     source.energy.mono = 1 * MeV
     source.add_dynamic_parametrisation(image=[source_image_1_path, source_image_2_path])
 
+    # Explicit manual changer creation is only used here to test the changer API.
+    # Normal user scripts should rely on add_dynamic_parametrisation(...), which
+    # auto-creates the SourceActivityImageChanger.
     changer = SourceActivityImageChanger(
         name="source_activity_image_changer",
         activity_images=[source_image_1_path, source_image_2_path],

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_tac.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_tac.py
@@ -122,10 +122,9 @@ def mixed_tac_activity(
     slow_starting_activity,
     slow_decay_constant,
 ):
-    return (
-        fast_starting_activity * np.exp(-fast_decay_constant * t_sec)
-        + slow_starting_activity * np.exp(-slow_decay_constant * t_sec)
-    )
+    return fast_starting_activity * np.exp(
+        -fast_decay_constant * t_sec
+    ) + slow_starting_activity * np.exp(-slow_decay_constant * t_sec)
 
 
 if __name__ == "__main__":
@@ -280,11 +279,15 @@ if __name__ == "__main__":
     run_1_ratio = run_1_primary_counts / run_1_secondary_counts
     ratio_tolerance = 0.7
 
-    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = utility.fit_exponential_decay(
-        run_0_event_times_sec, run_0_start_sec, run_0_end_sec
+    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = (
+        utility.fit_exponential_decay(
+            run_0_event_times_sec, run_0_start_sec, run_0_end_sec
+        )
     )
-    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = utility.fit_exponential_decay(
-        run_1_event_times_sec, run_1_start_sec, run_1_end_sec
+    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = (
+        utility.fit_exponential_decay(
+            run_1_event_times_sec, run_1_start_sec, run_1_end_sec
+        )
     )
     run_0_expected_half_life_sec = fast_nominal_half_life / sec
     run_1_expected_half_life_sec = slow_nominal_half_life / sec

--- a/opengate/tests/src/source/test097_dynamic_voxel_source_tac.py
+++ b/opengate/tests/src/source/test097_dynamic_voxel_source_tac.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+
+import itk
+import matplotlib.pyplot as plt
+import numpy as np
+
+import opengate as gate
+from opengate.actors.dynamicactors import SourceActivityImageChanger
+from opengate.tests import utility
+
+
+def xyz_to_zyx(index_xyz):
+    return tuple(reversed(index_xyz))
+
+
+def create_activity_image(reference_image, peak_weights, output_path):
+    array = np.zeros_like(itk.array_view_from_image(reference_image), dtype=np.float32)
+    for peak_index_xyz, weight in peak_weights.items():
+        array[xyz_to_zyx(peak_index_xyz)] = weight
+    image = itk.image_from_array(array)
+    image.CopyInformation(reference_image)
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+def create_reference_image(output_path):
+    array = np.zeros((10, 10, 10), dtype=np.float32)
+    image = itk.image_from_array(array)
+    image.SetSpacing([1.0, 1.0, 1.0])
+    image.SetOrigin([0.0, 0.0, 0.0])
+    itk.imwrite(image, str(output_path))
+    return image
+
+
+def world_positions_to_voxel_indices(positions_xyz, image_info, source_translation):
+    source_origin = (
+        -image_info.size / 2.0 * image_info.spacing
+        + np.array(source_translation, dtype=float)
+        + image_info.spacing / 2.0
+    )
+    indices = np.floor((positions_xyz - source_origin) / image_info.spacing + 0.5)
+    return indices.astype(int)
+
+
+def count_indices(indices_xyz):
+    return Counter(map(tuple, indices_xyz))
+
+
+def plot_event_positions_and_decay(
+    run_0_positions_xyz,
+    run_1_positions_xyz,
+    run_0_decay_times_sec,
+    run_1_decay_times_sec,
+    fit_x_0,
+    fit_y_0,
+    fit_x_1,
+    fit_y_1,
+    output_path,
+):
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4), constrained_layout=True)
+
+    axes[0].scatter(run_0_positions_xyz[:, 0], run_0_positions_xyz[:, 1], s=2)
+    axes[0].set_title("Run 0 event positions")
+    axes[0].set_xlabel("x [mm]")
+    axes[0].set_ylabel("y [mm]")
+    axes[0].set_aspect("equal", adjustable="box")
+
+    axes[1].scatter(run_1_positions_xyz[:, 0], run_1_positions_xyz[:, 1], s=2)
+    axes[1].set_title("Run 1 event positions")
+    axes[1].set_xlabel("x [mm]")
+    axes[1].set_ylabel("y [mm]")
+    axes[1].set_aspect("equal", adjustable="box")
+
+    axes[2].hist(
+        run_0_decay_times_sec, bins="auto", density=True, alpha=0.6, label="run 0"
+    )
+    axes[2].hist(
+        run_1_decay_times_sec, bins="auto", density=True, alpha=0.6, label="run 1"
+    )
+    axes[2].plot(fit_x_0, fit_y_0, label="fit run 0")
+    axes[2].plot(fit_x_1, fit_y_1, label="fit run 1")
+    axes[2].set_title("Event times by run")
+    axes[2].set_xlabel("time [s]")
+    axes[2].set_ylabel("density")
+    axes[2].legend()
+
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+def plot_decay_fit(
+    all_event_times_sec,
+    all_bin_edges,
+    fit_x_0,
+    fit_y_0,
+    fit_x_1,
+    fit_y_1,
+    nominal_x,
+    nominal_y,
+    output_path,
+):
+    fig, ax = plt.subplots(1, 1, figsize=(9, 4), constrained_layout=True)
+    ax.hist(all_event_times_sec, bins=all_bin_edges, alpha=0.7, label="events")
+    ax.plot(fit_x_0, fit_y_0, label="fit run 0", linewidth=2)
+    ax.plot(fit_x_1, fit_y_1, label="fit run 1", linewidth=2)
+    ax.plot(nominal_x, nominal_y, label="nominal TAC", linewidth=2, linestyle="--")
+    ax.set_title("Event times with run-wise fits and nominal TAC")
+    ax.set_xlabel("time [s]")
+    ax.set_ylabel("counts")
+    ax.legend()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+def mixed_tac_activity(
+    t_sec,
+    fast_starting_activity,
+    fast_decay_constant,
+    slow_starting_activity,
+    slow_decay_constant,
+):
+    return (
+        fast_starting_activity * np.exp(-fast_decay_constant * t_sec)
+        + slow_starting_activity * np.exp(-slow_decay_constant * t_sec)
+    )
+
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test097")
+
+    sim = gate.Simulation()
+    sim.g4_verbose = False
+    sim.visu = False
+    sim.number_of_threads = 1
+    sim.random_seed = 123456
+    sim.output_dir = paths.output
+
+    m = gate.g4_units.m
+    mm = gate.g4_units.mm
+    keV = gate.g4_units.keV
+    Bq = gate.g4_units.Bq
+    kBq = 1e3 * Bq
+    sec = gate.g4_units.s
+    run_timing_intervals = [(0, 1.5 * sec), (3.0 * sec, 5.5 * sec)]
+    run_0_start_sec = run_timing_intervals[0][0] / sec
+    run_0_end_sec = run_timing_intervals[0][1] / sec
+    run_1_start_sec = run_timing_intervals[1][0] / sec
+    run_1_end_sec = run_timing_intervals[1][1] / sec
+
+    sim.volume_manager.add_material_database(paths.data / "GateMaterials.db")
+    sim.world.size = [1 * m, 1 * m, 1 * m]
+
+    ct_image_path = paths.output / "ct_image.mhd"
+    ct_itk = create_reference_image(ct_image_path)
+
+    ct = sim.add_volume("Image", "ct")
+    ct.image = str(ct_image_path)
+    ct.material = "G4_AIR"
+    ct.voxel_materials = [[0, 10, "G4_WATER"]]
+    ct.load_input_image()
+
+    source_image_1_path = paths.output / "dynamic_source_1.mhd"
+    source_image_2_path = paths.output / "dynamic_source_2.mhd"
+    run_0_primary_peak_xyz = (2, 5, 5)
+    run_0_secondary_peak_xyz = (2, 2, 5)
+    run_1_primary_peak_xyz = (7, 5, 5)
+    run_1_secondary_peak_xyz = (7, 2, 5)
+    run_0_expected_ratio = 3.0
+    run_1_expected_ratio = 4.0
+    create_activity_image(
+        ct_itk,
+        {
+            run_0_primary_peak_xyz: run_0_expected_ratio,
+            run_0_secondary_peak_xyz: 1.0,
+        },
+        source_image_1_path,
+    )
+    create_activity_image(
+        ct_itk,
+        {
+            run_1_primary_peak_xyz: run_1_expected_ratio,
+            run_1_secondary_peak_xyz: 1.0,
+        },
+        source_image_2_path,
+    )
+    source_info = gate.image.read_image_info(str(source_image_1_path))
+
+    source = sim.add_source("VoxelSource", "vox_source")
+    source.attached_to = ct.name
+    source.particle = "gamma"
+    source.image = str(source_image_1_path)
+    source.direction.type = "iso"
+    source.position.translation = gate.image.get_translation_between_images_center(
+        ct.image, source_image_1_path
+    )
+    source.energy.mono = 140 * keV
+
+    fast_nominal_half_life = 0.3 * sec
+    slow_nominal_half_life = 4.0 * sec
+    fast_decay_constant = np.log(2.0) / (fast_nominal_half_life / sec)
+    slow_decay_constant = np.log(2.0) / (slow_nominal_half_life / sec)
+    fast_starting_activity = 200 * kBq
+    slow_starting_activity = 5 * kBq
+    source.tac_times = (
+        np.linspace(run_0_start_sec, run_1_end_sec, num=500, endpoint=True) * sec
+    )
+    source.tac_activities = [
+        mixed_tac_activity(
+            t / sec,
+            fast_starting_activity,
+            fast_decay_constant,
+            slow_starting_activity,
+            slow_decay_constant,
+        )
+        for t in source.tac_times
+    ]
+    source.add_dynamic_parametrisation(image=[source_image_1_path, source_image_2_path])
+
+    # Explicit manual changer creation is only used here to test the changer API.
+    # Normal user scripts should rely on add_dynamic_parametrisation(...), which
+    # auto-creates the SourceActivityImageChanger.
+    changer = SourceActivityImageChanger(
+        name="source_activity_image_changer",
+        activity_images=[source_image_1_path, source_image_2_path],
+        attached_to=source,
+        simulation=sim,
+    )
+
+    stats = sim.add_actor("SimulationStatisticsActor", "stats")
+    stats.track_types_flag = True
+
+    phsp = sim.add_actor("PhaseSpaceActor", "phsp")
+    phsp.attributes = ["EventPosition", "GlobalTime", "RunID"]
+    phsp.steps_to_store = "first"
+    phsp.output_filename = "test097_dynamic_voxel_source_tac.root"
+
+    sim.physics_manager.physics_list_name = "QGSP_BERT_EMZ"
+    sim.physics_manager.enable_decay = False
+    sim.physics_manager.global_production_cuts.all = 1 * mm
+    sim.run_timing_intervals = run_timing_intervals
+
+    sim.run()
+
+    root_data, _ = utility.open_root_as_np(phsp.get_output_path(), "phsp")
+    event_times_sec = root_data["GlobalTime"] / sec
+    run_ids = root_data["RunID"]
+    event_positions_xyz = np.column_stack(
+        (
+            root_data["EventPosition_X"],
+            root_data["EventPosition_Y"],
+            root_data["EventPosition_Z"],
+        )
+    )
+    event_indices_xyz = world_positions_to_voxel_indices(
+        event_positions_xyz, source_info, source.position.translation
+    )
+
+    run_0_mask = run_ids == 0
+    run_1_mask = run_ids == 1
+    run_0_indices = event_indices_xyz[run_0_mask]
+    run_1_indices = event_indices_xyz[run_1_mask]
+    run_0_positions = event_positions_xyz[run_0_mask]
+    run_1_positions = event_positions_xyz[run_1_mask]
+    run_0_event_times_sec = event_times_sec[run_0_mask]
+    run_1_event_times_sec = event_times_sec[run_1_mask]
+    run_0_counts = count_indices(run_0_indices)
+    run_1_counts = count_indices(run_1_indices)
+
+    run_0_primary_counts = run_0_counts[run_0_primary_peak_xyz]
+    run_0_secondary_counts = run_0_counts[run_0_secondary_peak_xyz]
+    run_1_primary_counts = run_1_counts[run_1_primary_peak_xyz]
+    run_1_secondary_counts = run_1_counts[run_1_secondary_peak_xyz]
+    run_0_other_primary_counts = run_0_counts[run_1_primary_peak_xyz]
+    run_1_other_primary_counts = run_1_counts[run_0_primary_peak_xyz]
+
+    run_0_ratio = run_0_primary_counts / run_0_secondary_counts
+    run_1_ratio = run_1_primary_counts / run_1_secondary_counts
+    ratio_tolerance = 0.7
+
+    fitted_half_life_run_0_sec, fit_x_0, fit_y_0_density = utility.fit_exponential_decay(
+        run_0_event_times_sec, run_0_start_sec, run_0_end_sec
+    )
+    fitted_half_life_run_1_sec, fit_x_1, fit_y_1_density = utility.fit_exponential_decay(
+        run_1_event_times_sec, run_1_start_sec, run_1_end_sec
+    )
+    run_0_expected_half_life_sec = fast_nominal_half_life / sec
+    run_1_expected_half_life_sec = slow_nominal_half_life / sec
+    half_life_run_0_relative_error = (
+        abs(fitted_half_life_run_0_sec - run_0_expected_half_life_sec)
+        / run_0_expected_half_life_sec
+    )
+    half_life_run_1_relative_error = (
+        abs(fitted_half_life_run_1_sec - run_1_expected_half_life_sec)
+        / run_1_expected_half_life_sec
+    )
+    half_life_tolerance = 0.10
+
+    combined_counts, combined_bin_edges = np.histogram(event_times_sec, bins="auto")
+    combined_bin_width = np.mean(np.diff(combined_bin_edges))
+    fit_y_0 = fit_y_0_density * len(run_0_event_times_sec) * combined_bin_width
+    fit_y_1 = fit_y_1_density * len(run_1_event_times_sec) * combined_bin_width
+
+    nominal_x = np.linspace(run_0_start_sec, run_1_end_sec, 300)
+    nominal_y = (
+        mixed_tac_activity(
+            nominal_x,
+            fast_starting_activity / Bq,
+            fast_decay_constant,
+            slow_starting_activity / Bq,
+            slow_decay_constant,
+        )
+        * combined_bin_width
+    )
+
+    plot_event_positions_and_decay(
+        run_0_positions,
+        run_1_positions,
+        run_0_event_times_sec,
+        run_1_event_times_sec,
+        fit_x_0,
+        fit_y_0_density,
+        fit_x_1,
+        fit_y_1_density,
+        paths.output / "test097_dynamic_voxel_source_tac.png",
+    )
+    plot_decay_fit(
+        event_times_sec,
+        combined_bin_edges,
+        fit_x_0,
+        fit_y_0,
+        fit_x_1,
+        fit_y_1,
+        nominal_x,
+        nominal_y,
+        paths.output / "test097_dynamic_voxel_source_tac_decay.png",
+    )
+
+    is_ok = True
+    utility.print_test(
+        changer.attached_to == source.name,
+        f"Changer attached_to property resolves to source name: {changer.attached_to}",
+    )
+    is_ok = changer.attached_to == source.name and is_ok
+
+    utility.print_test(
+        stats.counts.runs == len(sim.run_timing_intervals),
+        f"Stats runs count {stats.counts.runs} matches number of timing intervals",
+    )
+    is_ok = stats.counts.runs == len(sim.run_timing_intervals) and is_ok
+
+    utility.print_test(
+        run_0_other_primary_counts == 0,
+        f"Run 0 contains no events in inactive run 1 primary voxel: {run_0_other_primary_counts}",
+    )
+    is_ok = run_0_other_primary_counts == 0 and is_ok
+
+    utility.print_test(
+        run_1_other_primary_counts == 0,
+        f"Run 1 contains no events in inactive run 0 primary voxel: {run_1_other_primary_counts}",
+    )
+    is_ok = run_1_other_primary_counts == 0 and is_ok
+
+    utility.print_test(
+        abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance,
+        f"Run 0 event-count ratio at xyz {run_0_primary_peak_xyz}/{run_0_secondary_peak_xyz}: {run_0_ratio:.2f}, expected {run_0_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_0_ratio - run_0_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.print_test(
+        abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance,
+        f"Run 1 event-count ratio at xyz {run_1_primary_peak_xyz}/{run_1_secondary_peak_xyz}: {run_1_ratio:.2f}, expected {run_1_expected_ratio:.2f}",
+    )
+    is_ok = abs(run_1_ratio - run_1_expected_ratio) < ratio_tolerance and is_ok
+
+    utility.print_test(
+        half_life_run_0_relative_error < half_life_tolerance,
+        f"Run 0 TAC-derived half life {run_0_expected_half_life_sec:.2f} sec vs fitted {fitted_half_life_run_0_sec:.2f} sec",
+    )
+    is_ok = half_life_run_0_relative_error < half_life_tolerance and is_ok
+
+    utility.print_test(
+        half_life_run_1_relative_error < half_life_tolerance,
+        f"Run 1 TAC-derived half life {run_1_expected_half_life_sec:.2f} sec vs fitted {fitted_half_life_run_1_sec:.2f} sec",
+    )
+    is_ok = half_life_run_1_relative_error < half_life_tolerance and is_ok
+
+    utility.test_ok(is_ok)


### PR DESCRIPTION
This PR extends the dynamic parametrisation framework to VoxelSource, so the source activity image can change from one G4Run to the next, using the same user-facing interface already used for dynamic geometry. A voxel source can now be configured with add_dynamic_parametrisation(image=[...]), and the per-run image update is applied through the existing dynamic actor / changer mechanism at BeginOfRunActionMasterThread.

Along the way, this work also fixed a few related issues that showed up while validating the feature. On the source side, dynamic source initialization is now properly wired, DynamicSourceActor is registered and used consistently through the shared changers interface, and the source manager exposes the dynamic sources needed by the engine. Separately, two bugs in per-run image handling were fixed: aliasing in ITK image merge logic, and a Python interface bug where get_data(which=...) did not actually forward the requested run selection. The branch also includes the Geant4 11.4.1 compatibility fix for eager G4EmCalculator construction in G4Cache payloads.

Test coverage was added and expanded around the new feature. The test suite now includes:

a single-thread dynamic voxel source regression test
a multithreaded companion test
a half-life compatibility test
a TAC compatibility test
These tests check both spatial behavior and time behavior: run-specific activity images, relative peak weights, per-run output retrieval, and compatibility with source decay models.

Documentation was added in both guides:

a new developer-guide chapter explaining the dynamic parametrisation architecture and how to make a parameter dynamic
a new user-guide chapter introducing dynamic parametrisations from the user perspective
clarifications that voxel source images are used as relative spatial activity distributions, while total source strength is controlled separately by activity, half_life, or n