### PR TITLE
Fix link in user_guide_resources.rst

### DIFF
--- a/docs/source/user_guide/user_guide_resources.rst
+++ b/docs/source/user_guide/user_guide_resources.rst
@@ -17,7 +17,7 @@ Teaching Resources and Examples
 
 - `Geant 4 past events <https://geant4.web.cern.ch/collaboration/events?past>`_ Geant4 past events
 
-- Example of SPECT system matrix `here https://github.com/leontiou/PERSPECT/tree/main/GATE10`_
+- Example of SPECT system matrix `here <https://github.com/leontiou/PERSPECT/tree/main/GATE10>`_
 
 
 


### PR DESCRIPTION
The link currently looks like this:
<img width="1185" height="163" alt="image" src="https://github.com/user-attachments/assets/08ce1293-8475-4814-ae15-815fe1e0fdd5" />
