### PR TITLE
Improve phase space actor attached to logic

### DIFF
--- a/core/opengate_core/opengate_lib/GateGeometryUtils.cpp
+++ b/core/opengate_core/opengate_lib/GateGeometryUtils.cpp
@@ -67,7 +67,8 @@ void FindAndBuildTouchables(G4VPhysicalVolume *currentVolume,
 }
 
 std::vector<std::unique_ptr<G4VTouchable>>
-FindAllTouchables(const G4String &targetLVName) {
+FindAllTouchables(const G4String &targetLVName,
+                  const G4String &requestedWorldName) {
   std::vector<std::unique_ptr<G4VTouchable>> touchableResults;
 
   // Get the transportation manager to access all worlds
@@ -79,11 +80,30 @@ FindAllTouchables(const G4String &targetLVName) {
           "The geometry is not initialized.");
   }
 
-  // Get the iterator to all navigators (one per world: mass world + parallel
-  // worlds)
-  const auto navigatorsBegin = transportMgr->GetActiveNavigatorsIterator();
+  if (!requestedWorldName.empty()) {
+    G4Navigator *navigator = transportMgr->GetNavigator(requestedWorldName);
+    if (!navigator) {
+      Fatal("FindAllTouchables: Could not get navigator for world '" +
+            requestedWorldName + "'.");
+    }
 
-  // Get the number of worlds to know how many navigators to iterate through
+    G4VPhysicalVolume *worldVolume = navigator->GetWorldVolume();
+    if (!worldVolume) {
+      Fatal("FindAllTouchables: World volume for world '" + requestedWorldName +
+            "' is null.");
+    }
+
+    G4NavigationHistory navHistory;
+    navHistory.SetFirstEntry(worldVolume);
+    FindAndBuildTouchables(worldVolume, navHistory, targetLVName,
+                           touchableResults, requestedWorldName);
+    return touchableResults;
+  }
+
+  // Legacy fallback: iterate across all worlds when no world was specified.
+  // This remains useful for callers such as unique-volume-ID initialization
+  // that need a global geometry scan.
+  const auto navigatorsBegin = transportMgr->GetActiveNavigatorsIterator();
   const size_t numWorlds = transportMgr->GetNoWorlds();
 
   if (numWorlds == 0) {
@@ -91,7 +111,6 @@ FindAllTouchables(const G4String &targetLVName) {
           "The geometry is not initialized.");
   }
 
-  // Iterate through all navigators
   for (size_t i = 0; i < numWorlds; ++i) {
     const G4Navigator *navigator = *(navigatorsBegin + i);
 
@@ -108,11 +127,8 @@ FindAllTouchables(const G4String &targetLVName) {
 
     const G4String worldName = worldVolume->GetName();
 
-    // Create a navigation history for this world
     G4NavigationHistory navHistory;
     navHistory.SetFirstEntry(worldVolume);
-
-    // Start the recursive search from this world volume
     FindAndBuildTouchables(worldVolume, navHistory, targetLVName,
                            touchableResults, worldName);
   }

--- a/core/opengate_core/opengate_lib/GateGeometryUtils.h
+++ b/core/opengate_core/opengate_lib/GateGeometryUtils.h
@@ -28,8 +28,7 @@
  * @return A vector of pointers to G4VTouchable objects.
  **/
 std::vector<std::unique_ptr<G4VTouchable>>
-FindAllTouchables(const G4String &targetLVName,
-                  const G4String &worldName = "");
+FindAllTouchables(const G4String &targetLVName, const G4String &worldName = "");
 
 void FindAndBuildTouchables(G4VPhysicalVolume *currentVolume,
                             G4NavigationHistory &navHistory,

--- a/core/opengate_core/opengate_lib/GateGeometryUtils.h
+++ b/core/opengate_core/opengate_lib/GateGeometryUtils.h
@@ -14,19 +14,22 @@
 
 /**
  * Finds all unique instances of a Logical Volume and returns their touchable
- *histories.
+ * histories.
  *
- * This function traverses the entire geometry tree, starting from the world
- *volume, and builds a G4TouchableHistory for every unique path. If the logical
- *volume at the end of a path matches the `targetLVName`, its touchable history
- *is stored.
+ * This function traverses the geometry tree, starting from the requested world
+ * volume(s), and builds a G4TouchableHistory for every unique path. If the
+ * logical volume at the end of a path matches the `targetLVName`, its
+ * touchable history is stored.
  *
  * @param targetLVName The name of the logical volume to search for (e.g.,
- *"pet_crystal").
+ * "pet_crystal").
+ * @param worldName If non-empty, restrict the search to this world only.
+ * If empty, traverse all currently known worlds.
  * @return A vector of pointers to G4VTouchable objects.
  **/
 std::vector<std::unique_ptr<G4VTouchable>>
-FindAllTouchables(const G4String &targetLVName);
+FindAllTouchables(const G4String &targetLVName,
+                  const G4String &worldName = "");
 
 void FindAndBuildTouchables(G4VPhysicalVolume *currentVolume,
                             G4NavigationHistory &navHistory,

--- a/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
+++ b/core/opengate_core/opengate_lib/GatePhaseSpaceActor.cpp
@@ -132,13 +132,18 @@ void GatePhaseSpaceActor::SteppingAction(G4Step *step) {
 
   auto &l = fThreadLocalData.Get();
 
-  // Particle enters the volume if the pre step is at the volume boundary
-  const bool entering =
-      step->GetPreStepPoint()->GetStepStatus() == fGeomBoundary;
+  bool entering = false;
+  if (fStoreEnteringStep) {
+    // Particle enters the volume if the pre step is at the volume boundary
+    entering = step->GetPreStepPoint()->GetStepStatus() == fGeomBoundary;
+  }
 
-  // Particle exits the volume if the post step is at the volume boundary or at
-  // the world boundary if the phsp is attached to the world
-  const bool exiting = IsStepExitingAttachedVolume(step);
+  bool exiting = false;
+  if (fStoreExitingStep) {
+    // Particle exits the volume if the post step is at the volume boundary or
+    // at the world boundary if the phsp is attached to the world
+    exiting = IsStepExitingAttachedVolume(step);
+  }
 
   // When this is the first time we've seen this particle, fFirstStepInVolume is
   // true We then set it to false
@@ -170,12 +175,18 @@ void GatePhaseSpaceActor::SteppingAction(G4Step *step) {
     const auto *vol = step->GetPreStepPoint()->GetTouchable()->GetVolume();
     const auto vol_name = vol->GetName();
     std::string pname = "noproc";
+    std::string entering_s = "not_requested";
+    std::string exiting_s = "not_requested";
     if (p != nullptr)
       pname = p->GetProcessName();
+    if (fStoreEnteringStep)
+      entering_s = entering ? "true" : "false";
+    if (fStoreExitingStep)
+      exiting_s = exiting ? "true" : "false";
     std::cout << GetName() << " "
               << step->GetTrack()->GetParticleDefinition()->GetParticleName()
-              << /*" hits=" << fHits->GetSize() <<*/ " [" << entering << " "
-              << exiting << " " << first_step_in_volume << "]"
+              << /*" hits=" << fHits->GetSize() <<*/ " [" << entering_s << " "
+              << exiting_s << " " << first_step_in_volume << "]"
               << " eid=" << id << " tid=" << step->GetTrack()->GetTrackID()
               << " vol=" << vol_name
               << " mat=" << vol->GetLogicalVolume()->GetMaterial()->GetName()

--- a/core/opengate_core/opengate_lib/GateUniqueVolumeIDManager.cpp
+++ b/core/opengate_core/opengate_lib/GateUniqueVolumeIDManager.cpp
@@ -94,6 +94,12 @@ void GateUniqueVolumeIDManager::InitializeNumericIDsForLV(
     const G4LogicalVolume *lv, const G4VTouchable *touchable) {
   auto &l = fThreadLocalData.Get();
 
+  // TODO: In parallel-world setups, revisit this global touchable scan.
+  // FindAllTouchables(lv->GetName()) may aggregate instances across worlds
+  // that share the same LV name, whereas numeric ID assignment should ideally
+  // be resolved in the world context of the current touchable. We keep the
+  // legacy behavior on this branch to avoid mixing that refactor with the
+  // PhaseSpaceActor attached_to work.
   // Collect all touchables for this LV
   const auto touchables = FindAllTouchables(lv->GetName());
 

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -218,16 +218,9 @@ bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
     if (exitPair.first == preVol && exitPair.second == postVol)
       return true;
   }
-  if (!fAttachedToVolumeExitPairs.empty())
-    return false;
-
-  if (fAttachedToVolumeMotherName == "None") {
-    // Fallback for actors that still rely on a single attached_to mother volume.
-    Fatal("Cannot use IsStepExitingAttachedVolume when "
-          "fAttachedToVolumeMotherName is 'None'");
+  if (fAttachedToVolumeExitPairs.empty()) {
+    Fatal("Cannot use IsStepExitingAttachedVolume because no attached volume "
+          "exit pairs were configured.");
   }
-
-  // Legacy fallback for single-volume actors that still provide only the
-  // attached_to mother volume name.
-  return postVol->GetName() == fAttachedToVolumeMotherName;
+  return false;
 }

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -52,9 +52,8 @@ void GateVActor::AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
     Fatal("Cannot register an attached volume exit pair with a null physical "
           "volume.");
   }
-  const auto pair =
-      std::make_pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>(
-          attachedVolume, motherVolume);
+  const std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *> pair(
+      attachedVolume, motherVolume);
   for (const auto &existingPair : fAttachedToVolumeExitPairs) {
     if (existingPair == pair)
       return;

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -177,6 +177,11 @@ bool GateVActor::IsStepEnteringVolume(
 
 bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
   if (fAttachedToVolumeMotherName == "None") {
+    // This value is set when an actor has no single attached_to mother volume.
+    // For example, Python may receive attached_to as a list whose volumes do
+    // not share a common mother. PhaseSpaceActor guards that configuration in
+    // Python when exiting steps are requested, so this remains a defensive C++
+    // fallback.
     Fatal("Cannot use IsStepExitingAttachedVolume when "
           "fAttachedToVolumeMotherName is 'None'");
   }

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -211,7 +211,8 @@ bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
 
   const auto *preVol = step->GetPreStepPoint()->GetTouchable()->GetVolume();
   const auto *postVol = step->GetPostStepPoint()->GetTouchable()->GetVolume();
-  const auto &exitPairs = fThreadLocalExitPairsData.Get().attachedToVolumeExitPairs;
+  const auto &exitPairs =
+      fThreadLocalExitPairsData.Get().attachedToVolumeExitPairs;
 
   // Runtime-resolved physical-volume pairs are the robust path, notably for
   // repeated volumes whose physical names are auto-generated.

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -52,9 +52,9 @@ void GateVActor::AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
     Fatal("Cannot register an attached volume exit pair with a null physical "
           "volume.");
   }
-  const auto pair = std::make_pair<const G4VPhysicalVolume *,
-                                   const G4VPhysicalVolume *>(attachedVolume,
-                                                              motherVolume);
+  const auto pair =
+      std::make_pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>(
+          attachedVolume, motherVolume);
   for (const auto &existingPair : fAttachedToVolumeExitPairs) {
     if (existingPair == pair)
       return;

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -42,6 +42,26 @@ void GateVActor::SetMotherAttachedToVolumeName(
   fAttachedToVolumeMotherName = attachedToVolumeName;
 }
 
+void GateVActor::ClearAttachedVolumeExitPairs() {
+  fAttachedToVolumeExitPairs.clear();
+}
+
+void GateVActor::AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
+                                           G4VPhysicalVolume *motherVolume) {
+  if (attachedVolume == nullptr || motherVolume == nullptr) {
+    Fatal("Cannot register an attached volume exit pair with a null physical "
+          "volume.");
+  }
+  const auto pair = std::make_pair<const G4VPhysicalVolume *,
+                                   const G4VPhysicalVolume *>(attachedVolume,
+                                                              motherVolume);
+  for (const auto &existingPair : fAttachedToVolumeExitPairs) {
+    if (existingPair == pair)
+      return;
+  }
+  fAttachedToVolumeExitPairs.push_back(pair);
+}
+
 void GateVActor::InitializeUserInfo(py::dict &user_info) {
   fAttachedToVolumeName = DictGetStr(user_info, "attached_to");
   fActorName = DictGetStr(user_info, "name");
@@ -176,16 +196,6 @@ bool GateVActor::IsStepEnteringVolume(
 }
 
 bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
-  if (fAttachedToVolumeMotherName == "None") {
-    // This value is set when an actor has no single attached_to mother volume.
-    // For example, Python may receive attached_to as a list whose volumes do
-    // not share a common mother. PhaseSpaceActor guards that configuration in
-    // Python when exiting steps are requested, so this remains a defensive C++
-    // fallback.
-    Fatal("Cannot use IsStepExitingAttachedVolume when "
-          "fAttachedToVolumeMotherName is 'None'");
-  }
-
   // If the post step is world boundary: exiting
   if (step->GetPostStepPoint()->GetStepStatus() == fWorldBoundary)
     return true;
@@ -199,9 +209,25 @@ bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
   // boundaries overlap fAttachedToVolume boundaries, post step gives the
   // daughter.
 
-  // if the post step is at the boundary AND if it is in the mother volume:
-  // exiting
-  const auto *vol = step->GetPostStepPoint()->GetTouchable()->GetVolume();
-  const auto vol_name = vol->GetName();
-  return vol_name == fAttachedToVolumeMotherName;
+  const auto *preVol = step->GetPreStepPoint()->GetTouchable()->GetVolume();
+  const auto *postVol = step->GetPostStepPoint()->GetTouchable()->GetVolume();
+
+  // Runtime-resolved physical-volume pairs are the robust path, notably for
+  // repeated volumes whose physical names are auto-generated.
+  for (const auto &exitPair : fAttachedToVolumeExitPairs) {
+    if (exitPair.first == preVol && exitPair.second == postVol)
+      return true;
+  }
+  if (!fAttachedToVolumeExitPairs.empty())
+    return false;
+
+  if (fAttachedToVolumeMotherName == "None") {
+    // Fallback for actors that still rely on a single attached_to mother volume.
+    Fatal("Cannot use IsStepExitingAttachedVolume when "
+          "fAttachedToVolumeMotherName is 'None'");
+  }
+
+  // Legacy fallback for single-volume actors that still provide only the
+  // attached_to mother volume name.
+  return postVol->GetName() == fAttachedToVolumeMotherName;
 }

--- a/core/opengate_core/opengate_lib/GateVActor.cpp
+++ b/core/opengate_core/opengate_lib/GateVActor.cpp
@@ -43,7 +43,7 @@ void GateVActor::SetMotherAttachedToVolumeName(
 }
 
 void GateVActor::ClearAttachedVolumeExitPairs() {
-  fAttachedToVolumeExitPairs.clear();
+  fThreadLocalExitPairsData.Get().attachedToVolumeExitPairs.clear();
 }
 
 void GateVActor::AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
@@ -54,11 +54,12 @@ void GateVActor::AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
   }
   const std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *> pair(
       attachedVolume, motherVolume);
-  for (const auto &existingPair : fAttachedToVolumeExitPairs) {
+  auto &exitPairs = fThreadLocalExitPairsData.Get().attachedToVolumeExitPairs;
+  for (const auto &existingPair : exitPairs) {
     if (existingPair == pair)
       return;
   }
-  fAttachedToVolumeExitPairs.push_back(pair);
+  exitPairs.push_back(pair);
 }
 
 void GateVActor::InitializeUserInfo(py::dict &user_info) {
@@ -210,14 +211,15 @@ bool GateVActor::IsStepExitingAttachedVolume(const G4Step *step) const {
 
   const auto *preVol = step->GetPreStepPoint()->GetTouchable()->GetVolume();
   const auto *postVol = step->GetPostStepPoint()->GetTouchable()->GetVolume();
+  const auto &exitPairs = fThreadLocalExitPairsData.Get().attachedToVolumeExitPairs;
 
   // Runtime-resolved physical-volume pairs are the robust path, notably for
   // repeated volumes whose physical names are auto-generated.
-  for (const auto &exitPair : fAttachedToVolumeExitPairs) {
+  for (const auto &exitPair : exitPairs) {
     if (exitPair.first == preVol && exitPair.second == postVol)
       return true;
   }
-  if (fAttachedToVolumeExitPairs.empty()) {
+  if (exitPairs.empty()) {
     Fatal("Cannot use IsStepExitingAttachedVolume because no attached volume "
           "exit pairs were configured.");
   }

--- a/core/opengate_core/opengate_lib/GateVActor.h
+++ b/core/opengate_core/opengate_lib/GateVActor.h
@@ -9,6 +9,7 @@
 #define GateVActor_h
 
 #include "filters/GateVFilter.h"
+#include <G4Cache.hh>
 #include <G4Event.hh>
 #include <G4Run.hh>
 #include <G4VPrimitiveScorer.hh>
@@ -138,6 +139,12 @@ public:
 
   std::map<std::string, ActorOutputInfo_t> fActorOutputInfos;
 
+  struct threadLocalT {
+    std::vector<
+        std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>>
+        attachedToVolumeExitPairs;
+  };
+
   void SetSourceManager(GateSourceManager *s);
 
   void SetMotherAttachedToVolumeName(const std::string &attachedToVolumeName);
@@ -152,8 +159,7 @@ public:
   // Name of the mother volume (logical volume)
   std::string fAttachedToVolumeName;
   std::string fAttachedToVolumeMotherName;
-  std::vector<std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>>
-      fAttachedToVolumeExitPairs;
+  mutable G4Cache<threadLocalT> fThreadLocalExitPairsData;
 
   // Pointer to the filter
   GateVFilter *fFilter;

--- a/core/opengate_core/opengate_lib/GateVActor.h
+++ b/core/opengate_core/opengate_lib/GateVActor.h
@@ -13,10 +13,12 @@
 #include <G4Run.hh>
 #include <G4VPrimitiveScorer.hh>
 #include <pybind11/stl.h>
+#include <vector>
 
 namespace py = pybind11;
 
 class GateSourceManager;
+class G4VPhysicalVolume;
 
 class GateVActor : public G4VPrimitiveScorer {
 
@@ -139,6 +141,9 @@ public:
   void SetSourceManager(GateSourceManager *s);
 
   void SetMotherAttachedToVolumeName(const std::string &attachedToVolumeName);
+  void ClearAttachedVolumeExitPairs();
+  void AddAttachedVolumeExitPair(G4VPhysicalVolume *attachedVolume,
+                                 G4VPhysicalVolume *motherVolume);
 
   // List of actions (set to trigger some actions)
   // Can be set either on cpp or py side
@@ -147,6 +152,8 @@ public:
   // Name of the mother volume (logical volume)
   std::string fAttachedToVolumeName;
   std::string fAttachedToVolumeMotherName;
+  std::vector<std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>>
+      fAttachedToVolumeExitPairs;
 
   // Pointer to the filter
   GateVFilter *fFilter;

--- a/core/opengate_core/opengate_lib/GateVActor.h
+++ b/core/opengate_core/opengate_lib/GateVActor.h
@@ -140,8 +140,7 @@ public:
   std::map<std::string, ActorOutputInfo_t> fActorOutputInfos;
 
   struct threadLocalT {
-    std::vector<
-        std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>>
+    std::vector<std::pair<const G4VPhysicalVolume *, const G4VPhysicalVolume *>>
         attachedToVolumeExitPairs;
   };
 

--- a/core/opengate_core/opengate_lib/pyGateGeometryUtils.cpp
+++ b/core/opengate_core/opengate_lib/pyGateGeometryUtils.cpp
@@ -13,5 +13,6 @@ namespace py = pybind11;
 #include "GateGeometryUtils.h"
 
 void init_GateGeometryUtils(py::module &m) {
-  m.def("FindAllTouchables", FindAllTouchables);
+  m.def("FindAllTouchables", FindAllTouchables, py::arg("target_lv_name"),
+        py::arg("world_name") = "");
 }

--- a/core/opengate_core/opengate_lib/pyGateVActor.cpp
+++ b/core/opengate_core/opengate_lib/pyGateVActor.cpp
@@ -86,6 +86,9 @@ void init_GateVActor(py::module &m) {
       .def("HasAction", &GateVActor::HasAction)
       .def("SetMotherAttachedToVolumeName",
            &GateVActor::SetMotherAttachedToVolumeName)
+      .def("ClearAttachedVolumeExitPairs",
+           &GateVActor::ClearAttachedVolumeExitPairs)
+      .def("AddAttachedVolumeExitPair", &GateVActor::AddAttachedVolumeExitPair)
       .def("StartSimulationAction", &GateVActor::StartSimulationAction)
       .def("EndSimulationAction", &GateVActor::EndSimulationAction)
       .def("BeginOfRunAction", &GateVActor::BeginOfRunAction)

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -485,6 +485,8 @@ The option “exiting” stores the particle information whenever, starting from
 
 The option “all” stores the particle information for every step in the volume, including secondary particles generated in the volume. If you want to track all steps for both primary and secondary particles, use this option.
 
+When using local coordinates such as ``PrePositionLocal`` or ``PostPositionLocal`` with multiple ``attached_to`` volumes, each stored position is expressed in the local frame of the volume touched by that step. To interpret these entries afterwards, it is useful to also store a volume-identifying attribute such as ``PreStepUniqueVolumeID`` or ``PostStepUniqueVolumeID``. For simpler cases, ``TrackVolumeName`` together with ``PreStepVolumeCopyNo`` or ``PostStepVolumeCopyNo`` can also help distinguish the contributing volumes. If uniquely meaningful local coordinates are important for the analysis, it is often simpler to attach one ``PhaseSpaceActor`` per volume rather than combining several ``attached_to`` volumes in the same actor.
+
 
 Reference
 ~~~~~~~~~

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -474,7 +474,7 @@ By default, the PhaseSpaceActor stores information about particles entering the 
    phsp.steps_to_store = "entering exiting first"  # other options (combined)
    phsp.steps_to_store = "all"   # all steps (including secondary particles)
 
-If ``steps_to_store`` includes ``"exiting"`` and ``attached_to`` contains multiple volumes, those volumes must share the same mother volume. This is required so that the actor can unambiguously detect when a track exits the attached geometry.
+If ``steps_to_store`` includes ``"exiting"`` and ``attached_to`` contains multiple volumes, the actor resolves the exit condition independently for each attached physical volume. This allows repeated volumes and attached volumes with different mothers to be handled consistently.
 
 The option “first” stores the particle information when it enters the volume to which the actor is attached for the first time. The variables to be used are the PrePosition, PreDirection, etc.
 

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -474,6 +474,8 @@ By default, the PhaseSpaceActor stores information about particles entering the 
    phsp.steps_to_store = "entering exiting first"  # other options (combined)
    phsp.steps_to_store = "all"   # all steps (including secondary particles)
 
+If ``steps_to_store`` includes ``"exiting"`` and ``attached_to`` contains multiple volumes, those volumes must share the same mother volume. This is required so that the actor can unambiguously detect when a track exits the attached geometry.
+
 The option “first” stores the particle information when it enters the volume to which the actor is attached for the first time. The variables to be used are the PrePosition, PreDirection, etc.
 
 The option “entering” stores the particle information whenever it is at the boundary between the surrounding environment (world, another volume) and the volume to which the actor is attached. The variables to be used are the PrePosition, PreDirection, etc.

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -516,10 +516,11 @@ class ActorBase(GateObject):
             }
             pairs_added = 0
 
-            # Touchable histories let us recover the concrete mother physical
-            # volume for each attached copy. This avoids relying on auto-
-            # generated physical-volume names for repeated geometries.
-            for touchable in g4.FindAllTouchables(volume_name):
+            # Restrict the touchable lookup to the world currently being
+            # constructed. A global scan across all active navigators is too
+            # fragile during parallel-world setup because some other worlds may
+            # not have a ready navigator yet.
+            for touchable in g4.FindAllTouchables(volume_name, world_name):
                 attached_pv = touchable.GetVolume(0)
                 if attached_pv.GetInstanceID() not in valid_instance_ids:
                     continue
@@ -533,12 +534,12 @@ class ActorBase(GateObject):
                 self.AddAttachedVolumeExitPair(attached_pv, mother_pv)
                 pairs_added += 1
 
-            if pairs_added == 0:
-                fatal(
-                    f"Could not resolve any attached volume / mother volume "
-                    f"pairs for attached volume '{volume_name}' in actor "
-                    f"'{self.name}'."
-                )
+            # Some actors never use the attached volume / mother volume pairs,
+            # and in parallel-world setup there may be ConstructSDandField
+            # passes where Geant4 does not yield touchables for a given volume
+            # yet. We therefore leave the setup non-fatal here and let actors
+            # that actually need these pairs fail later if they try to use
+            # IsStepExitingAttachedVolume() without any resolved pairs.
 
     def _init_user_output_instance(self):
         for output_name, output_config in self._processed_user_output_config.items():

--- a/opengate/actors/base.py
+++ b/opengate/actors/base.py
@@ -6,6 +6,7 @@ from ..exception import fatal, GateImplementationError
 from ..base import GateObject, process_cls
 from ..utility import insert_suffix_before_extension
 from .actoroutput import ActorOutputRoot
+import opengate_core as g4
 
 
 def _setter_hook_attached_to(self, attached_to):
@@ -478,6 +479,7 @@ class ActorBase(GateObject):
             self.mother_attached_to = "None"
         # set the name of the attached_to mother volume to cpp
         self.SetMotherAttachedToVolumeName(self.mother_attached_to)
+        self.ClearAttachedVolumeExitPairs()
 
         any_active = False
         for p in self._existing_properties_to_interfaces:
@@ -498,6 +500,45 @@ class ActorBase(GateObject):
                 f"(actor type: {self.type_name}). "
                 f"Does the actor class somehow inherit from GateVActor (as it should)?"
             )
+
+    def initialize_attached_volume_mother_pairs(self, world_name):
+        attached_to = self.attached_to
+        if isinstance(attached_to, str):
+            attached_to = [attached_to]
+
+        for volume_name in attached_to:
+            volume = self.simulation.volume_manager.get_volume(volume_name)
+            if volume.world_volume.name != world_name or volume_name == __world_name__:
+                continue
+
+            valid_instance_ids = {
+                pv.GetInstanceID() for pv in volume.g4_physical_volumes
+            }
+            pairs_added = 0
+
+            # Touchable histories let us recover the concrete mother physical
+            # volume for each attached copy. This avoids relying on auto-
+            # generated physical-volume names for repeated geometries.
+            for touchable in g4.FindAllTouchables(volume_name):
+                attached_pv = touchable.GetVolume(0)
+                if attached_pv.GetInstanceID() not in valid_instance_ids:
+                    continue
+                if touchable.GetHistoryDepth() < 1:
+                    fatal(
+                        f"Could not resolve the mother physical volume for "
+                        f"attached volume '{volume_name}' in actor "
+                        f"'{self.name}'."
+                    )
+                mother_pv = touchable.GetVolume(1)
+                self.AddAttachedVolumeExitPair(attached_pv, mother_pv)
+                pairs_added += 1
+
+            if pairs_added == 0:
+                fatal(
+                    f"Could not resolve any attached volume / mother volume "
+                    f"pairs for attached volume '{volume_name}' in actor "
+                    f"'{self.name}'."
+                )
 
     def _init_user_output_instance(self):
         for output_name, output_config in self._processed_user_output_config.items():

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -1446,48 +1446,6 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
             )
         g4.GatePhaseSpaceActor.EndSimulationAction(self)
 
-    def initialize_attached_volume_exit_pairs(self, world_name):
-        if "exiting" not in self.steps_to_store:
-            return
-
-        attached_to = self.attached_to
-        if isinstance(attached_to, str):
-            attached_to = [attached_to]
-
-        for volume_name in attached_to:
-            volume = self.simulation.volume_manager.get_volume(volume_name)
-            if volume.world_volume.name != world_name or volume_name == "world":
-                continue
-
-            valid_instance_ids = {
-                pv.GetInstanceID() for pv in volume.g4_physical_volumes
-            }
-            pairs_added = 0
-
-            # Touchable histories let us recover the concrete mother physical
-            # volume for each attached copy. This avoids relying on auto-
-            # generated physical-volume names for repeated geometries.
-            for touchable in g4.FindAllTouchables(volume_name):
-                attached_pv = touchable.GetVolume(0)
-                if attached_pv.GetInstanceID() not in valid_instance_ids:
-                    continue
-                if touchable.GetHistoryDepth() < 1:
-                    fatal(
-                        f"Could not resolve the mother physical volume for "
-                        f"attached volume '{volume_name}' in PhaseSpaceActor "
-                        f"'{self.name}'."
-                    )
-                mother_pv = touchable.GetVolume(1)
-                self.AddAttachedVolumeExitPair(attached_pv, mother_pv)
-                pairs_added += 1
-
-            if pairs_added == 0:
-                fatal(
-                    f"Could not resolve any exiting-step geometry pairs for "
-                    f"attached volume '{volume_name}' in PhaseSpaceActor "
-                    f"'{self.name}'."
-                )
-
 
 class DigiAttributeProcessDefinedStepInVolumeActor(
     ActorBase, g4.GateDigiAttributeProcessDefinedStepInVolumeActor

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -1397,7 +1397,8 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
             "entering",
             {
                 "doc": "Define when to store the hits, can be 'entering', 'exiting', 'first' or 'all'. "
-                "Or several values separated by a space. ",
+                "Or several values separated by a space. If 'exiting' is used with multiple "
+                "attached_to volumes, those volumes must share a unique common mother volume. ",
                 # "allowed_values": ["entering", "exiting", "first", "all"], # can be multiple
             },
         ),
@@ -1413,8 +1414,41 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
     def __initcpp__(self):
         g4.GatePhaseSpaceActor.__init__(self, self.user_info)
 
+    def _get_attached_to_mother_for_exiting(self):
+        # Exiting-step detection in C++ compares the post-step volume name
+        # against a single attached_to mother volume name. Multiple attached
+        # volumes are therefore acceptable only if they all share that mother.
+        if isinstance(self.attached_to, str):
+            vol = self.simulation.volume_manager.get_volume(self.attached_to)
+            return vol.mother if vol.mother is not None else "world"
+
+        mothers = set()
+        for volume_name in self.attached_to:
+            vol = self.simulation.volume_manager.get_volume(volume_name)
+            mothers.add(vol.mother if vol.mother is not None else "world")
+
+        if len(mothers) != 1:
+            fatal(
+                f"PhaseSpaceActor '{self.name}' stores exiting steps and therefore "
+                f"requires a single attached_to mother volume. The attached volumes "
+                f"{self.attached_to} have different mothers: {sorted(mothers)}."
+            )
+        return next(iter(mothers))
+
     def initialize(self):
+        attached_to_mother = None
+        if "exiting" in self.steps_to_store:
+            # Only the exiting-step mode needs an unambiguous mother volume.
+            # Other phase-space modes can still work with multiple attached
+            # volumes because they do not call IsStepExitingAttachedVolume().
+            attached_to_mother = self._get_attached_to_mother_for_exiting()
         DigitizerBase.initialize(self)
+        if attached_to_mother is not None:
+            # ActorBase.initialize() stores "None" for list-style attached_to.
+            # Override it here with the validated common mother required by the
+            # PhaseSpaceActor exiting-step logic in C++.
+            self.mother_attached_to = attached_to_mother
+            self.SetMotherAttachedToVolumeName(attached_to_mother)
         if "entering" in self.steps_to_store:
             self.SetStoreEnteringStepFlag(True)
         if "exiting" in self.steps_to_store:

--- a/opengate/actors/digitizers.py
+++ b/opengate/actors/digitizers.py
@@ -1397,8 +1397,9 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
             "entering",
             {
                 "doc": "Define when to store the hits, can be 'entering', 'exiting', 'first' or 'all'. "
-                "Or several values separated by a space. If 'exiting' is used with multiple "
-                "attached_to volumes, those volumes must share a unique common mother volume. ",
+                "Or several values separated by a space. When 'exiting' is used with multiple "
+                "attached_to volumes, exit transitions are resolved independently for each "
+                "attached physical volume. ",
                 # "allowed_values": ["entering", "exiting", "first", "all"], # can be multiple
             },
         ),
@@ -1414,41 +1415,13 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
     def __initcpp__(self):
         g4.GatePhaseSpaceActor.__init__(self, self.user_info)
 
-    def _get_attached_to_mother_for_exiting(self):
-        # Exiting-step detection in C++ compares the post-step volume name
-        # against a single attached_to mother volume name. Multiple attached
-        # volumes are therefore acceptable only if they all share that mother.
-        if isinstance(self.attached_to, str):
-            vol = self.simulation.volume_manager.get_volume(self.attached_to)
-            return vol.mother if vol.mother is not None else "world"
-
-        mothers = set()
-        for volume_name in self.attached_to:
-            vol = self.simulation.volume_manager.get_volume(volume_name)
-            mothers.add(vol.mother if vol.mother is not None else "world")
-
-        if len(mothers) != 1:
-            fatal(
-                f"PhaseSpaceActor '{self.name}' stores exiting steps and therefore "
-                f"requires a single attached_to mother volume. The attached volumes "
-                f"{self.attached_to} have different mothers: {sorted(mothers)}."
-            )
-        return next(iter(mothers))
-
     def initialize(self):
-        attached_to_mother = None
-        if "exiting" in self.steps_to_store:
-            # Only the exiting-step mode needs an unambiguous mother volume.
-            # Other phase-space modes can still work with multiple attached
-            # volumes because they do not call IsStepExitingAttachedVolume().
-            attached_to_mother = self._get_attached_to_mother_for_exiting()
         DigitizerBase.initialize(self)
-        if attached_to_mother is not None:
-            # ActorBase.initialize() stores "None" for list-style attached_to.
-            # Override it here with the validated common mother required by the
-            # PhaseSpaceActor exiting-step logic in C++.
-            self.mother_attached_to = attached_to_mother
-            self.SetMotherAttachedToVolumeName(attached_to_mother)
+        if "exiting" in self.steps_to_store:
+            # Exit transitions are resolved later, once Geant4 has constructed
+            # the physical volumes and we can identify concrete (pre, post)
+            # volume pairs for each attached volume copy.
+            self.ClearAttachedVolumeExitPairs()
         if "entering" in self.steps_to_store:
             self.SetStoreEnteringStepFlag(True)
         if "exiting" in self.steps_to_store:
@@ -1472,6 +1445,48 @@ class PhaseSpaceActor(DigitizerWithRootOutput, g4.GatePhaseSpaceActor):
                 f"Empty output, no particles stored in {self.get_output_path()}"
             )
         g4.GatePhaseSpaceActor.EndSimulationAction(self)
+
+    def initialize_attached_volume_exit_pairs(self, world_name):
+        if "exiting" not in self.steps_to_store:
+            return
+
+        attached_to = self.attached_to
+        if isinstance(attached_to, str):
+            attached_to = [attached_to]
+
+        for volume_name in attached_to:
+            volume = self.simulation.volume_manager.get_volume(volume_name)
+            if volume.world_volume.name != world_name or volume_name == "world":
+                continue
+
+            valid_instance_ids = {
+                pv.GetInstanceID() for pv in volume.g4_physical_volumes
+            }
+            pairs_added = 0
+
+            # Touchable histories let us recover the concrete mother physical
+            # volume for each attached copy. This avoids relying on auto-
+            # generated physical-volume names for repeated geometries.
+            for touchable in g4.FindAllTouchables(volume_name):
+                attached_pv = touchable.GetVolume(0)
+                if attached_pv.GetInstanceID() not in valid_instance_ids:
+                    continue
+                if touchable.GetHistoryDepth() < 1:
+                    fatal(
+                        f"Could not resolve the mother physical volume for "
+                        f"attached volume '{volume_name}' in PhaseSpaceActor "
+                        f"'{self.name}'."
+                    )
+                mother_pv = touchable.GetVolume(1)
+                self.AddAttachedVolumeExitPair(attached_pv, mother_pv)
+                pairs_added += 1
+
+            if pairs_added == 0:
+                fatal(
+                    f"Could not resolve any exiting-step geometry pairs for "
+                    f"attached volume '{volume_name}' in PhaseSpaceActor "
+                    f"'{self.name}'."
+                )
 
 
 class DigiAttributeProcessDefinedStepInVolumeActor(

--- a/opengate/contrib/pet/castor_helpers.py
+++ b/opengate/contrib/pet/castor_helpers.py
@@ -29,6 +29,11 @@ def create_castor_config(simulation_engine, param):
     }
 
     volume_name = param["volume_name"]
+    # TODO: In parallel-world setups, consider passing an explicit world to
+    # FindAllTouchables(). This helper currently performs a global scan by
+    # volume name, which may mix instances from multiple worlds with the same
+    # logical-volume name. We keep the behavior unchanged on this branch to
+    # avoid coupling the CASToR helper refactor to the PhaseSpaceActor fix.
     touchables = g4.FindAllTouchables(volume_name)
     m = g4.GateUniqueVolumeIDManager.GetInstance()
 

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -691,8 +691,11 @@ class ActorEngine(EngineBase):
                         register_sensitive_detector_to_children(
                             actor, volume.g4_logical_volume
                         )
-                if hasattr(actor, "initialize_attached_volume_exit_pairs"):
-                    actor.initialize_attached_volume_exit_pairs(world_name)
+            # This must happen here, after Geant4 has constructed the physical
+            # volumes for the current world. The ActorBase hook resolves
+            # concrete (attached physical volume -> mother physical volume)
+            # pairs, which cannot be derived earlier from user_info alone.
+            actor.initialize_attached_volume_mother_pairs(world_name)
 
             # 4. Handle Biasing Operators/Actors (specific)
             # this is needed for MultiThread run

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -691,6 +691,8 @@ class ActorEngine(EngineBase):
                         register_sensitive_detector_to_children(
                             actor, volume.g4_logical_volume
                         )
+                if hasattr(actor, "initialize_attached_volume_exit_pairs"):
+                    actor.initialize_attached_volume_exit_pairs(world_name)
 
             # 4. Handle Biasing Operators/Actors (specific)
             # this is needed for MultiThread run


### PR DESCRIPTION
This PR improves `PhaseSpaceActor` handling of `attached_to` volumes, especially for repeated geometries and multi-volume attachments.

It first makes the exiting-step logic less restrictive and more user-facing: validation is moved to Python, the error messages are clearer, and the docs around `steps_to_store` now explain the relevant behavior. It also cleans up the stepping logic so debug output does not affect what is computed, and `"entering"` / `"exiting"` are only evaluated when actually requested.

The main refactor replaces the old single `attached_to` mother-name mechanism with runtime-resolved physical-volume to mother-volume pairs. These pairs are built after geometry construction in `ActorBase`, then used by `GateVActor::IsStepExitingAttachedVolume()` to detect exits robustly for repeated volumes and multiple attached volumes. This removes the dependence on auto-generated repeated physical-volume names and centralizes the setup in the actor base/engine lifecycle.