### PR TITLE
More robust uncertainty calculation

### DIFF
--- a/core/opengate_core/opengate_lib/GateDoseActor.cpp
+++ b/core/opengate_core/opengate_lib/GateDoseActor.cpp
@@ -34,6 +34,7 @@ GateDoseActor::GateDoseActor(py::dict &user_info)
     : GateVActor(user_info, true) {
 
   fUncertaintyGoal = 0.0;
+  fTopVoxelsCount = 0;
   fThreshEdepPerc = 0.0;
   fOvershoot = 0.0;
   fNbEventsFirstCheck = 0;
@@ -284,20 +285,19 @@ double GateDoseActor::ComputeMeanUncertainty() {
       cpp_edep_image, cpp_edep_image->GetLargestPossibleRegion());
   double mean_unc = 0.0;
   int n_voxel_unc = 0;
-  double n = 2.0;
-  n = fNbOfEvent;
+  double n = fNbOfEvent;
 
   if (n < 2.0) {
     n = 2.0;
   }
-  double max_edep = GetMaxValueOfImage(cpp_edep_image);
+  double mean_max_edep = GetMeanOfHighestNValues(cpp_edep_image);
 
   for (edep_iterator3D.GoToBegin(); !edep_iterator3D.IsAtEnd();
        ++edep_iterator3D) {
     Image3DType::IndexType index_f = edep_iterator3D.GetIndex();
     double val = cpp_edep_image->GetPixel(index_f);
 
-    if (val > max_edep * fThreshEdepPerc) {
+    if (val > mean_max_edep * fThreshEdepPerc) {
       val /= n;
       n_voxel_unc++;
       const double val_squared_mean =
@@ -400,26 +400,35 @@ void GateDoseActor::FlushSquaredValues(threadLocalT &data,
 
 int GateDoseActor::EndOfRunActionMasterThread(int run_id) { return 0; }
 
-double GateDoseActor::GetMaxValueOfImage(Image3DType::Pointer imageP) {
+double GateDoseActor::GetMeanOfHighestNValues(Image3DType::Pointer imageP) {
   itk::ImageRegionIterator<Image3DType> iterator3D(
       imageP, imageP->GetLargestPossibleRegion());
-  Image3DType::PixelType max = 0;
-  Image3DType::IndexType index_max;
-  // keep track of the 10 highest values of the image
-  std::priority_queue<double, std::vector<double>, std::greater<double>> pq;
+
+  // Min-heap holding the top N values
+  std::priority_queue<double, std::vector<double>, std::greater<double>>
+      topValues;
+
   for (iterator3D.GoToBegin(); !iterator3D.IsAtEnd(); ++iterator3D) {
-    Image3DType::IndexType index_f = iterator3D.GetIndex();
-    Image3DType::PixelType val = imageP->GetPixel(index_f);
-    if (val > max) {
-      max = val;
-      index_max = index_f;
-      pq.push(max);
-      if (pq.size() > 10) {
-        pq.pop();
-      }
+    const double val = iterator3D.Get();
+
+    if (topValues.size() < fTopVoxelsCount) {
+      topValues.push(val);
+    } else if (val > topValues.top()) {
+      topValues.pop();
+      topValues.push(val);
     }
   }
-  return max;
+
+  // Compute mean of the values in the heap
+  double sum = 0.0;
+  const std::size_t count = topValues.size();
+
+  while (!topValues.empty()) {
+    sum += topValues.top();
+    topValues.pop();
+  }
+
+  return (count > 0) ? (sum / static_cast<double>(count)) : 0.0;
 }
 
 double GateDoseActor::CalculateSPR(G4Step *step) {

--- a/core/opengate_core/opengate_lib/GateDoseActor.h
+++ b/core/opengate_core/opengate_lib/GateDoseActor.h
@@ -78,6 +78,8 @@ public:
 
   void SetUncertaintyGoal(const double b) { fUncertaintyGoal = b; }
 
+  void SetTopVoxelsCount(const std::size_t b) { fTopVoxelsCount = b; }
+
   void SetThreshEdepPerc(const double b) { fThreshEdepPerc = b; }
 
   void SetOvershoot(const double b) { fOvershoot = b; }
@@ -95,7 +97,7 @@ public:
 
   void ind2sub(int index, Image3DType::IndexType &index3D);
 
-  double GetMaxValueOfImage(Image3DType::Pointer imageP);
+  double GetMeanOfHighestNValues(Image3DType::Pointer imageP);
   double ComputeMeanUncertainty();
 
   // The image is accessible on py side (shared by all threads)
@@ -146,6 +148,7 @@ public:
 
   // Option: set target statistical uncertainty for each run
   double fUncertaintyGoal;
+  std::size_t fTopVoxelsCount;
   double fThreshEdepPerc;
   double fOvershoot;
 

--- a/core/opengate_core/opengate_lib/pyGateDoseActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateDoseActor.cpp
@@ -56,6 +56,7 @@ void init_GateDoseActor(py::module &m) {
       .def("GetCountsFlag", &GateDoseActor::GetCountsFlag)
       .def("SetCountsFlag", &GateDoseActor::SetCountsFlag)
       .def("SetUncertaintyGoal", &GateDoseActor::SetUncertaintyGoal)
+      .def("SetTopVoxelsCount", &GateDoseActor::SetTopVoxelsCount)
       .def("SetThreshEdepPerc", &GateDoseActor::SetThreshEdepPerc)
       .def("SetOvershoot", &GateDoseActor::SetOvershoot)
       .def("SetNbEventsFirstCheck", &GateDoseActor::SetNbEventsFirstCheck)

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -123,7 +123,10 @@ To ensure simulation efficiency, we may wish to stop early when a target uncerta
    # Target statistical uncertainty (e.g., 5%)
    unc_goal = 0.05
 
-   # Define how "high-dose" voxels are selected: here, > 70% of max edep value
+   # Define how "high-dose" voxels are selected:
+   # first compute the mean edep of the N highest voxels,
+   # then keep voxels above 70% of that reference value
+   n_top_voxels = 20
    thresh_voxel_edep_for_unc_calc = 0.7
 
    # Planned number of primary particles or events (e.g., 100 MBq)
@@ -135,22 +138,25 @@ These parameters are then passed to the dose actor:
 
    dose.uncertainty_goal = unc_goal # 0.05
    dose.uncertainty_first_check_after_n_events = 0.01 * n_planned # check statistical uncertainty every 1 MBq particles
+   dose.uncertainty_top_voxels_count = n_top_voxels # 20
    dose.uncertainty_voxel_edep_threshold = thresh_voxel_edep_for_unc_calc # 0.7
 
 Uncertainty is computed only in high-deposition voxels to focus on the clinically relevant region:
 
 .. code-block:: python
 
-   def calculate_mean_unc(edep_arr, unc_arr, edep_thresh_rel=0.7):
+   def calculate_mean_unc(edep_arr, unc_arr, n_top_voxels=20, edep_thresh_rel=0.7):
        # Average the uncertainty values ​​over the high energy deposition areas
-       edep_max = np.amax(edep_arr)
-       mask = edep_arr > edep_max * edep_thresh_rel
+       flat = edep_arr.ravel()
+       top_n = np.partition(flat, -n_top_voxels)[-n_top_voxels:]
+       edep_mean_max = float(top_n.mean())
+       mask = edep_arr > edep_mean_max * edep_thresh_rel
        unc_used = unc_arr[mask]
        unc_mean = np.mean(unc_used)
 
        return unc_mean
 
-Note: This method uses a relative threshold based on the maximum deposited energy, which may be sensitive to outliers. Consider using a percentile-based threshold for robustness if needed.
+The parameter ``uncertainty_top_voxels_count`` must be greater than 0 and no larger than the number of voxels in the scoring image.
 
 At the end of the simulation, the actual mean uncertainty and the number of events used are reported:
 

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -420,10 +420,17 @@ class DoseActor(VoxelDepositActor, g4.GateDoseActor):
                 "After the first evaluation, the value is updated with an estimation of the N events needed to achieve the uncertainty goal, Therefore it is recommended to select a sufficiently large number so the uncertainty of the uncertainty is not too large.",
             },
         ),
+        "uncertainty_top_voxels_count": (
+            10,
+            {
+                "doc": "Only applies if uncertainty_goal is set True: the N voxels with the highest edep will be used to calculate a 'mean maximum' of the edep in the image.",
+            },
+        ),
         "uncertainty_voxel_edep_threshold": (
             0.7,
             {
-                "doc": "Only applies if uncertainty_goal is set True: The calculation of the mean uncertainty of the edep image, only voxels that are above this relative threshold are considered. The threshold must range between [0, 1] and gives the fraction relative to max edep value in the image.",
+                "doc": "Only applies if uncertainty_goal is set True: The threshold must range between [0, 1] and represents the fraction relative to the 'mean maximum' edep value in the image. "
+                "Only voxels with value above this threshold are used for the uncertainty calculation.",
             },
         ),
         "uncertainty_overshoot_factor_N_events": (
@@ -601,9 +608,18 @@ class DoseActor(VoxelDepositActor, g4.GateDoseActor):
             self.SetUncertaintyGoal(0)
         else:
             self.SetUncertaintyGoal(self.uncertainty_goal)
-        self.SetThreshEdepPerc(self.uncertainty_voxel_edep_threshold)
-        self.SetOvershoot(self.uncertainty_overshoot_factor_N_events)
-        self.SetNbEventsFirstCheck(int(self.uncertainty_first_check_after_n_events))
+            n_voxels = self.size[0] * self.size[1] * self.size[2]
+            if (
+                self.uncertainty_top_voxels_count < 0
+                or self.uncertainty_top_voxels_count > n_voxels
+            ):
+                fatal(
+                    "uncertainty_top_voxels_count cannot be negative or bigger than the number of voxels in the image. "
+                )
+            self.SetTopVoxelsCount(self.uncertainty_top_voxels_count)
+            self.SetThreshEdepPerc(self.uncertainty_voxel_edep_threshold)
+            self.SetOvershoot(self.uncertainty_overshoot_factor_N_events)
+            self.SetNbEventsFirstCheck(int(self.uncertainty_first_check_after_n_events))
 
         # Set the physical volume name on the C++ side
         # self.SetPhysicalVolumeName(self.get_physical_volume_name())

--- a/opengate/actors/doseactors.py
+++ b/opengate/actors/doseactors.py
@@ -610,11 +610,11 @@ class DoseActor(VoxelDepositActor, g4.GateDoseActor):
             self.SetUncertaintyGoal(self.uncertainty_goal)
             n_voxels = self.size[0] * self.size[1] * self.size[2]
             if (
-                self.uncertainty_top_voxels_count < 0
+                self.uncertainty_top_voxels_count <= 0
                 or self.uncertainty_top_voxels_count > n_voxels
             ):
                 fatal(
-                    "uncertainty_top_voxels_count cannot be negative or bigger than the number of voxels in the image. "
+                    "uncertainty_top_voxels_count must be greater than 0 and cannot be bigger than the number of voxels in the image. "
                 )
             self.SetTopVoxelsCount(self.uncertainty_top_voxels_count)
             self.SetThreshEdepPerc(self.uncertainty_voxel_edep_threshold)

--- a/opengate/tests/src/actors/test066_stop_simulation_criteria_mt.py
+++ b/opengate/tests/src/actors/test066_stop_simulation_criteria_mt.py
@@ -16,9 +16,11 @@ import itk
 import numpy as np
 
 
-def calculate_mean_unc(edep_arr, unc_arr, edep_thresh_rel=0.7):
-    edep_max = np.amax(edep_arr)
-    mask = edep_arr > edep_max * edep_thresh_rel
+def calculate_mean_unc(edep_arr, unc_arr, n_top_voxels=20, edep_thresh_rel=0.7):
+    flat = edep_arr.ravel()
+    top_n = np.partition(flat, -n_top_voxels)[-n_top_voxels:]
+    edep_mean_max = float(top_n.mean())
+    mask = edep_arr > edep_mean_max * edep_thresh_rel
     unc_used = unc_arr[mask]
     unc_mean = np.mean(unc_used)
 
@@ -36,8 +38,9 @@ if __name__ == "__main__":
 
     # goal uncertainty
     unc_goal = 0.05  # means 5%
+    n_top_voxels = 20  # n voxels used to calculate mean max edep
     thresh_voxel_edep_for_unc_calc = (
-        0.7  # calculated over the voxels whose value is > 0.7 * max edep value
+        0.7  # calculated over the voxels whose value is > 0.7 * mean max edep value
     )
 
     # create the simulation
@@ -103,6 +106,7 @@ if __name__ == "__main__":
     dose.edep_uncertainty.active = True
     dose.uncertainty_goal = unc_goal
     dose.uncertainty_first_check_after_n_events = 100
+    dose.uncertainty_top_voxels_count = n_top_voxels
     dose.uncertainty_voxel_edep_threshold = thresh_voxel_edep_for_unc_calc
     dose.write_to_disk = False
 
@@ -124,7 +128,10 @@ if __name__ == "__main__":
     unc_array = np.asarray(dose.edep_uncertainty.image)
 
     unc_mean = calculate_mean_unc(
-        edep_arr, unc_array, edep_thresh_rel=thresh_voxel_edep_for_unc_calc
+        edep_arr,
+        unc_array,
+        n_top_voxels=n_top_voxels,
+        edep_thresh_rel=thresh_voxel_edep_for_unc_calc,
     )
     print(f"{unc_goal = }")
     print(f"{unc_mean = }")

--- a/opengate/tests/src/actors/test066_stop_simulation_criteria_multiple_runs_mt.py
+++ b/opengate/tests/src/actors/test066_stop_simulation_criteria_multiple_runs_mt.py
@@ -16,9 +16,11 @@ import itk
 import numpy as np
 
 
-def calculate_mean_unc(edep_arr, unc_arr, edep_thresh_rel=0.7):
-    edep_max = np.amax(edep_arr)
-    mask = edep_arr > edep_max * edep_thresh_rel
+def calculate_mean_unc(edep_arr, unc_arr, n_top_voxels=20, edep_thresh_rel=0.7):
+    flat = edep_arr.ravel()
+    top_n = np.partition(flat, -n_top_voxels)[-n_top_voxels:]
+    edep_mean_max = float(top_n.mean())
+    mask = edep_arr > edep_mean_max * edep_thresh_rel
     unc_used = unc_arr[mask]
     unc_mean = np.mean(unc_used)
 
@@ -40,8 +42,9 @@ if __name__ == "__main__":
     unc_expected = unc_goal_run / np.sqrt(
         n_runs
     )  # uncertainty expected at the end of the simulation
+    n_top_voxels = 20  # n voxels used to calculate mean max edep
     thresh_voxel_edep_for_unc_calc = (
-        0.7  # calculated over the voxels whose value is > 0.7 * max edep value
+        0.7  # calculated over the voxels whose value is > 0.7 * mean max edep value
     )
 
     # create the simulation
@@ -109,6 +112,7 @@ if __name__ == "__main__":
     dose.edep.keep_data_per_run = True
     dose.uncertainty_goal = unc_goal_run
     dose.uncertainty_first_check_after_n_events = 100
+    dose.uncertainty_top_voxels_count = n_top_voxels
     dose.uncertainty_voxel_edep_threshold = thresh_voxel_edep_for_unc_calc
     dose.write_to_disk = False  # we don't need to save the images for this test
 
@@ -132,7 +136,10 @@ if __name__ == "__main__":
         edep_arr = np.asarray(dose.edep.get_data(which=i))
         unc_arr = np.asarray(dose.edep_uncertainty.get_data(which=i))
         unc_mean = calculate_mean_unc(
-            edep_arr, unc_arr, edep_thresh_rel=thresh_voxel_edep_for_unc_calc
+            edep_arr,
+            unc_arr,
+            n_top_voxels=n_top_voxels,
+            edep_thresh_rel=thresh_voxel_edep_for_unc_calc,
         )
         b = unc_mean < unc_goal_run
         print(


### PR DESCRIPTION
This PR only affects the dose actor feature "stop simulation on uncertainty goal".

The average uncertainty of the image is calculated considering only the voxels that have an energy deposition larger than a threshold. Before, this threshold was defined as a fraction of the maximum energy deposition in the image. However, since this value can fluctuate a lot, especially in the early phase of the simulation, it is better to use the maximum of the N highest voxels, with N configurable and range checked.