### PR TITLE
windows-latest now is windows2025-vs2026

### DIFF
--- a/.github/workflows/actions_build/action.yml
+++ b/.github/workflows/actions_build/action.yml
@@ -48,8 +48,8 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/software
-        key: ${{ runner.os }}-${{ steps.get-os-version.outputs.release }}_geant4_${{ env.GEANT4_VERSION }}_itk_${{ env.ITK_VERSION }}_build
-        restore-keys: ${{ runner.os }}-${{ steps.get-os-version.outputs.release }}_geant4_${{ env.GEANT4_VERSION }}_itk_${{ env.ITK_VERSION }}_build
+        key: ${{ runner.os }}-${{ steps.get-os-version.outputs.release }}_geant4_${{ env.GEANT4_VERSION }}_itk_${{ env.ITK_VERSION }}_build2
+        restore-keys: ${{ runner.os }}-${{ steps.get-os-version.outputs.release }}_geant4_${{ env.GEANT4_VERSION }}_itk_${{ env.ITK_VERSION }}_build2
     - uses: conda-incubator/setup-miniconda@v3
       if: (inputs.os == 'macos-15') || (inputs.os == 'macos-15-intel') || (inputs.os == 'windows-2025') || (inputs.os == 'windows-11-arm')
       with:

--- a/.github/workflows/actions_build/ci_build_wheel_windows.sh
+++ b/.github/workflows/actions_build/ci_build_wheel_windows.sh
@@ -4,7 +4,7 @@ set -e
 source $GITHUB_WORKSPACE/env_dump.txt
 source $CONDA/Scripts/activate opengate_core
 conda info
-conda install cmake==3.31.2
+conda install cmake==4.2.3
 cmake --version
 conda install openssl==3.0.19
 conda list
@@ -26,6 +26,7 @@ export SSL_CERT_FILE="C:\certifi-ca.pem"
 export REQUESTS_CA_BUNDLE="C:\certifi-ca.pem"
 
 which pip
+which cmake
 mkdir -p $HOME/software
 if [ "${MATRIX_CACHE}" != 'true' ]; then
     cd $HOME/software


### PR DESCRIPTION
no MSVC found during cibuild wheel
Try to generate the cache again to see if it resolve the problem

https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners

Same error than here: https://discourse.cmake.org/t/cmake-4-2-2-not-able-to-detect-vs2026-outside-developer-command-prompt/15478