### PR TITLE
Reduce GlobalTime divergence of threads, reducing memory usage of act…

### DIFF
--- a/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.cpp
@@ -11,7 +11,7 @@
 #include "GateDigiCollectionManager.h"
 #include "GateHelpersDigitizer.h"
 #include <G4Threading.hh>
-#include <memory>
+#include <thread>
 #include <utility>
 
 GateTimeSorter::GateTimeSorter(const std::string &name) : fName(name) {
@@ -181,11 +181,16 @@ void GateTimeSorter::OnEndOfEventAction(std::function<void(void)> work) {
       // If the current thread has been identified as the fastest progressing
       // one, then do the processing.
       const int tid = std::max(0, G4Threading::G4GetThreadId());
+      bool hasProcessed = false;
       if (tid == fFastestThread.load()) {
         Process(); // executes time-sorting logic
         work();    // executes the work provided by the actor
+        hasProcessed = true;
       }
       fProcessingOngoing.store(false, std::memory_order_release);
+      if (hasProcessed) {
+        std::this_thread::yield();
+      }
     }
   }
 }


### PR DESCRIPTION
`GateTimeSorter` is used by `GateCoincidenceSorterActor`, `GateDigitizerDeadTimeActor` and `GateDigitizerPileupActor` to sort digis according to `GlobalTime`. In multi-threaded simulations, if the `GlobalTime` diverges between threads, more digis need to be buffered before `GateTimeSorter` can guarantee that the digis are sorted. To reduce memory consumption, it is important to reduce `GlobalTime` divergence between threads. `GateTimeSorter` does this by having the fastest progressing thread do the actor's work, which slows this thread down relative to the other threads. 

The `GlobalTime` divergence can be reduced more by making the fastest thread `yield()` after it has executed the actor's work, giving more opportunity to the threads with slower `GlobalTime` increase. This call to `yield()` is what is being added in this PR.