### PR TITLE
Fix memory leak in GateDigitizerReadoutActor

### DIFF
--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.cpp
@@ -153,8 +153,6 @@ void GateDigitizerAdderActor::EndOfEventAction(const G4Event *event) {
         fOutputNumberOfHitsAttribute->FillDValue(hit->fNumberOfHits);
       lr.fDigiAttributeFiller->Fill(hit->fFinalIndex);
     }
-    // Clean up the allocated GateDigiAdderInVolume object
-    delete hit;
   }
 
   // reset the structure of hits
@@ -189,7 +187,7 @@ void GateDigitizerAdderActor::AddDigiPerVolume() const {
   // Find or create an entry in the map for this unique key.
   if (l.fMapOfDigiInVolume.find(key) == l.fMapOfDigiInVolume.end()) {
     // If no entry exists, create a new one.
-    l.fMapOfDigiInVolume[key] = new GateDigiAdderInVolume(
+    l.fMapOfDigiInVolume[key] = std::make_unique<GateDigiAdderInVolume>(
         fPolicy, fTimeDifferenceFlag, fNumberOfHitsFlag);
   }
 

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.cpp
@@ -13,6 +13,8 @@
 #include <functional>
 #include <sstream>
 
+GateDigitizerAdderActor::threadLocalT::~threadLocalT() = default;
+
 GateDigitizerAdderActor::GateDigitizerAdderActor(py::dict &user_info)
     : GateVDigitizerWithOutputActor(user_info, true) {
   // actions (in addition to the ones in GateVDigitizerWithOutputActor)

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
@@ -16,6 +16,7 @@
 #include "GateTDigiAttribute.h"
 #include "GateVDigitizerWithOutputActor.h"
 #include <cstdint> // Required for uint64_t
+#include <memory>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
@@ -102,7 +103,8 @@ protected:
 
   // During computation (thread local)
   struct threadLocalT {
-    std::map<DigiKey, GateDigiAdderInVolume *> fMapOfDigiInVolume;
+    std::map<DigiKey, std::unique_ptr<GateDigiAdderInVolume>>
+        fMapOfDigiInVolume;
 
     double *edep;
     G4ThreeVector *pos;

--- a/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateDigitizerAdderActor.h
@@ -112,6 +112,8 @@ protected:
     double *time;
     double *weight;
     int64_t *track_info_id;
+
+    ~threadLocalT();
   };
   G4Cache<threadLocalT> fThreadLocalData;
 };


### PR DESCRIPTION
`GateDigitizerAdderActor` creates instances of `GateDigiAdderInVolume` with `new` in `AddDigiPerVolume()`, which are later deleted in `EndOfEventAction()`.
`GateDigitizerReadoutActor` inherits from `GateDigitizerAdderActor` and uses the parent's implementation of `AddDigiPerVolume()`, but overrides `EndOfEventAction()` with its own implementation, where the `delete` is missing.

This PR fixes it by using `std::unique_ptr<GateDigiAdderInVolume>` instead of `GateDigiAdderInVolume*` in the parent class, so that ` l.fMapOfDigiInVolume.clear()` automatically deletes the instances, both in the parent and the child class.