### PR TITLE
improve region initialization and fix parallel geometry segfault

### DIFF
--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -421,6 +421,11 @@ class PhysicsEngine(EngineBase):
         for region in self.physics_manager.regions.values():
             region.initialize_after_runmanager()
 
+    def initialize_regions_for_volume(self, volume): 
+        region = self.physics_manager.find_region(volume.name)
+        if region is not None: 
+            region.initialize_root_logical_volume(volume)
+
     def initialize_global_cuts(self):
         ui = self.physics_manager.user_info
 
@@ -1094,11 +1099,11 @@ class ParallelWorldEngine(g4.G4VUserParallelWorld, EngineBase):
         G4 overloaded.
         Override the Construct method from G4VUserParallelWorld
         """
-
         # Construct all volumes within this world along the tree hierarchy
         # The world volume of this world is the first item
         for volume in PreOrderIter(self.parallel_world_volume):
             volume.construct()
+            self.simulation_engine.physics_engine.initialize_regions_for_volume(volume)
 
     def ConstructSD(self):
         self.simulation_engine.actor_engine.register_sensitive_detectors(
@@ -1157,22 +1162,13 @@ class VolumeEngine(g4.G4VUserDetectorConstruction, EngineBase):
         G4 overloaded.
         Override the Construct method from G4VUserDetectorConstruction
         """
-
-        # # build the materials
-        # # FIXME: should go into initialize method
-        # self.simulation_engine.simulation.volume_manager.material_database.initialize()
-
         # Construct all volumes within the mass world along the tree hierarchy
         # The world volume is the first item
 
         self.volume_manager.update_volume_tree()
         for volume in PreOrderIter(self.volume_manager.world_volume):
             volume.construct()
-
-        for (
-            region
-        ) in self.simulation_engine.simulation.physics_manager.regions.values():
-            region.initialize_during_runmanager()
+            self.simulation_engine.physics_engine.initialize_regions_for_volume(volume)
 
         # return the (main) world physical volume
         self._is_constructed = True

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -421,9 +421,9 @@ class PhysicsEngine(EngineBase):
         for region in self.physics_manager.regions.values():
             region.initialize_after_runmanager()
 
-    def initialize_regions_for_volume(self, volume): 
+    def initialize_regions_for_volume(self, volume):
         region = self.physics_manager.find_region(volume.name)
-        if region is not None: 
+        if region is not None:
             region.initialize_root_logical_volume(volume)
 
     def initialize_global_cuts(self):

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -941,6 +941,9 @@ class PhysicsManager(GateObject):
         except AttributeError:
             fatal(f"Expected a volume name or a volume object, but received: {volume}")
 
+    def find_region(self, volume_name): 
+        return self.volumes_regions_lut.get(volume_name, None)
+
     def find_or_create_region(self, volume_name):
         if volume_name == self.simulation.world.name:
             region_name = "DefaultRegionForTheWorld"
@@ -1114,6 +1117,8 @@ class PhysicsManager(GateObject):
         for region in self.regions.values():
             region.resolve_and_validate_config()
 
+        if len(set(r.name for r in self.regions.values()).difference(set(r.name for r in self.volumes_regions_lut.values()))) > 0: 
+            fatal("The PhysicsManager has regions not represented in the volumes_regions_lut. ")
 
 def _setter_hook_chemistry_list_name(self, chemistry_list_name):
     if chemistry_list_name is None:

--- a/opengate/managers.py
+++ b/opengate/managers.py
@@ -941,7 +941,7 @@ class PhysicsManager(GateObject):
         except AttributeError:
             fatal(f"Expected a volume name or a volume object, but received: {volume}")
 
-    def find_region(self, volume_name): 
+    def find_region(self, volume_name):
         return self.volumes_regions_lut.get(volume_name, None)
 
     def find_or_create_region(self, volume_name):
@@ -1117,8 +1117,18 @@ class PhysicsManager(GateObject):
         for region in self.regions.values():
             region.resolve_and_validate_config()
 
-        if len(set(r.name for r in self.regions.values()).difference(set(r.name for r in self.volumes_regions_lut.values()))) > 0: 
-            fatal("The PhysicsManager has regions not represented in the volumes_regions_lut. ")
+        if (
+            len(
+                set(r.name for r in self.regions.values()).difference(
+                    set(r.name for r in self.volumes_regions_lut.values())
+                )
+            )
+            > 0
+        ):
+            fatal(
+                "The PhysicsManager has regions not represented in the volumes_regions_lut. "
+            )
+
 
 def _setter_hook_chemistry_list_name(self, chemistry_list_name):
     if chemistry_list_name is None:

--- a/opengate/physics.py
+++ b/opengate/physics.py
@@ -622,8 +622,8 @@ class Region(GateObject):
                 s += f"{pname}: {cut}\n"
         return s
 
-    def initialize_root_logical_volume(self, volume): 
-        if volume.g4_logical_volume is None: 
+    def initialize_root_logical_volume(self, volume):
+        if volume.g4_logical_volume is None:
             fatal(
                 f"Cannot attach region '{self.name}' to volume "
                 f"'{getattr(volume, 'name', volume)}' because its "
@@ -652,9 +652,11 @@ class Region(GateObject):
             )
 
     def initialize_g4_production_cuts(self):
-        if self.g4_region is None: 
-            fatal(f"Unable to initialize production cuts in region {self.name}."
-                  "The associated G4Region object is missing. ")
+        if self.g4_region is None:
+            fatal(
+                f"Unable to initialize production cuts in region {self.name}."
+                "The associated G4Region object is missing. "
+            )
 
         self.user_info = Box(self.user_info)
 
@@ -695,9 +697,11 @@ class Region(GateObject):
         self._g4_production_cuts_initialized = True
 
     def initialize_g4_user_limits(self):
-        if self.g4_region is None: 
-            fatal(f"Unable to initialize user limits in region {self.name}."
-                  "The associated G4Region object is missing. ")
+        if self.g4_region is None:
+            fatal(
+                f"Unable to initialize user limits in region {self.name}."
+                "The associated G4Region object is missing. "
+            )
 
         if self._g4_user_limits_initialized is True:
             return

--- a/opengate/physics.py
+++ b/opengate/physics.py
@@ -602,6 +602,12 @@ class Region(GateObject):
         self.physics_manager.volumes_regions_lut[volume_name] = self
 
     def resolve_and_validate_config(self):
+        if len(self.root_logical_volumes) == 0:
+            fatal(
+                f"Region '{self.name}' exists in the PhysicsManager but is not "
+                f"associated with any root logical volume. Associate at least one "
+                f"volume with region.associate_volume(...) or remove the region."
+            )
         # Resolve associated volumes early against the simulation-side volume
         # registry so invalid region-volume links fail during config handling
         # rather than later during runmanager initialization. These are the same
@@ -616,20 +622,25 @@ class Region(GateObject):
                 s += f"{pname}: {cut}\n"
         return s
 
-    @requires_fatal("physics_engine")
-    def initialize_during_runmanager(self):
-        """Create and attach the G4Region during geometry construction."""
-        # This runs from VolumeEngine.Construct(), i.e. after logical volumes
-        # exist but still early enough for Geant4 physics construction to see
-        # the region-based EM configuration.
-        self.initialize_g4_region()
+    def initialize_root_logical_volume(self, volume): 
+        if volume.g4_logical_volume is None: 
+            fatal(
+                f"Cannot attach region '{self.name}' to volume "
+                f"'{getattr(volume, 'name', volume)}' because its "
+                f"G4LogicalVolume is not available yet."
+            )
+
+        if self.g4_region is None:
+            rs = g4.G4RegionStore.GetInstance()
+            self.g4_region = rs.FindOrCreateRegion(self.user_info.name)
+        self.g4_region.AddRootLogicalVolume(volume.g4_logical_volume, True)
+        volume.g4_logical_volume.SetRegion(self.g4_region)
 
     @requires_fatal("physics_engine")
     def initialize_after_runmanager(self):
         """Finalize region-related G4 objects after G4RunManager.Initialize()."""
         self.initialize_g4_production_cuts()
         self.initialize_g4_user_limits()
-        self.initialize_g4_region()
 
     # Resolve region-attached volume names into Python volume objects during
     # the config phase. Their G4 counterparts are created later during geometry
@@ -640,30 +651,16 @@ class Region(GateObject):
                 self.simulation.volume_manager.get_volume(vname)
             )
 
-    def initialize_g4_region(self):
-        if self._g4_region_initialized is not True:
-            rs = g4.G4RegionStore.GetInstance()
-            self.g4_region = rs.FindOrCreateRegion(self.user_info.name)
-
-            for vol in self.root_logical_volumes.values():
-                self.g4_region.AddRootLogicalVolume(vol.g4_logical_volume, True)
-                vol.g4_logical_volume.SetRegion(self.g4_region)
-
-            self._g4_region_initialized = True
-
-        if self.g4_user_limits is not None:
-            self.g4_region.SetUserLimits(self.g4_user_limits)
-
-        if self.g4_production_cuts is not None:
-            self.g4_region.SetProductionCuts(self.g4_production_cuts)
-
     def initialize_g4_production_cuts(self):
+        if self.g4_region is None: 
+            fatal(f"Unable to initialize production cuts in region {self.name}."
+                  "The associated G4Region object is missing. ")
+
         self.user_info = Box(self.user_info)
 
         if self._g4_production_cuts_initialized is True:
             return
-        if self.g4_production_cuts is None:
-            self.g4_production_cuts = g4.G4ProductionCuts()
+        self.g4_production_cuts = g4.G4ProductionCuts()
 
         # 'all' overrides individual cuts per particle
         try:
@@ -694,9 +691,14 @@ class Region(GateObject):
                     )
                     self.g4_production_cuts.SetProductionCut(global_cut, g4_pname)
 
+        self.g4_region.SetProductionCuts(self.g4_production_cuts)
         self._g4_production_cuts_initialized = True
 
     def initialize_g4_user_limits(self):
+        if self.g4_region is None: 
+            fatal(f"Unable to initialize user limits in region {self.name}."
+                  "The associated G4Region object is missing. ")
+
         if self._g4_user_limits_initialized is True:
             return
 
@@ -743,6 +745,7 @@ class Region(GateObject):
                 self.user_info["user_limits"]["min_range"]
             )
 
+        self.g4_region.SetUserLimits(self.g4_user_limits)
         self._g4_user_limits_initialized = True
 
     def initialize_em_switches(self):


### PR DESCRIPTION
Fix segfault when a region is attached to a volume in a parallel world.

The root cause was the region lifecycle introduced around the G4-DNA work: regions could be initialized too early, before parallel-world logical volumes existed. That timing pressure comes from the DNA EM physics activator, which needs region names/configuration available before physics construction, but the actual `G4Region` attachment must wait until the corresponding logical volumes have been constructed.

This PR changes the region initialization workflow accordingly:
- attach regions lazily as each root logical volume is constructed, in both the mass world and parallel worlds
- keep production cuts and user limits initialization after `G4RunManager.Initialize()`
- add early validation for inconsistent region configuration

This preserves the DNA-region workflow while avoiding the premature attachment that caused the segfault.