### PR TITLE
Fix bug related to min_transaxial_distance and max_axial_distance in GateCoincidenceSorterActor

### DIFF
--- a/core/opengate_core/opengate_lib/digitizer/GateCoincidenceSorterActor.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateCoincidenceSorterActor.cpp
@@ -264,7 +264,7 @@ void GateCoincidenceSorterActor::DetectCoincidences(bool lastCall) {
         iter++;
       }
       const auto numCoincidences = secondSingleIndex.size();
-      if (numCoincidences == 1) {
+      if (numCoincidences == 1 && goodCoincidence[0] == 1) {
         fCurrentStorage->fillerOut->Fill(i0, secondSingleIndex[0]);
       } else if (numCoincidences > 1) {
         const auto filteredIndices =

--- a/opengate/tests/src/actors/test098_coincidence_actor.py
+++ b/opengate/tests/src/actors/test098_coincidence_actor.py
@@ -6,7 +6,6 @@ import opengate.tests.utility as utility
 import opengate.contrib.pet.philipsvereos as vereos
 from opengate.actors.coincidences import CoincidenceSorter
 from test098_coincidence_helpers import compare_coincidences
-import uproot
 
 if __name__ == "__main__":
     paths = utility.get_default_test_paths(
@@ -16,6 +15,7 @@ if __name__ == "__main__":
 
     # units
     m = gate.g4_units.m
+    mm = gate.g4_units.mm
     cm = gate.g4_units.cm
     Bq = gate.g4_units.Bq
     sec = gate.g4_units.s
@@ -69,6 +69,8 @@ if __name__ == "__main__":
     cc = sim.add_actor("CoincidenceSorterActor", "coincidences")
     cc.input_digi_collection = sc.name
     cc.window = 1e-9 * sec
+    cc.min_transaxial_distance = 260 * mm
+    cc.max_axial_distance = 100 * mm
     cc.output_filename = root_filename
 
     sim.run_timing_intervals = [[0, 0.001 * sec]]
@@ -88,6 +90,8 @@ if __name__ == "__main__":
         # Calculate the coincidences using the Python implementation.
         sorter = CoincidenceSorter()
         sorter.window = 1e-9 * sec
+        sorter.min_transaxial_distance = 260 * mm
+        sorter.max_axial_distance = 100 * mm
         sorter.multiples_policy = policy
 
         coincidences_python = sorter.run(root_filename, "singles")


### PR DESCRIPTION
In `GateCoincidenceSorterActor` (for on-line coincidence sorting), the attributes `min_transaxial_distance` and `max_axial_distance` were applied in case of multiple coincidences (as part of applying the multiples policy), but were ignored for coincidences  that were alone in their coincidence window. This has been fixed in this PR.

The implementation in the Python class `CoincidenceSorter` (for offline coincidence sorting) does not have the bug. 

The test that compares the on-line and off-line implementation did not yet use the attributes `min_transaxial_distance` and `max_axial_distance`. This has also been changed in this PR.