### PR TITLE
Install setuptools during CI

### DIFF
--- a/.github/workflows/actions_build/ci_build_wheel_macos.sh
+++ b/.github/workflows/actions_build/ci_build_wheel_macos.sh
@@ -23,7 +23,7 @@ conda list
 which python
 python --version
 export PATH="/usr/local/miniconda/envs/opengate_core/bin/:$PATH"
-pip install wget colored
+pip install wget colored setuptools
 pip install wheel delocate
 if [[ ${MATRIX_OS} == "macos-15-intel" ]]; then
     conda install conda-forge::qt6-main conda-forge::qt6-3d


### PR DESCRIPTION
Without the installation, it leads to error with MacOS python 3.14