### PR TITLE
source visualization validation fix

### DIFF
--- a/docs/source/user_guide/user_guide_reference_sources_generic_source.rst
+++ b/docs/source/user_guide/user_guide_reference_sources_generic_source.rst
@@ -171,7 +171,8 @@ before ``sim.run()``:
     source.visualization.color = "red"
     source.visualization.size = 3
 
-The visualization of the source is only available with ``"qt"``.
+The visualization of the source is only available with ``"qt"`` and single
+thread mode.
 
 The ``count`` parameter controls the number of sampled positions. Values
 larger than 10000 are reduced to 2000. The ``size`` parameter controls the

--- a/opengate/sources/generic.py
+++ b/opengate/sources/generic.py
@@ -312,11 +312,18 @@ class VisualizationValidator(UserInfoValidatorBase):
     def validate(self, parent_obj, attr_name: str, parent_context: str = None):
         context_name = super().validate(parent_obj, attr_name, parent_context)
         b = getattr(parent_obj, attr_name)
+
+        if not parent_obj.simulation.visu:
+            return context_name  # Skip validation if visualization is disabled
+
         if b.count <= 0:
             logger.info(
                 f"For source {parent_obj.name}, visualization count is set to {b.count}. No visualization will be performed."
             )
-        elif b.count > 10000:
+        elif parent_obj.simulation.number_of_threads > 1:
+            fatal(f"Source visualization is not supported when using multiple threads.")
+
+        if b.count > 10000:
             warning(
                 f"For source {parent_obj.name}, visualization count is too high ({b.count}), using 2000 instead."
             )


### PR DESCRIPTION
fix two minor problems:
1. MT mode will cause source visualization position error, so I made it to generate a fatal error to notify the user
2. if sim.visu = False and in MT mode and some of the sources are set visualization.count = 0, then 
```
logger.info(
                f"For source {parent_obj.name}, visualization count is set to {b.count}. No visualization will be performed."
            )
```
will be printed by each of the thread source, which is annoying.