### PR TITLE
Timesorter improvement

### DIFF
--- a/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.cpp
+++ b/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.cpp
@@ -139,14 +139,9 @@ void GateTimeSorter::OnEndOfEventAction(std::function<void(void)> work) {
   // with a mutex, because all threads must copy their digis sequentially into
   // the same buffer.
   // 2. The actual time-sorting, followed by the work provided by the actor,
-  // happens next on two conditions: (i) a minimum number of ingestions
-  // has happened since the previous time sorting, and (ii) the current thread
-  // is the one with the most advanced GlobalTime value. If these conditions are
-  // not fulfilled, the execution of stage 2 is postponed until a later
-  // invocation of OnEndOfEventAction. These conditions avoid incurring the
-  // overhead of stage 2 after every ingestion of (typically very few) digis and
-  // make sure that the fastest progressing working threads do more work than
-  // the slower ones, which reduces GlobalTime divergence between threads.
+  // happens next when a certain number of ingestions has happened since the
+  // previous time sorting. This condition avoid incurring the overhead of stage
+  // 2 after every ingestion of (typically very few) digis.
 
   // Phase 1
 
@@ -166,7 +161,7 @@ void GateTimeSorter::OnEndOfEventAction(std::function<void(void)> work) {
     return;
   }
 
-  // Number of ingestions thas reached the threshold: subtract the threshold
+  // Number of ingestions has reached the threshold: subtract the threshold
   // value and continue.
   fNumIngestions.fetch_sub(numIngestionsPerProcessCall,
                            std::memory_order_relaxed);
@@ -178,13 +173,8 @@ void GateTimeSorter::OnEndOfEventAction(std::function<void(void)> work) {
     if (fProcessingOngoing.compare_exchange_strong(expected, true,
                                                    std::memory_order_acquire,
                                                    std::memory_order_relaxed)) {
-      // If the current thread has been identified as the fastest progressing
-      // one, then do the processing.
-      const int tid = std::max(0, G4Threading::G4GetThreadId());
-      if (tid == fFastestThread.load()) {
-        Process(); // executes time-sorting logic
-        work();    // executes the work provided by the actor
-      }
+      Process(); // executes time-sorting logic
+      work();    // executes the work provided by the actor
       fProcessingOngoing.store(false, std::memory_order_release);
     }
   }
@@ -206,7 +196,6 @@ void GateTimeSorter::OnEndOfRunAction(
     lastThreadWork();
   }
   anyThreadWork();
-  MarkThreadAsFinished(std::max(0, G4Threading::G4GetThreadId()));
 }
 
 GateDigiCollection *GateTimeSorter::OutputCollection() const {
@@ -402,12 +391,6 @@ void GateTimeSorter::Process() {
   if ((n >= n1 && n >= fSortedCollectionA->GetSize() / 2) || n >= n2) {
     Prune();
   }
-
-  // The current thread was the fastest one at the time when Process() got
-  // called. Since it has been doing sorting work since, it may no longer be the
-  // one with the highest GlobalTime value. So we have to re-evaluate which
-  // thread is currently the fastest one.
-  IdentifyFastestThread();
 }
 
 void GateTimeSorter::Flush() {
@@ -433,26 +416,6 @@ void GateTimeSorter::Flush() {
               << fMinimumSortingWindow << " ns (suggestion: > " << fMaxDropDelta
               << "ns)\n";
   }
-}
-
-void GateTimeSorter::IdentifyFastestThread() {
-  // Look up the index of the thread that currently has the largest GlobalTime
-  // value.
-  const auto maxIt = std::max_element(
-      fMaxGlobalTimePerThread.get(),
-      fMaxGlobalTimePerThread.get() + fNumWorkingThreads,
-      [](const PaddedAtomicDouble &a, const PaddedAtomicDouble &b) {
-        return a.value.load() < b.value.load();
-      });
-  fFastestThread.store(
-      static_cast<int>(std::distance(fMaxGlobalTimePerThread.get(), maxIt)));
-}
-
-void GateTimeSorter::MarkThreadAsFinished(int threadId) {
-  // Sets the maximum observed GlobalTime of the given thread to zero, to make
-  // sure that it can no longer be selected to do sorting work.
-  fMaxGlobalTimePerThread[threadId].value.store(0.0);
-  IdentifyFastestThread();
 }
 
 void GateTimeSorter::Prune() {

--- a/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.h
+++ b/core/opengate_core/opengate_lib/digitizer/GateTimeSorter.h
@@ -47,7 +47,6 @@ private:
   G4Mutex fIngestionMutex;
   int fNumWorkingThreads{};
   std::atomic<double> fSortingWindow{1000.0}; // nanoseconds
-  std::atomic<int> fFastestThread{};
   std::atomic<int> fNumActiveWorkingThreads{};
   std::atomic<bool> fProcessingOngoing{};
   std::atomic<int> fNumIngestions{};

--- a/docs/source/developer_guide/developer_guide_coincidence_sorter_mt.rst
+++ b/docs/source/developer_guide/developer_guide_coincidence_sorter_mt.rst
@@ -165,23 +165,13 @@ If the CAS fails — either because another thread already holds the token or
 the preliminary relaxed load showed it was taken — the calling thread simply
 returns and continues simulating.  It is never blocked.
 
-If the CAS succeeds, the thread checks whether it is the one currently
-tracking the highest ``GlobalTime``:
+If the CAS succeeds, the thread calls ``Process()`` and ``work()``:
 
 .. code-block:: cpp
 
-    if (tid == fFastestThread.load()) {
-        Process();
-        work();   // actor lambda: ProcessTimeSortedSingles + DetectCoincidences
-    }
+    Process(); // executes time-sorting logic
+    work();    // actor lambda: ProcessTimeSortedSingles + DetectCoincidences
     fProcessingOngoing.store(false, std::memory_order_release);
-
-A thread that wins the CAS but is *not* the fastest one releases the token
-immediately without calling ``Process()``.  The intent is that sorting work
-migrates to whichever thread is furthest ahead in simulation time: the fastest
-thread occasionally pauses to do sorting and coincidence detection work,
-which gives the slower threads time to catch up, reducing ``GlobalTime``
-divergence.
 
 Inside ``Process()``:
 
@@ -206,12 +196,6 @@ Inside ``Process()``:
    This *sorting window guarantee* ensures time-monotonicity in the output
    stream: no future ingestion can produce a digi with a low enough
    ``GlobalTime`` to be inserted before anything already drained.
-
-4. **Fastest-thread re-evaluation.** Because the current thread has been
-   doing sorting and coincidence detection work since it was identified
-   as the fastest, it may no longer hold that distinction.
-   ``IdentifyFastestThread()`` refreshes ``fFastestThread`` so that
-   subsequent processing calls are routed to the correct thread.
 
 
 The Sorting Window
@@ -252,10 +236,7 @@ The thread that takes the counter to zero is the last active worker; it calls
 ``fSortedIndicesA`` into ``fOutputCollection`` without applying the sorting
 window, since no further digis will arrive.
 It then calls ``lastThreadWork()``.  Every thread subsequently calls
-``anyThreadWork()``.  Before ``OnEndOfRunAction()`` returns,
-each thread calls ``MarkThreadAsFinished()``, which zeroes its
-``fMaxGlobalTimePerThread`` entry so it is no longer eligible to be selected
-as the fastest thread.
+``anyThreadWork()``.
 
 
 Correctness of the Lock-Free Processing Path
@@ -264,7 +245,7 @@ Correctness of the Lock-Free Processing Path
 After the buffer swap inside ``Process()``, the remainder of that function
 reads and writes ``fIngestionBufferB``, ``fSortedCollectionA``,
 ``fSortedIndicesA``, ``fOutputCollection``, ``fMostRecentTimeArrived``,
-``fMostRecentTimeDeparted``, and ``fFastestThread``
+and ``fMostRecentTimeDeparted``
 **without holding any mutex**, and reads ``fSortingWindow`` via an atomic
 load (``fSortingWindow`` is ``std::atomic<double>`` because ``Ingest()``
 writes to it concurrently).  This section explains why that is safe.
@@ -300,7 +281,7 @@ section around the body of ``Process()``:
   relationship with the **release** store at the end of the *previous*
   ``Process()`` invocation.  All writes made by that invocation to
   ``fSortedCollectionA``, ``fSortedIndicesA``, ``fOutputCollection``,
-  ``fMostRecentTimeArrived``, ``fMostRecentTimeDeparted``, and ``fFastestThread``
+  ``fMostRecentTimeArrived``, and ``fMostRecentTimeDeparted``
   are therefore visible to the current invocation, even though no mutex guards
   those fields directly.  (``fSortingWindow`` is excluded from this list
   because it is an atomic written by ``Ingest()`` independently of the CAS.)
@@ -321,8 +302,7 @@ additional synchronisation.
 Non-Processing Threads Are Never Blocked
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A thread that fails the CAS — or that wins it but is not the fastest thread
-and immediately releases the token — returns from ``OnEndOfEventAction()``
+A thread that fails the CAS returns from ``OnEndOfEventAction()``
 and continues simulating without ever waiting on a lock or spinning.  The
 entire fast path (ingestion counter increment → preliminary flag check → CAS
 attempt → early return) is **wait-free**: it completes in a bounded number of
@@ -336,7 +316,7 @@ Visibility of ``fMaxGlobalTimePerThread``
 padded to one cache-line (64 bytes) to prevent false sharing.  Each thread
 writes only to its own element inside ``Ingest()``.  ``Ingest()`` also reads
 all elements (under ``fIngestionMutex``) to compute the sorting window
-extension.  ``Process()`` reads all elements to re-evaluate the fastest thread.
+extension.
 
 Concurrent access is safe because:
 
@@ -346,12 +326,6 @@ Concurrent access is safe because:
   ``Ingest()`` happen under ``fIngestionMutex``, which serialises concurrent
   ``Ingest()`` calls.  The resulting ``fSortingWindow`` update is an atomic
   store, immediately visible to any subsequent atomic load in ``Process()``.
-* **Benign races for fastest-thread selection.** ``Ingest()`` can run
-  concurrently with ``Process()`` after the buffer swap.  A load of
-  ``fMaxGlobalTimePerThread[tid]`` inside ``IdentifyFastestThread()`` may
-  therefore see a value that is one ingestion stale.  This is harmless:
-  fastest-thread selection is heuristic and routing processing to a slightly
-  suboptimal thread does not affect correctness.
 
 
 GateCoincidenceSorterActor: Consuming the Sorted Stream
@@ -423,13 +397,12 @@ Thread Lifecycle Summary
        to per-thread max, occasional ``fSortingWindow`` extension).  Returns
        early if no digis; otherwise increment ``fNumIngestions`` (relaxed
        atomic).  If threshold reached: attempt CAS on ``fProcessingOngoing``
-       (atomic, non-blocking).  If CAS succeeds and thread is fastest:
-       ``Process()`` — acquires ``fIngestionMutex`` for buffer swap only,
-       then fully lock-free — followed by actor lambda (lock-free).
+       (atomic, non-blocking).  If CAS succeeds: ``Process()`` — acquires
+       ``fIngestionMutex`` for buffer swap only, then fully lock-free —
+       followed by actor lambda (lock-free).
    * - ``EndOfRunAction``
      - All workers
      - Decrement ``fNumActiveWorkingThreads`` (atomic).  Last thread:
        ``Process()`` then ``Flush()`` (both single-threaded at this point)
        then ``lastThreadWork()``.
-       All threads: ``anyThreadWork()``.  Each thread: ``MarkThreadAsFinished()``
-       (atomic store).
+       All threads: ``anyThreadWork()``.


### PR DESCRIPTION
@dsarrut @nkrah @tbaudier 

GateTimeSorter has a mechanism for limiting the GlobalTime divergence between threads in multi-threaded simulations, with the goal of reducing the amount of memory needed for buffering digis during sorting. That mechanism gives more work to the thread that is most ahead in terms of GlobalTime, with the goal of slowing it down to give the other threads the opportunity to catch up.

It appears that there are two issues with this approach:

1. The mechanism is not always effective: depending on the setup of the simulation, the sorting work may only be a tiny fraction of the overall work done by Geant4 and GATE. So shifting that work to the fastest thread does not help a lot. Since the GlobalTime divergence is probabilistic, it may be that one execution of a simulation has a small thread divergence (making you think that the mechanism works), but when executing the same simulation again, the divergence might be a lot higher, consuming more memory.
2. When a simulation setup has more than one TimeSorter (e.g. a pile-up actor followed downstream by a coincidence actor), the behavior of the downstream TimeSorter becomes problematic because it will buffer many, if not all, digis until the end of the simulation, waiting to sort and process them until the very end of the simulation (or run). If the simulation is long, there may not be enough memory available to reach the end of the simulation. The reason for this problematic behavior is that the GlobalTime of digis observed by a thread is no longer an indication of the current GlobalTime in that thread, because digis can switch from one thread to another in the upstream TimeSorter.

What I propose to do:
* **This PR**: Remove the "fastest thread does the work" mechanism, which solves issue 2. If this could make it to the upcoming release, it would allow users to have multi-threaded simulations with combinations of dead time, pile-up and coincidence actors without being limited to rather short simulations.
* **Future PR**: A mechanism for reducing GlobalTime divergence is still needed, otherwise multi-threaded simulations would slowly keep growing in memory. As an alternative, I propose to impose a thread "barrier", which would mean that once in a while the fast threads wait for the slow ones to catch up. I have a working implementation of this, but it still needs tuning to make sure that the barrier is used frequently enough to keep memory usage low, but not too frequently to prevent that threads spend too much time waiting. This mechanism will probably not be finished and sufficiently tested before the upcoming release.


As illustration, this is the memory usage as a function of time for a multi-threaded simulation containing pile-up + dead time + coincidence actors, once when run from the current master branch, and once with the code from this PR (removal of the "fastest thread does the work" mechanism). As you can see, even after the change in this PR, memory is still slowly going up over time, which would be solved by the future PR.

<img width="1552" height="1082" alt="image" src="https://github.com/user-attachments/assets/45029afe-b309-4b07-be98-ebfa9f27dafa" />
