### PR TITLE
Added methods to apply color to voxel parameterization and slices.

### DIFF
--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -1056,7 +1056,9 @@ class ImageVolume(VolumeBase, solids.ImageSolid):
         self.construct_solid()
         self.construct_slices()
         self.construct_logical_volume()
+        self.apply_color_to_slices()
         self.g4_voxel_param = self.create_image_parametrisation()
+        self.apply_color_to_voxels()
         self.construct_physical_volume()
 
     def construct_slices(self):
@@ -1336,6 +1338,51 @@ class ImageVolume(VolumeBase, solids.ImageSolid):
         with open(labels_filename, "r") as infile:
             labels = json.load(infile)
         self.voxel_materials = labels
+        
+    def create_voxel_color_image(self):
+        # Encode color for every voxel
+        color = self.color
+        
+        # Format: RGBA en 32-bit (R, G, B, Alpha)
+        color_value = (
+            int(color[0] * 255) << 24 |  # R
+            int(color[1] * 255) << 16 |  # G
+            int(color[2] * 255) << 8 |   # B
+            int(color[3] * 255)           # Alpha
+        )
+ 
+        #Create new image with same size from original image
+        color_image = itk.GetImageFromArray(
+            np.full(itk.GetArrayFromImage(self.label_image).shape,
+                    color_value, dtype=np.uint32)
+        )
+        color_image.CopyInformation(self.label_image)
+ 
+        return color_image
+ 
+    def apply_color_to_voxels(self):
+        # Apply the ImageVolume colors to the voxel parameterization
+        # by storing the color information in the parameterization.
+        if self.g4_voxel_param is None:
+            fatal(f"Voxel parametrization not initialized for {self.name}")
+ 
+        # Create image of colors
+        color_image = self.create_voxel_color_image()
+ 
+        # Store the color in the parameterization
+        if hasattr(self.g4_voxel_param, 'SetColorImage'):
+            update_image_py_to_cpp(color_image, self.g4_voxel_param.color_image, True)
+ 
+    def apply_color_to_slices(self):
+        #Apply color to visible slides
+        self.g4_vis_attributes_logical_slices = g4.G4VisAttributes()
+        self.g4_vis_attributes_logical_slices.SetColor(*self.color)
+        self.g4_vis_attributes_logical_slices.SetVisibility(bool(self.color[3]))
+ 
+        # apply to logical volumes
+        self.g4_logical_x.SetVisAttributes(self.g4_vis_attributes_logical_slices)
+        self.g4_logical_y.SetVisAttributes(self.g4_vis_attributes_logical_slices)
+        self.g4_logical_z.SetVisAttributes(self.g4_vis_attributes_logical_slices)
 
 
 class ParallelWorldVolume(NodeMixin):

--- a/opengate/geometry/volumes.py
+++ b/opengate/geometry/volumes.py
@@ -1338,47 +1338,50 @@ class ImageVolume(VolumeBase, solids.ImageSolid):
         with open(labels_filename, "r") as infile:
             labels = json.load(infile)
         self.voxel_materials = labels
-        
+
     def create_voxel_color_image(self):
         # Encode color for every voxel
         color = self.color
-        
+
         # Format: RGBA en 32-bit (R, G, B, Alpha)
         color_value = (
-            int(color[0] * 255) << 24 |  # R
-            int(color[1] * 255) << 16 |  # G
-            int(color[2] * 255) << 8 |   # B
-            int(color[3] * 255)           # Alpha
+            int(color[0] * 255) << 24  # R
+            | int(color[1] * 255) << 16  # G
+            | int(color[2] * 255) << 8  # B
+            | int(color[3] * 255)  # Alpha
         )
- 
-        #Create new image with same size from original image
+
+        # Create new image with same size from original image
         color_image = itk.GetImageFromArray(
-            np.full(itk.GetArrayFromImage(self.label_image).shape,
-                    color_value, dtype=np.uint32)
+            np.full(
+                itk.GetArrayFromImage(self.label_image).shape,
+                color_value,
+                dtype=np.uint32,
+            )
         )
         color_image.CopyInformation(self.label_image)
- 
+
         return color_image
- 
+
     def apply_color_to_voxels(self):
         # Apply the ImageVolume colors to the voxel parameterization
         # by storing the color information in the parameterization.
         if self.g4_voxel_param is None:
             fatal(f"Voxel parametrization not initialized for {self.name}")
- 
+
         # Create image of colors
         color_image = self.create_voxel_color_image()
- 
+
         # Store the color in the parameterization
-        if hasattr(self.g4_voxel_param, 'SetColorImage'):
+        if hasattr(self.g4_voxel_param, "SetColorImage"):
             update_image_py_to_cpp(color_image, self.g4_voxel_param.color_image, True)
- 
+
     def apply_color_to_slices(self):
-        #Apply color to visible slides
+        # Apply color to visible slides
         self.g4_vis_attributes_logical_slices = g4.G4VisAttributes()
         self.g4_vis_attributes_logical_slices.SetColor(*self.color)
         self.g4_vis_attributes_logical_slices.SetVisibility(bool(self.color[3]))
- 
+
         # apply to logical volumes
         self.g4_logical_x.SetVisAttributes(self.g4_vis_attributes_logical_slices)
         self.g4_logical_y.SetVisAttributes(self.g4_vis_attributes_logical_slices)


### PR DESCRIPTION
**Propagation of ImageVolume colors to child voxels**

EN : 

This modification allows users to define the color of an ImageVolume with zero opacity ([R, G, B, 0]) during simulation setup.

Before this patch, when sim.visu = True, Geant4 exported every voxel of the image to the WRL file, even when the user intended the volume to be invisible. For images containing millions of voxels, this could generate WRL files several gigabytes in size and significantly increase both generation and visualization times.

This patch propagates the parent volume's color and opacity properties to its child voxels during initialization. As a result, when the opacity is set to zero, Geant4 no longer exports those voxels to the WRL file. This is because opacity is one of the criteria used by Geant4 to determine whether a volume should be displayed and written to the WRL file.

This significantly reduces the size of generated WRL files while preserving the expected visualization behavior for visible volumes.


FR : 

Cette modification permet de définir la couleur d'un ImageVolume avec une opacité nulle ([R, G, B, 0]) dès la configuration de la simulation.

Avant ce correctif, lorsque sim.visu = True, Geant4 exportait tous les voxels de l'image dans le fichier WRL, même si l'utilisateur souhaitait rendre le volume invisible. Pour une image contenant plusieurs millions de voxels, cela pouvait produire des fichiers WRL de plusieurs gigaoctets et ralentir considérablement leur génération ainsi que leur visualisation.

Ce patch propage les propriétés de couleur et d'opacité du volume parent vers les voxels fils lors de leur initialisation. Ainsi, si l'opacité est nulle, Geant4 n'exporte plus les voxels dans le fichier WRL. En effet, l'opacité fait partie des critères utilisés par Geant4 pour décider si un volume doit être affiché et enregistré dans le fichier WRL.

Cette modification réduit fortement la taille des fichiers WRL tout en conservant le comportement attendu pour les volumes visibles.