### PR TITLE
Possible discrepancy NEMA IEC IQ phantom with legacy GATE (v9) code 

### DIFF
--- a/opengate/contrib/phantoms/nemaiec.py
+++ b/opengate/contrib/phantoms/nemaiec.py
@@ -53,7 +53,7 @@ def add_iec_phantom(
 
     # Inside space for the water, same as the shell, with 3 mm less
     thickness = 3 * mm
-    thickness_z = 10 * mm
+    thickness_z = 3 * mm  # 10 * mm <-> /gate/topshell1/geometry/setHeight 0.3 cm
     interior, top_interior, _ = add_iec_body(
         simulation, f"{name}_interior", thickness, thickness_z
     )
@@ -79,7 +79,9 @@ def add_iec_body(simulation, name, thickness=0.0, thickness_z=0.0):
     deg = g4_units.deg
 
     # total length
-    length = 21.4 * cm
+    length = (
+        22 * cm
+    )  # 21.4 * cm <-> /gate/upperinterior/geometry/setHeight 21.4 cm & /gate/topshell1/geometry/setHeight 0.3 cm & /gate/bottomshell1/geometry/setHeight 0.3 cm
 
     # top
     top_shell = opengate.geometry.volumes.TubsVolume(name=f"{name}_top_shell")
@@ -184,7 +186,9 @@ def add_iec_all_spheres(
     It can be modified.
     """
     v = f"{name}_interior"
-    h_relative = 2.7 * cm
+    h_relative = (
+        3.7 * cm
+    )  # 2.7 * cm <-> /gate/sphere10/placement/setTranslation 2.86 8.45367 3.7 cm
     r = 11.45367 * cm / 2
     ang = 360 / 6 * deg
     if starting_angle is False:
@@ -244,7 +248,9 @@ def add_iec_one_sphere(
     cap.rmax = 0.25 * cm
     cap.rmin = 0 * cm
     # 21.4/2 = 10.7 interior height (top_interior)
-    h = 21.4 / 2 * cm - thickness_z
+    h = (
+        22 / 2 * cm - thickness_z
+    )  # 21.4 / 2 * cm - thickness_z <-> 21.4 is interior height in GATE 9
     cap.dz = (h - h_relative - rad - sph_thick) / 2.0
     cap.translation[2] = h_relative + rad + sph_thick + cap.dz
 


### PR DESCRIPTION
While doing some checks on the IEC phantom, I noticed a possible discrepancy in how the phantom's axial length is defined in v10 vs. the GateContrib implementation from Gate v9 (https://gitlab.in2p3.fr/opengate/GateContrib/-/blob/master/imaging/PhantomSource/Analytical_Phantom/NEMA_IEC_2001.mac?ref_type=heads).

Specifically: v9 uses an interior height of 21.4 cm, and adds top and bottom plastic shells of 3 mm each, giving a total height of 22 cm. v10 instead uses a total height of 21.4 cm, with top and bottom shells of 1 cm each, giving an interior height of 19.4 cm.

I think both implementations are valid, since the NEMA guidelines seemingly only specify a minimum interior height of 180 mm with no stated maximum. Furthermore, the difference shouldn't meaningfully affect imaging results. Still, it seemed worth flagging, since it could cause confusion when translating legacy workflows to v10. I couldn't find any documentation on why these particular values were chosen (or why 21.4 cm was used as the reference height in the first place), so it's possible there's a genuine reason for the change that I'm just not aware of — raising this as a potential mismatch, not asserting the current code is wrong :)

Note: changing the phantom height may affect existing reference data (e.g. because it also changes the heights of the spheres, to keep the 7 cm distance from the top, as specified by NEMA), which I haven't checked (yet).
