### PR TITLE
Fix the docs

### DIFF
--- a/docs/source/developer_guide/developer_guide_code_structure.rst
+++ b/docs/source/developer_guide/developer_guide_code_structure.rst
@@ -308,3 +308,8 @@ inherits from another class, call the superclass:
 
 In particular, the GateObject superclass (and variants) implement a
 ``__str__()`` method which lists all user_info of the object.
+
+Reference
+---------
+
+.. autoclass:: opengate.base.GateObject

--- a/docs/source/developer_guide/developer_guide_contribute.rst
+++ b/docs/source/developer_guide/developer_guide_contribute.rst
@@ -41,7 +41,7 @@ that simulation outcome is reliable as we keep developing the code.
 Therefore, we have a large set of tests which are regularly run. If you
 propose new features or make changes to the inner workings of Gate,
 please create a little test simulation that goes with it. It should be
-imlpemented in such a way that it checks whether the feature works as
+implemented in such a way that it checks whether the feature works as
 expected. This might be a check of Geant4 parameters, e.g. if production
 cuts are set correctly, or based on simulation outcome, such as a dose
 maps or a particle phase space. Best is to look at the folder ``tests``

--- a/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
+++ b/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
@@ -524,3 +524,8 @@ To make a parameter dynamic:
 
 This architecture keeps the user-facing API simple while keeping the runtime
 logic generic and reusable.
+
+References
+----------
+
+.. autoclass:: opengate.base.DynamicGateObject

--- a/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
+++ b/docs/source/developer_guide/developer_guide_dynamic_parametrisations.rst
@@ -23,17 +23,18 @@ General architecture
 
 The dynamic system has four main building blocks:
 
-1. a dynamic object,
-2. one or more changers,
-3. a hidden dynamic actor,
-4. engine-side wiring which creates and registers that actor.
+1. a :ref:`dynamic object <section-dynamic-objects>`,
+2. one or more :ref:`changers <section-changers>`,
+3. a hidden :ref:`dynamic actor <section-dynamic-actors>`,
+4. :ref:`engine-side wiring <section-engine-side-wiring>` which creates and registers that actor.
 
+.. _section-dynamic-objects:
 
 Dynamic objects
 ~~~~~~~~~~~~~~~
 
 Objects which support dynamic parametrisations inherit from
-``DynamicGateObject`` in ``opengate/base.py``.
+:class:`opengate.base.DynamicGateObject` in ``opengate/base.py``.
 
 This base class provides:
 
@@ -143,6 +144,7 @@ The more elaborate example
 ``opengate/tests/src/actors/test030_dose_motion_dynamic_param_custom.py`` uses
 the same idea for custom translation and rotation changers.
 
+.. _section-changers:
 
 Changers
 ~~~~~~~~
@@ -171,6 +173,7 @@ The ``attached_to`` user parameter of changers is handled like other GateObject
 parameters and becomes a generated property when ``process_cls()`` is called on
 the changer class.
 
+.. _section-dynamic-actors:
 
 Dynamic actors
 ~~~~~~~~~~~~~~
@@ -191,6 +194,7 @@ For geometry, ``DynamicGeometryActor`` may temporarily open and close the
 geometry around the update. For sources, ``DynamicSourceActor`` simply forwards
 the run id to its changers.
 
+.. _section-engine-side-wiring:
 
 Engine-side wiring
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/developer_guide/developer_guide_how_to_implement.rst
+++ b/docs/source/developer_guide/developer_guide_how_to_implement.rst
@@ -4,39 +4,61 @@ How to implement an actor
 Mandatory basic class structure
 -------------------------------
 
-1) Implement an ``initialize()`` method which should at least:
+1. Implement an ``initialize()`` method which should at least:
+    - call the ``initialize()`` method from the python super class;
+    - call the ``InitializeCpp()`` method from the C++ super class;
+    - call the ``InitializeUserInfo()`` method from the C++ super class;
+    - If you need to perform specific checks, e.g. plausibility of user
+      input parameters, you will probably want to do that before calling
+      the C++ methods.
+    - Example:
+       .. code:: python
 
--  call the ``initialize()`` method from the python super class.
--  call the ``InitializeCpp()`` method from the C++ super class
--  call the ``InitializeUserInfo()`` method from the C++ super class
--  If you need to perform specific checks, e.g. plausibility of user
-   input parameters, you will probably want to do that before calling
-   the C++ methods.
--  Example:
-   ``python     def initialize(self):         ActorBase.initialize(self)         # possibly implement some checks here ...         self.InitializeUserInfo(self.user_info)         self.InitializeCpp()``
+           def initialize(self):
+               ActorBase.initialize(self)
+               # possibly implement some checks here ...
+               self.InitializeUserInfo(self.user_info)
+               self.InitializeCpp()
 
-2) Implement a ``__initcpp__()`` method. This should at least call the
+2. Implement a ``__initcpp__()`` method. This should at least call the
    C++ constructor method and add actions if needed. Example:
-   ``python     def __initcpp__(self):         g4.GateSimulationStatisticsActor.__init__(self, self.user_info)         self.AddActions({"StartSimulationAction", "EndSimulationAction"})``
+
+   .. code:: python
+
+       def __initcpp__(self):
+           g4.GateSimulationStatisticsActor.__init__(self, self.user_info)
+           self.AddActions({"StartSimulationAction", "EndSimulationAction"})
+
    Do **not** call the C++ constructor in the python ``__init__()``
    method. This will cause problems when a simulation is run in a
    subprocess. Reason: The subprocessing mechanism relies on
    de-/serialization and GATE expects a ``__initcpp__()`` method to make
    sure the C++ constructor is called after deserialization (see
-   ``__setstate__()`` in *actors/base.py*)
+   ``__setstate__()`` in ``actors/base.py``).
 
-3) Inherit first from the python base class and then from the C++ base
+3. Inherit first from the python base class and then from the C++ base
    class. In other words, write:
-   ``python     class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):``
-   Do **not** write:
-   ``python     class SimulationStatisticsActor( g4.GateSimulationStatisticsActor, ActorBase):``
 
-4) Refer to the super class explicitly and do **not** use the
+   .. code:: python
+
+       class SimulationStatisticsActor(ActorBase, g4.GateSimulationStatisticsActor):
+           # docstring, IDE hints, methods, etc.
+
+   Do **not** write:
+
+   .. code:: python
+
+       class SimulationStatisticsActor( g4.GateSimulationStatisticsActor, ActorBase):
+           # docstring, IDE hints, methods, etc.
+
+4. Refer to the super class explicitly and do **not** use the
    ``super()`` builtin from python because it cannot resolve C++ super
    classes.
 
-Inheritance in actor classes
-----------------------------
+..
+    Inheritance in actor classes
+    ----------------------------
 
-FIXME: Inherit first from python base class and then from C++ base
-class.
+..
+    FIXME: Inherit first from python base class and then from C++ base
+    class. (DJB: I commented this out because I think this is already described in point 3 above.)

--- a/docs/source/developer_guide/developer_guide_init_actors.rst
+++ b/docs/source/developer_guide/developer_guide_init_actors.rst
@@ -4,25 +4,27 @@ Initialization sequence for actors
 
 Here is the chronological initialization sequence for actors, mapping the bridge between Python and C++.
 
-### Monothread (ST) Initialization Sequence
+Single threaded (ST) Initialization Sequence
+--------------------------------------------
 
-1. **`actor_engine.initialize()` (Python):** Python master loop triggers actor configuration before Geant4 builds the geometry.
-2. **`InitializeUserInfo()` & `InitializeCpp()` (C++):** Extracts parameters from the Python dictionary (e.g., splitting factors, kill volumes) and registers the C++ actor instance.
-3. **`g4_RunManager.Initialize()` (C++):** Geant4 constructs the master mass and parallel geometries.
-4. **`ConstructSDandField()` (Python/C++):** Geant4 triggers OpenGATE to handle sensitive detectors and biasing operators.
-5. **`ConfigureForWorker()` (C++):** The actor looks up the main `G4LogicalVolume` and attaches itself (and to all daughter volumes).
-6. **`actor_engine.register_actions()` (Python):** Binds the Python actor to the master thread's Tracking, Stepping, Event, and Run action lists.
-7. **`StartTracking()` (C++):** Triggered natively by Geant4 when a particle track begins, resetting tracking flags.
+1. ``actor_engine.initialize()`` (Python): Python master loop triggers actor configuration before Geant4 builds the geometry.
+2. ``InitializeUserInfo()`` & ``InitializeCpp()`` (C++): Extracts parameters from the Python dictionary (e.g., splitting factors, kill volumes) and registers the C++ actor instance.
+3. ``g4_RunManager.Initialize()`` (C++): Geant4 constructs the master mass and parallel geometries.
+4. ``ConstructSDandField()`` (Python/C++): Geant4 triggers OpenGATE to handle sensitive detectors and biasing operators.
+5. ``ConfigureForWorker()`` (C++): The actor looks up the main ``G4LogicalVolume`` and attaches itself (and to all daughter volumes).
+6. ``actor_engine.register_actions()`` (Python): Binds the Python actor to the master thread's Tracking, Stepping, Event, and Run action lists.
+7. ``StartTracking()`` (C++): Triggered natively by Geant4 when a particle track begins, resetting tracking flags.
 
 
-### Multithread (MT) Initialization Sequence
+Multithreaded (MT) Initialization Sequence
+------------------------------------------
 
-1. **`actor_engine.initialize()` (Python):** Executed strictly on the Master Thread to push Python parameters to C++ before workers exist.
-2. **`InitializeUserInfo()` & `InitializeCpp()` (C++):** Executes on the Master Thread to save variables (must *not* initialize thread-local pointers here).
-3. **`g4_RunManager.InitializeWithoutFakeRun()` (C++):** Geant4 builds the master geometry but holds off on worker creation.
-4. **`FakeBeamOn()` (C++):** Geant4 officially spawns the worker threads.
-5. **`ConstructSDandField()` (Python/C++):** Triggered by Geant4 independently *for every single worker thread*.
-6. **`ConfigureForWorker()` (C++):** Called per worker. The actor securely attaches itself to the thread-local instances of the `G4LogicalVolume`.
-7. **`actor_engine.register_actions()` (Python):** Binds the Python actor to the newly created, thread-local Geant4 action lists.
-8. **`PreUserTrackingAction()` (C++):** OpenGATE's mandatory MT hook to force tracking initialization (since Geant4 skips native `StartTracking` for MT biasing operators).
-9. **`StartTracking()` (C++):** Triggered by `PreUserTrackingAction`. Lazy-initializes the thread-local caches (`threadLocalData.Get()`), instantiates the thread-local operations, and resets flags.
+1. ``actor_engine.initialize()`` (Python): Executed strictly on the Master Thread to push Python parameters to C++ before workers exist.
+2. ``InitializeUserInfo()`` & ``InitializeCpp()`` (C++): Executes on the Master Thread to save variables (must *not* initialize thread-local pointers here).
+3. ``g4_RunManager.InitializeWithoutFakeRun()`` (C++): Geant4 builds the master geometry but holds off on worker creation.
+4. ``FakeBeamOn()`` (C++): Geant4 officially spawns the worker threads.
+5. ``ConstructSDandField()`` (Python/C++): Triggered by Geant4 independently *for every single worker thread*.
+6. ``ConfigureForWorker()`` (C++): Called per worker. The actor securely attaches itself to the thread-local instances of the ``G4LogicalVolume``.
+7. ``actor_engine.register_actions()`` (Python): Binds the Python actor to the newly created, thread-local Geant4 action lists.
+8. ``PreUserTrackingAction()`` (C++): OpenGATE's mandatory MT hook to force tracking initialization (since Geant4 skips native ``StartTracking`` for MT biasing operators).
+9. ``StartTracking()`` (C++): Triggered by ``PreUserTrackingAction``. Lazy-initializes the thread-local caches (``threadLocalData.Get()``), instantiates the thread-local operations, and resets flags.

--- a/docs/source/developer_guide/developer_guide_installation.rst
+++ b/docs/source/developer_guide/developer_guide_installation.rst
@@ -181,9 +181,10 @@ Documentation for the documentation
 
 The document is created with `readthedoc <https://docs.readthedocs.io/en/stable/index.html>`_. To build the html pages locally, use `make html` in the `docs/` folder of the source directory. Configuration is in the `docs/source/conf.py` file. The current theme is `sphinx_pdj_theme <https://github.com/jucacrispim/sphinx_pdj_theme>`_.
 
-You also need to install some packages : `pip install sphinx sphinx-copybutton pydata-sphinx-theme`
+You also need to install some packages : ``pip install sphinx sphinx-copybutton pydata-sphinx-theme``
 
 Help with reStructuredText syntax:
 
 - `quickref <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_
 - `directives <https://docutils.sourceforge.io/docs/ref/rst/directives.html>`_
+- `sphinx for python <https://www.sphinx-doc.org/en/master/usage/domains/python.html>`_

--- a/docs/source/developer_guide/developer_guide_installation.rst
+++ b/docs/source/developer_guide/developer_guide_installation.rst
@@ -179,9 +179,9 @@ pytorch and gaga-phsp first with:
 Documentation for the documentation
 -----------------------------------
 
-The document is created with `readthedoc <https://docs.readthedocs.io/en/stable/index.html>`_. To build the html pages locally, use `make html` in the `docs/` folder of the source directory. Configuration is in the `docs/source/config.py` file. The current theme is `sphinx_pdj_theme <https://github.com/jucacrispim/sphinx_pdj_theme>`_.
+The document is created with `readthedoc <https://docs.readthedocs.io/en/stable/index.html>`_. To build the html pages locally, use `make html` in the `docs/` folder of the source directory. Configuration is in the `docs/source/conf.py` file. The current theme is `sphinx_pdj_theme <https://github.com/jucacrispim/sphinx_pdj_theme>`_.
 
-You also need to install some packages : `pip install sphinx sphinx_copybutton pydata_sphinx_theme`
+You also need to install some packages : `pip install sphinx sphinx-copybutton pydata-sphinx-theme`
 
 Help with reStructuredText syntax:
 

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -21,5 +21,6 @@ Developer guide
    :maxdepth: 2
 
    developer_guide_notes
-   developer_guide_remaining_stuff
+   developer_guide_init_actors
    developer_guide_coincidence_sorter_mt
+   developer_guide_remaining_stuff

--- a/docs/source/user_guide/user_guide_actors.rst
+++ b/docs/source/user_guide/user_guide_actors.rst
@@ -77,10 +77,10 @@ The :class:`~.opengate.actors.digitizers.PhaseSpaceActor` has only a single outp
   sim.output_dir = "/my/preferred/location/"
   phsp_actor1 = sim.add_actor("PhaseSpaceActor", name="phsp_actor1")
   phsp_actor1.output_filename = 'phsp1.root'
-  phsp_actor2 = sim.add_actor("PhaseSpaceActor", name="phsp_actor1")
+  phsp_actor2 = sim.add_actor("PhaseSpaceActor", name="phsp_actor2")
   phsp_actor2.output_filename = 'phsp2.root'
 
-In the example above, we set the global output directory of the simulation to our preferred location via :attr:`~.opengate.managers.Simulation.output_dir` and define the filename for each actor via :attr:`~.opengate.acrtors.digitizers.PhaseSpaceActor.output_filename`. GATE will automatically combine the filenames with the output path. You can also use relative paths including subfolders, like:
+In the example above, we set the global output directory of the simulation to our preferred location via :attr:`~.opengate.managers.Simulation.output_dir` and define the filename for each actor via :attr:`~.opengate.actors.digitizers.PhaseSpaceActor.output_filename`. GATE will automatically combine the filenames with the output path. You can also use relative paths including subfolders, like:
 
 .. code-block:: python
 
@@ -93,7 +93,7 @@ This will create a subfolder ''phsp'' in your preferred output folder defined vi
 
 .. note:: We highly recommend the pathlib library to work with paths. It makes things very easier and platform independent.
 
-You can also decide not to write data to disk, if you wish so. In the above example, set :attr:`~.opengate.acrtors.digitizers.PhaseSpaceActor.write_to_disk` to ``False``:
+You can also decide not to write data to disk, if you wish so. In the above example, set :attr:`~.opengate.actors.digitizers.PhaseSpaceActor.write_to_disk` to ``False``:
 
 .. code-block:: python
 

--- a/docs/source/user_guide/user_guide_actors.rst
+++ b/docs/source/user_guide/user_guide_actors.rst
@@ -244,3 +244,13 @@ Actor output
 .. autoproperty:: opengate.actors.actoroutput.BaseUserInterfaceToActorOutput.keep_data_per_run
 
 .. autoproperty:: opengate.actors.actoroutput.BaseUserInterfaceToActorOutput.active
+
+.. autoproperty:: opengate.actors.digitizers.PhaseSpaceActor.root_output
+
+.. autoproperty:: opengate.managers.Simulation.output_dir
+
+.. autoproperty:: opengate.actors.digitizers.PhaseSpaceActor.output_filename
+
+.. autoproperty:: opengate.actors.digitizers.PhaseSpaceActor.write_to_disk
+
+.. autoproperty:: opengate.actors.actoroutput.UserInterfaceToActorOutputImage.image

--- a/docs/source/user_guide/user_guide_fields.rst
+++ b/docs/source/user_guide/user_guide_fields.rst
@@ -271,3 +271,5 @@ Class reference
 
 .. autoclass:: opengate.geometry.fields.CustomElectroMagneticField
    :members:
+
+.. automethod:: opengate.geometry.volumes.VolumeBase.add_field

--- a/docs/source/user_guide/user_guide_fields.rst
+++ b/docs/source/user_guide/user_guide_fields.rst
@@ -248,10 +248,11 @@ The field implementation is covered by the ``test099_fields_*`` tests in ``openg
 
 
 Class reference
-----------------
+---------------
 
 .. autoclass:: opengate.geometry.fields.FieldBase
    :members:
+   :noindex:
 
 .. autoclass:: opengate.geometry.fields.UniformMagneticField
    :members:

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -605,8 +605,12 @@ Reference
 
 .. autoclass:: opengate.actors.digitizers.DigitizerHitsCollectionActor
 
-ProcessDefinedStepInVolumeAttribute
------------------------------------
+.. note::
+    The ``ProcessDefinedStepInVolumeAttribute`` "hidden actor" was recently (May 2026) replaced by the ``auxiliary`` actor.
+    These docs will get corresponding updates soon.
+
+ProcessDefinedStepInVolumeAttributeLegacy
+-----------------------------------------
 
 Description
 ~~~~~~~~~~~
@@ -626,14 +630,14 @@ To use it, you must instantiate the class with the simulation object, the proces
 
 .. code-block:: python
 
-   from opengate.actors.digitizers import ProcessDefinedStepInVolumeAttribute
+   from opengate.actors.digitizers import ProcessDefinedStepInVolumeAttributeLegacy
 
    # 1. Define the custom attributes
    # Count "compt" (Compton scattering) interactions in volume "Waterbox1"
-   att_compt = ProcessDefinedStepInVolumeAttribute(sim, "compt", "Waterbox1")
+   att_compt = ProcessDefinedStepInVolumeAttributeLegacy(sim, "compt", "Waterbox1")
 
    # Count "Rayl" (Rayleigh scattering) interactions in volume "world"
-   att_rayl = ProcessDefinedStepInVolumeAttribute(sim, "Rayl", "world")
+   att_rayl = ProcessDefinedStepInVolumeAttributeLegacy(sim, "Rayl", "world")
 
    # 2. Create the actor (e.g. PhaseSpace)
    phsp = sim.add_actor("PhaseSpaceActor", "PhaseSpace")
@@ -664,10 +668,12 @@ Once defined, this custom attribute behaves like any other standard attribute (e
    * **Process Name:** Must match the internal Geant4 process name (e.g., ``compt``, ``phot``, ``Rayl``, ``eBrem``).
    * **Volume Name:** Must be the name of a volume existing in the simulation.
 
-Reference
-~~~~~~~~~
+..
+    Reference
+    ~~~~~~~~~
 
-.. autoclass:: opengate.actors.digitizers.ProcessDefinedStepInVolumeAttribute
+.. 
+    .. autoclass:: opengate.actors.digitizers.ProcessDefinedStepInVolumeAttributeLegacy
 
 DigitizerAdderActor
 -----------------------

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -1132,7 +1132,7 @@ This actor is typically attached to the world or a specific phantom volume. It e
 
 
 Angular Acceptance and Forced Direction Policies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When configuring directional biasing, the choice of policy is important.
 

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -672,7 +672,7 @@ Once defined, this custom attribute behaves like any other standard attribute (e
     Reference
     ~~~~~~~~~
 
-.. 
+..
     .. autoclass:: opengate.actors.digitizers.ProcessDefinedStepInVolumeAttributeLegacy
 
 DigitizerAdderActor

--- a/docs/source/user_guide/user_guide_reference_actors.rst
+++ b/docs/source/user_guide/user_guide_reference_actors.rst
@@ -679,7 +679,7 @@ DigitizerReadoutActor
 Description
 ~~~~~~~~~~~
 
-This actor is similar to the :class:`~.opengate.actors.digitizers.DigitizerAdderActor`, with one additional option: the resulting positions of the digi are set at the center of the defined volumes (discretized). The option :attr:`~.opengate.actors.digitizers.DigitizerAdderActor.discretize_volume` indicates the volume name where the discrete position will be taken.
+This actor is similar to the :class:`~.opengate.actors.digitizers.DigitizerAdderActor`, with one additional option: the resulting positions of the digi are set at the center of the defined volumes (discretized). The option :attr:`~.opengate.actors.digitizers.DigitizerReadoutActor.discretize_volume` indicates the volume name where the discrete position will be taken.
 
 .. code-block:: python
 
@@ -1283,3 +1283,7 @@ Reference
 
 .. autoclass:: opengate.actors.pgactors.VoxelizedPromptGammaAnalogActor
 .. autoclass:: opengate.actors.pgactors.VoxelizedPromptGammaTLEActor
+.. autoproperty:: opengate.actors.digitizers.DigitizerBase.authorize_repeated_volumes
+.. autoproperty:: opengate.actors.digitizers.DigitizerReadoutActor.discretize_volume
+.. autoproperty:: opengate.sources.base.SourceBase.half_life
+.. automethod:: opengate.managers.VolumeManager.dump_volume_tree

--- a/docs/source/user_guide/user_guide_reference_auxiliary_attributes.rst
+++ b/docs/source/user_guide/user_guide_reference_auxiliary_attributes.rst
@@ -71,9 +71,12 @@ Reference
 
 .. autoclass:: opengate.auxiliary_attributes.InteractionCounterAttribute
 
+.. note::
+    The ``ProcessDefinedStepInVolumeAttribute`` "hidden actor" was recently (May 2026) replaced by the ``auxiliary`` actor.
+    These docs will get corresponding updates soon.
 
-ProcessDefinedStepInVolumeAttribute
------------------------------------
+ProcessDefinedStepInVolumeAttributeLegacy
+-----------------------------------------
 
 Description
 ~~~~~~~~~~~
@@ -104,10 +107,12 @@ Example:
    aux.process_name = "compt"
    aux.volume_name = "water_box"
 
-Reference
-~~~~~~~~~
+..
+    Reference
+    ~~~~~~~~~
 
-.. autoclass:: opengate.auxiliary_attributes.ProcessDefinedStepInVolumeAttribute
+..
+    .. autoclass:: opengate.auxiliary_attributes.ProcessDefinedStepInVolumeAttributeLegacy
 
 
 LastProcessDefinedStepInVolumeAttribute

--- a/docs/source/user_guide/user_guide_reference_fields.rst
+++ b/docs/source/user_guide/user_guide_reference_fields.rst
@@ -23,3 +23,56 @@ Base class reference
 .. autoclass:: opengate.geometry.fields.ElectricField
    :members:
    :show-inheritance:
+
+.. note::
+
+     The class documention of G4FieldManager is incomplete (lacking method signatures and descriptions of what they actually do). It's kind of a place holder and helps to get the number of Sphinx warnings to be zero.
+
+G4 Field Manager class reference
+--------------------------------
+
+.. py:class:: opengate_core.G4FieldManager
+
+      .. py:method:: SetDetectorField()
+
+      .. py:method:: ProposeDetectorField()
+
+      .. py:method:: ChangeDetectorField()
+
+      .. py:method:: GetDetectorField()
+
+      .. py:method:: DoesFieldExist()
+
+      .. py:method:: CreateChordFinder()
+
+      .. py:method:: SetChordFinder()
+
+      .. py:method:: GetChordFinder()
+
+      .. py:method:: ConfigureForTrack()
+
+      .. py:method:: GetDeltaIntersection()
+
+      .. py:method:: GetDeltaOneStep()
+
+      .. py:method:: SetAccuraciesWithDeltaOneStep()
+
+      .. py:method:: SetDeltaOneStep()
+
+      .. py:method:: SetDeltaIntersection()
+
+      .. py:method:: GetMinimumEpsilonStep()
+
+      .. py:method:: SetMinimumEpsilonStep()
+
+      .. py:method:: GetMaximumEpsilonStep()
+
+      .. py:method:: SetMaximumEpsilonStep()
+
+      .. py:method:: DoesFieldChangeEnergy()
+
+      .. py:method:: SetFieldChangesEnergy()
+
+      .. py:method:: GetMaxAcceptedEpsilon()
+
+      .. py:method:: SetMaxAcceptedEpsilon()

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -1359,6 +1359,9 @@ class VolumeManager(GateObject):
         print(self.dump_volumes())
 
     def dump_volume_tree(self):
+        """
+        Updates volume tree (if needed) and returns a string representation of the volume tree.
+        """
         self.update_volume_tree_if_needed()
         s = ""
         for pre, _, node in RenderTree(self.volume_tree_root):


### PR DESCRIPTION
My goal was to make the docs build (`make html`) with zero errors/warnings. Mission accomplished. However, I see that there is a lot of work on-going, currently, so 5 seconds after I file my PR new crashes and warnings will appear.

Some autodoc links/references (e.g. `PhaseSpaceActor.root_output`) were failing due to simple typos, others (about a dozen) because the corresponding `autoclass`, `automethod` or `autoproperty` call was missing. I added a mock docomentation of opengate_core.G4FieldManager in order to get rid of a sphinx build warning. Of course mock doc could be decorated with real documentation info about the methods, their args and return values, I might do that later, if it's useful.

I found an rst file describing the initialization of actors, which was not included in the TOC. I fixed its grammar and put it back. Please remove if there was a non-grammar reason for leaving it out.

I see that the `ProcessDefinedStepInVolumeAttribute` class (in `digitizers.py` is now obsolete and has been renamed to `ProcessDefinedStepInVolumeAttributeLegacy`. I see that there is some update about that in the docs, but trying to import that legacy class causes an exception to be thrown, so no `autoclass` should be included in the sphinx docs, to avoid that crash.

There is much more that can be improved on the docs, but let me just submit this, this is a useful chunck of work (I hope).