### PR TITLE
Fix PhaseSpaceActor scoring in nested attached volumes

### DIFF
--- a/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
@@ -132,6 +132,15 @@ void GatePhaseSpaceActor::SteppingAction(G4Step *step) {
 
   auto &l = fThreadLocalData.Get();
 
+  // Check if this SteppingAction was triggered via the sensitive detector 
+  // attached to the top volume, i.e. the "attached_to" volume
+  // if it was triggered by a daughter volume, this is not truely a step
+  // at the outer surface, but rather an irrelevant (for the purpose of this actor) 
+  // internal surface crossing
+  if (!IsStepInTopAttachedVolume(step))
+    return;
+
+
   // Particle enters the volume if the pre step is at the volume boundary
   const bool entering =
       step->GetPreStepPoint()->GetStepStatus() == fGeomBoundary;

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
@@ -132,14 +132,13 @@ void GatePhaseSpaceActor::SteppingAction(G4Step *step) {
 
   auto &l = fThreadLocalData.Get();
 
-  // Check if this SteppingAction was triggered via the sensitive detector 
+  // Check if this SteppingAction was triggered via the sensitive detector
   // attached to the top volume, i.e. the "attached_to" volume
   // if it was triggered by a daughter volume, this is not truely a step
-  // at the outer surface, but rather an irrelevant (for the purpose of this actor) 
-  // internal surface crossing
+  // at the outer surface, but rather an irrelevant (for the purpose of this
+  // actor) internal surface crossing
   if (!IsStepInTopAttachedVolume(step))
     return;
-
 
   // Particle enters the volume if the pre step is at the volume boundary
   const bool entering =

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -175,6 +175,28 @@ bool GateVActor::IsStepEnteringVolume(
   return false;
 }
 
+bool GateVActor::IsStepInTopAttachedVolume(const G4Step *step) const {
+  const auto *touchable = step->GetPreStepPoint()->GetTouchable();
+  if (touchable == nullptr)
+    return false;
+
+  const auto history_depth = touchable->GetHistoryDepth();
+  int attached_volume_depth = -1;
+  for (int i = 0; i <= history_depth; i++) {
+    const auto *volume = touchable->GetVolume(i);
+    if (volume == nullptr)
+      continue;
+    const auto *logical_volume = volume->GetLogicalVolume();
+    if (logical_volume != nullptr &&
+        logical_volume->GetName() == fAttachedToVolumeName) {
+      attached_volume_depth = i;
+      break;
+    }
+  }
+
+  return attached_volume_depth == 0;
+}
+
 bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
   if (fAttachedToVolumeMotherName == "None") {
     Fatal("Cannot use IsStepExitingAttachedVolume when "

--- a/core/opengate_core/opengate_lib/GateVActor.h
+++ b/core/opengate_core/opengate_lib/GateVActor.h
@@ -122,6 +122,8 @@ public:
   IsStepEnteringVolume(const G4Step *step,
                        const std::vector<const G4LogicalVolume *> &volumes);
 
+  bool IsStepInTopAttachedVolume(const G4Step *step) const;
+
   bool IsStepExitingAttachedVolume(const G4Step *step) const;
 
   inline static std::string fOutputNameRoot = "root_output";


### PR DESCRIPTION
Summary:
- add a GateVActor helper to detect whether a step occurs in the top attached volume rather than a daughter
- use that helper in GatePhaseSpaceActor to ignore subtree-triggered internal surface crossings

Motivation:
PhaseSpaceActor is attached to a single volume in GATE, but the underlying sensitive detector registration is recursive over the attached volume hierarchy. This can lead to surprising extra phase-space entries when daughter volumes are crossed.

Changes:
- add GateVActor::IsStepInTopAttachedVolume(const G4Step*)
- early-return in GatePhaseSpaceActor::SteppingAction() unless the step is in the top attached volume

Notes:
- this keeps the framework helper isolated from the actor behavior change in two separate commits
- it does not change recursive SD registration globally; it only tightens PhaseSpaceActor behavior