### PR TITLE
make ProcessDefinedStepInVolumeAttribute able to follow multiple volumes

### DIFF
--- a/core/opengate_core/opengate_lib/GateProcessDefinedStepInVolumeAttribute.cpp
+++ b/core/opengate_core/opengate_lib/GateProcessDefinedStepInVolumeAttribute.cpp
@@ -23,7 +23,12 @@ void GateProcessDefinedStepInVolumeAttribute::InitializeUserInfo(
     py::dict &user_info) {
   GateVAuxiliaryAttribute::InitializeUserInfo(user_info);
   fProcessName = DictGetStr(user_info, "process_name");
-  fVolumeName = DictGetStr(user_info, "volume_name");
+  py::object volume_name_obj = user_info["volume_names"];
+  if (py::isinstance<py::str>(volume_name_obj)) {
+    fVolumeNameList.push_back(DictGetStr(user_info, "volume_names"));
+  } else {
+    fVolumeNameList = DictGetVecStr(user_info, "volume_names");
+  }
   fPropagateFromParentTrack =
       DictGetBool(user_info, "propagate_from_parent_track");
 }
@@ -47,12 +52,14 @@ int GateProcessDefinedStepInVolumeAttribute::GetIValue(
 void GateProcessDefinedStepInVolumeAttribute::SteppingAction(
     const G4Step *step) {
   const auto *pre_step_point = step->GetPreStepPoint();
-  if (IsStepInVolume(step, fVolumeName)) {
-    const auto *process = pre_step_point->GetProcessDefinedStep();
-    if (process != nullptr && process->GetProcessName() == fProcessName) {
-      auto *info =
-          GetOrCreateTrackData<GateIntegerCounterTrackData>(step->GetTrack());
-      info->Increment();
+  for (const auto &volumeName : fVolumeNameList) {
+    if (IsStepInVolume(step, volumeName)) {
+      const auto *process = pre_step_point->GetProcessDefinedStep();
+      if (process != nullptr && process->GetProcessName() == fProcessName) {
+        auto *info =
+            GetOrCreateTrackData<GateIntegerCounterTrackData>(step->GetTrack());
+        info->Increment();
+      }
     }
   }
 

--- a/core/opengate_core/opengate_lib/GateProcessDefinedStepInVolumeAttribute.h
+++ b/core/opengate_core/opengate_lib/GateProcessDefinedStepInVolumeAttribute.h
@@ -21,7 +21,8 @@ public:
 
 protected:
   std::string fProcessName;
-  std::string fVolumeName;
+  std::vector<std::string> fVolumeNameList;
+  // std::string fVolumeName;
   bool fPropagateFromParentTrack{false};
 };
 

--- a/opengate/auxiliary_attributes.py
+++ b/opengate/auxiliary_attributes.py
@@ -89,7 +89,7 @@ class ProcessDefinedStepInVolumeAttribute(
 ):
     """
     Count how often the configured process defined a step in the configured
-    volume for the current track. Optionally propagate the current count
+    volumes for the current track. Optionally propagate the current count
     snapshot to secondaries created along the track.
     """
 
@@ -100,10 +100,10 @@ class ProcessDefinedStepInVolumeAttribute(
                 "doc": "Name of the Geant4 process to count.",
             },
         ),
-        "volume_name": (
+        "volume_names": (
             None,
             {
-                "doc": "Name of the volume in which the process count is evaluated.",
+                "doc": "Names of the volumes in which the process count is evaluated.",
             },
         ),
         "propagate_from_parent_track": (

--- a/opengate/tests/src/actors/test023_filters_auxiliary_attribute.py
+++ b/opengate/tests/src/actors/test023_filters_auxiliary_attribute.py
@@ -21,10 +21,14 @@ if __name__ == "__main__":
     sim.world.size = [1 * m, 1 * m, 1 * m]
     sim.world.material = "G4_Galactic"
 
-    water_box = sim.add_volume("Box", "water_box")
-    water_box.size = [10 * cm, 10 * cm, 5 * cm]
-    water_box.material = "G4_WATER"
-    water_box.translation = [0, 0, 0]
+    water_box1 = sim.add_volume("Box", "water_box1")
+    water_box1.size = [10 * cm, 10 * cm, 2.5 * cm]
+    water_box1.material = "G4_WATER"
+    water_box1.translation = [0, 0, -1.25 * cm]
+    water_box2 = sim.add_volume("Box", "water_box2")
+    water_box2.size = [10 * cm, 10 * cm, 2.5 * cm]
+    water_box2.material = "G4_WATER"
+    water_box2.translation = [0, 0, 1.25 * cm]
 
     plane = sim.add_volume("Box", "plane")
     plane.size = [20 * cm, 20 * cm, 1 * nm]
@@ -46,7 +50,7 @@ if __name__ == "__main__":
         "ProcessDefinedStep__compt__water_box",
     )
     aux.process_name = "compt"
-    aux.volume_name = water_box.name
+    aux.volume_name = [water_box1.name, water_box2.name]
 
     phsp_all = sim.add_actor("PhaseSpaceActor", "phsp_all")
     phsp_all.attached_to = plane.name

--- a/opengate/tests/src/actors/test023_filters_auxiliary_attribute.py
+++ b/opengate/tests/src/actors/test023_filters_auxiliary_attribute.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         "ProcessDefinedStep__compt__water_box",
     )
     aux.process_name = "compt"
-    aux.volume_name = [water_box1.name, water_box2.name]
+    aux.volume_names = [water_box1.name, water_box2.name]
 
     phsp_all = sim.add_actor("PhaseSpaceActor", "phsp_all")
     phsp_all.attached_to = plane.name


### PR DESCRIPTION
For example, if a phantom is constituted with several parts, then it's prefered to count how much a particle is scattered in all those parts in total. Current `ProcessDefinedStepInVolumeAttribute` can only count how much the particle is scattered in those parts seperately, creating unnecessary c++ object footprint and enlarge the output file size. This PR is addressing this issue, making the `ProcessDefinedStepInVolumeAttribute` being able to follow a list of volumes and check whether a scatter happens in any of them.