### PR TITLE
EM Field Enhancement II: resolve field frames via the navigator, nested-volume fields, update defaults

### DIFF
--- a/core/opengate_core/opengate_lib/GateElectroMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/GateElectroMagneticField.cpp
@@ -8,13 +8,8 @@
 #include "GateElectroMagneticField.h"
 
 GateElectroMagneticField::GateElectroMagneticField(
-    G4ElectroMagneticField *inner, const G4VSolid *solid,
-    std::vector<G4ThreeVector> translations,
-    std::vector<G4RotationMatrix> rotations, double deltaChordMM)
-    : G4ElectroMagneticField(),
-      GateFieldBase(solid, std::move(translations), std::move(rotations),
-                    deltaChordMM),
-      m_inner(inner) {}
+    G4ElectroMagneticField *inner, const G4LogicalVolume *logicalVolume)
+    : G4ElectroMagneticField(), GateFieldBase(logicalVolume), m_inner(inner) {}
 
 void GateElectroMagneticField::GetFieldValue(const G4double Point[4],
                                              G4double *BEfield) const {

--- a/core/opengate_core/opengate_lib/GateElectroMagneticField.h
+++ b/core/opengate_core/opengate_lib/GateElectroMagneticField.h
@@ -10,19 +10,16 @@
 
 #include "GateFieldBase.h"
 #include <G4ElectroMagneticField.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // GATE wrapper for G4ElectroMagneticField.
 class GateElectroMagneticField : public G4ElectroMagneticField,
                                  public GateFieldBase {
 public:
   // constructor
-  GateElectroMagneticField(G4ElectroMagneticField *inner, const G4VSolid *solid,
-                           std::vector<G4ThreeVector> translations,
-                           std::vector<G4RotationMatrix> rotations,
-                           double deltaChordMM);
+  GateElectroMagneticField(G4ElectroMagneticField *inner,
+                           const G4LogicalVolume *logicalVolume);
 
   // override GetFieldValue to apply the coordinate transforms
   void GetFieldValue(const G4double Point[4], G4double *BEfield) const override;

--- a/core/opengate_core/opengate_lib/GateFieldBase.cpp
+++ b/core/opengate_core/opengate_lib/GateFieldBase.cpp
@@ -6,103 +6,91 @@
    -------------------------------------------------- */
 
 #include "GateFieldBase.h"
-#include <G4VSolid.hh>
-#include <cmath>
-#include <limits>
+#include "GateHelpers.h"
+#include <G4EventManager.hh>
+#include <G4LogicalVolume.hh>
+#include <G4NavigationHistory.hh>
+#include <G4Navigator.hh>
+#include <G4TouchableHistory.hh>
+#include <G4Track.hh>
+#include <G4TrackingManager.hh>
+#include <G4TransportationManager.hh>
+#include <G4VPhysicalVolume.hh>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 
+namespace {
+
+// World-to-local transform of the deepest level of the history that places the
+// given logical volume, or nullptr if the volume is not in the history at all.
+const G4AffineTransform *findPlacement(const G4NavigationHistory *history,
+                                       const G4LogicalVolume *lv) {
+  if (history == nullptr)
+    return nullptr;
+
+  for (G4int n = static_cast<G4int>(history->GetDepth()); n >= 0; --n) {
+    const G4VPhysicalVolume *pv = history->GetVolume(n);
+    if (pv != nullptr && pv->GetLogicalVolume() == lv)
+      return &history->GetTransform(n);
+  }
+  return nullptr;
+}
+
+// Navigation history of the track being tracked, or nullptr outside tracking.
+const G4NavigationHistory *trackingHistory() {
+  const G4EventManager *eventManager = G4EventManager::GetEventManager();
+  const G4TrackingManager *trackingManager =
+      (eventManager != nullptr) ? eventManager->GetTrackingManager() : nullptr;
+  const G4Track *track =
+      (trackingManager != nullptr) ? trackingManager->GetTrack() : nullptr;
+  const G4VTouchable *touchable =
+      (track != nullptr) ? track->GetTouchable() : nullptr;
+  return (touchable != nullptr) ? touchable->GetHistory() : nullptr;
+}
+
+} // namespace
+
 // constructor
-GateFieldBase::GateFieldBase(const G4VSolid *solid,
-                             std::vector<G4ThreeVector> translations,
-                             std::vector<G4RotationMatrix> rotations,
-                             double deltaChordMM)
-    : m_solid(solid),
-      m_fallbackFatalDistanceMM(
-          5.0 * std::sqrt(8.0 * kMaxCurvatureRadiusMM * deltaChordMM)) {
-  if (solid == nullptr)
-    throw std::invalid_argument("GateFieldBase: solid must not be null");
-
-  if (translations.size() != rotations.size() || translations.empty())
-    throw std::invalid_argument("GateFieldBase: translations and rotations "
-                                "must be non-empty and have the same size");
-
-  m_transforms.reserve(translations.size());
-  for (std::size_t i = 0; i < translations.size(); ++i)
-    m_transforms.emplace_back(rotations[i].inverse(), translations[i]);
-}
-
-// recache the world-to-local transforms (e.g. after a geometry change between
-// runs)
-void GateFieldBase::SetTransforms(std::vector<G4ThreeVector> translations,
-                                  std::vector<G4RotationMatrix> rotations) {
-  if (translations.size() != rotations.size() || translations.empty())
+GateFieldBase::GateFieldBase(const G4LogicalVolume *logicalVolume)
+    : m_logicalVolume(logicalVolume) {
+  if (logicalVolume == nullptr)
     throw std::invalid_argument(
-        "GateFieldBase::SetTransforms: translations and rotations must be "
-        "non-empty and have the same size");
-
-  m_transforms.clear();
-  m_transforms.reserve(translations.size());
-  for (std::size_t i = 0; i < translations.size(); ++i)
-    m_transforms.emplace_back(rotations[i].inverse(), translations[i]);
+        "GateFieldBase: logical volume must not be null");
 }
 
-// find the local coordinates of worldPoint in the containing placement of the
-// field's logical volume
-G4ThreeVector GateFieldBase::findContainingPlacement(
-    const G4ThreeVector &worldPoint,
-    const G4AffineTransform *&outTransform) const {
-  std::size_t closestIdx = 0;
-  double minDistToSurface = std::numeric_limits<double>::infinity();
-  G4ThreeVector closestLocal{};
+// world-to-local transform of the placement of the field's logical volume that
+// the current navigation history is in
+G4AffineTransform GateFieldBase::findPlacementTransform() const {
 
-  for (std::size_t i = 0; i < m_transforms.size(); ++i) {
-    const auto &tr = m_transforms[i];
-    const G4ThreeVector localPoint = tr.InverseTransformPoint(worldPoint);
+  // During tracking, use the current track's navigation history.
+  if (const G4AffineTransform *transform =
+          findPlacement(trackingHistory(), m_logicalVolume))
+    return *transform;
 
-    if (m_solid->Inside(localPoint) != kOutside) {
-      outTransform = &tr;
-      return localPoint;
-    }
-
-    const double d = m_solid->DistanceToIn(localPoint);
-    if (d < minDistToSurface) {
-      minDistToSurface = d;
-      closestIdx = i;
-      closestLocal = localPoint;
-    }
+  // Outside tracking (e.g. when visualising with /vis/scene/add/magneticField),
+  // use the navigator's history.
+  const G4Navigator *navigator =
+      G4TransportationManager::GetTransportationManager()
+          ->GetNavigatorForTracking();
+  if (navigator != nullptr) {
+    const std::unique_ptr<G4TouchableHistory> touchable(
+        navigator->CreateTouchableHistory());
+    if (const G4AffineTransform *transform =
+            findPlacement(touchable->GetHistory(), m_logicalVolume))
+      return *transform;
   }
 
-  // if the point is outside every placement, check if it's within the
-  // fallback-fatal distance which accounts for any reasonable field integrator
-  // overshoot due to tolerances. if not, this is very likely a bug in the
-  // geometry or field setup -> fatal
-  if (minDistToSurface > m_fallbackFatalDistanceMM) {
-    std::ostringstream msg;
-    msg << "GateFieldBase::findContainingPlacement: world point ("
-        << worldPoint.x() << ", " << worldPoint.y() << ", " << worldPoint.z()
-        << ") mm is " << minDistToSurface
-        << " mm outside every cached placement of the field's solid — "
-        << "well beyond any chord-finder overshoot.\n"
-        << "  Closest placement: index " << closestIdx << "  (local point "
-        << closestLocal.x() << ", " << closestLocal.y() << ", "
-        << closestLocal.z() << ").\n"
-        << "  Maximum allowed distance before fatal: "
-        << m_fallbackFatalDistanceMM << " mm.\n"
-        << "  This likely indicates a real bug in the geometry or field "
-           "setup.\n";
-
-    G4Exception("GateFieldBase::findContainingPlacement", "GateField0001",
-                FatalException, msg.str().c_str());
-  }
-
-  outTransform = &m_transforms[closestIdx];
-  return closestLocal;
-}
-
-// rotate a field vector from local to world coordinates using the given
-// transform
-G4ThreeVector GateFieldBase::rotateToWorld(const G4ThreeVector &localField,
-                                           const G4AffineTransform &transform) {
-  return transform.TransformAxis(localField);
+  // Neither source knows about the field's volume: there is no frame in which
+  // the field is defined. This is a genuine inconsistency.
+  std::ostringstream msg;
+  msg << "GateFieldBase: the field's logical volume '"
+      << m_logicalVolume->GetName()
+      << "' does not appear in the current navigation history, so the local "
+         "frame of the field is undefined.\n"
+      << "  The field value was requested at a point that Geant4 does not "
+         "locate inside (or below) that volume.\n"
+      << "  This likely indicates a real bug in the geometry or field setup.\n";
+  Fatal(msg.str());
+  return G4AffineTransform(); // to avoid warning
 }

--- a/core/opengate_core/opengate_lib/GateFieldBase.cpp
+++ b/core/opengate_core/opengate_lib/GateFieldBase.cpp
@@ -11,6 +11,7 @@
 #include <G4LogicalVolume.hh>
 #include <G4NavigationHistory.hh>
 #include <G4Navigator.hh>
+#include <G4StateManager.hh>
 #include <G4TouchableHistory.hh>
 #include <G4Track.hh>
 #include <G4TrackingManager.hh>
@@ -39,6 +40,13 @@ const G4AffineTransform *findPlacement(const G4NavigationHistory *history,
 
 // Navigation history of the track being tracked, or nullptr outside tracking.
 const G4NavigationHistory *trackingHistory() {
+  // G4TrackingManager::fpTrack is assigned in ProcessOneTrack and never
+  // cleared, so GetTrack() keeps returning the last track after the event
+  // manager has deleted it. Only trust it while an event is actually being
+  // processed; outside that, the caller falls back to the navigator.
+  if (G4StateManager::GetStateManager()->GetCurrentState() != G4State_EventProc)
+    return nullptr;
+
   const G4EventManager *eventManager = G4EventManager::GetEventManager();
   const G4TrackingManager *trackingManager =
       (eventManager != nullptr) ? eventManager->GetTrackingManager() : nullptr;

--- a/core/opengate_core/opengate_lib/GateFieldBase.h
+++ b/core/opengate_core/opengate_lib/GateFieldBase.h
@@ -9,50 +9,45 @@
 #define GateFieldBase_h
 
 #include <G4AffineTransform.hh>
-#include <G4RotationMatrix.hh>
 #include <G4ThreeVector.hh>
 #include <G4Types.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // Shared base class for all GATE field types
-//  - stores the world-to-local transforms of every physical placement of the
-//  logical volume
-//  - handles the full coordinate transform journey for GetFieldValue
+//
+// A GATE field is defined in the local frame of the logical volume it is
+// attached to. The world-to-local transform is read from
+// Geant4's navigation history on every query, so it always describes the
+// placement the track actually occupies.
 class GateFieldBase {
 public:
   // constructor
-  GateFieldBase(const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-                std::vector<G4RotationMatrix> rotations, double deltaChordMM);
-
-  // update the transforms (e.g. after a geometry change between runs)
-  void SetTransforms(std::vector<G4ThreeVector> translations,
-                     std::vector<G4RotationMatrix> rotations);
+  explicit GateFieldBase(const G4LogicalVolume *logicalVolume);
 
 protected:
   // LocalFieldFn is expected to be something like:
   //   void getLocalField(const G4double localPos[4], G4double *field);
   // which fills the field array with the local field value at the given
   // localPos.
-  template <typename LocalFieldFn>
-
+  //
   // Get the field value at the given world point by transforming to local
   // coordinates, calling getLocalField to fill the field value in local frame,
   // and then rotating the field vector(s) back to world frame
+  template <typename LocalFieldFn>
   void applyTransforms(const G4double Point[4], G4double *field,
                        int nComponents, LocalFieldFn getLocalField) const {
-    const G4ThreeVector worldPt(Point[0], Point[1], Point[2]);
-    const G4AffineTransform *tr = nullptr;
-    const G4ThreeVector localPt = findContainingPlacement(worldPt, tr);
+    const G4AffineTransform worldToLocal = findPlacementTransform();
+    const G4ThreeVector localPt = worldToLocal.TransformPoint(
+        G4ThreeVector(Point[0], Point[1], Point[2]));
     const G4double localPos[4] = {localPt.x(), localPt.y(), localPt.z(),
                                   Point[3]};
 
     getLocalField(localPos, field);
 
     for (int i = 0; i < nComponents; i += 3) {
-      const G4ThreeVector v = rotateToWorld(
-          G4ThreeVector(field[i], field[i + 1], field[i + 2]), *tr);
+      const G4ThreeVector v = worldToLocal.InverseTransformAxis(
+          G4ThreeVector(field[i], field[i + 1], field[i + 2]));
       field[i] = v.x();
       field[i + 1] = v.y();
       field[i + 2] = v.z();
@@ -60,22 +55,11 @@ protected:
   }
 
 private:
-  // find the local coordinates of worldPoint in the containing placement of the
-  // field's logical volume
-  G4ThreeVector
-  findContainingPlacement(const G4ThreeVector &worldPoint,
-                          const G4AffineTransform *&outTransform) const;
+  // world-to-local transform of the placement of the field's logical volume
+  // that the current navigation history is in
+  G4AffineTransform findPlacementTransform() const;
 
-  // rotate a field vector from local to world coordinates using the given
-  // transform
-  static G4ThreeVector rotateToWorld(const G4ThreeVector &localField,
-                                     const G4AffineTransform &transform);
-
-  const G4VSolid *m_solid;
-  double m_fallbackFatalDistanceMM;
-  std::vector<G4AffineTransform> m_transforms;
-
-  static constexpr double kMaxCurvatureRadiusMM = 100.0e3;
+  const G4LogicalVolume *m_logicalVolume;
 };
 
 #endif // GateFieldBase_h

--- a/core/opengate_core/opengate_lib/GateMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/GateMagneticField.cpp
@@ -9,13 +9,8 @@
 
 // constructor
 GateMagneticField::GateMagneticField(G4MagneticField *inner,
-                                     const G4VSolid *solid,
-                                     std::vector<G4ThreeVector> translations,
-                                     std::vector<G4RotationMatrix> rotations,
-                                     double deltaChordMM)
-    : G4MagneticField(), GateFieldBase(solid, std::move(translations),
-                                       std::move(rotations), deltaChordMM),
-      m_inner(inner) {}
+                                     const G4LogicalVolume *logicalVolume)
+    : G4MagneticField(), GateFieldBase(logicalVolume), m_inner(inner) {}
 
 void GateMagneticField::GetFieldValue(const G4double Point[4],
                                       G4double *Bfield) const {

--- a/core/opengate_core/opengate_lib/GateMagneticField.h
+++ b/core/opengate_core/opengate_lib/GateMagneticField.h
@@ -10,18 +10,15 @@
 
 #include "GateFieldBase.h"
 #include <G4MagneticField.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // GATE wrapper for G4MagneticField
 class GateMagneticField : public G4MagneticField, public GateFieldBase {
 public:
   // constructor
-  GateMagneticField(G4MagneticField *inner, const G4VSolid *solid,
-                    std::vector<G4ThreeVector> translations,
-                    std::vector<G4RotationMatrix> rotations,
-                    double deltaChordMM);
+  GateMagneticField(G4MagneticField *inner,
+                    const G4LogicalVolume *logicalVolume);
 
   // override GetFieldValue to apply the coordinate transforms
   void GetFieldValue(const G4double Point[4], G4double *Bfield) const override;

--- a/core/opengate_core/opengate_lib/GateMappedElectricField.cpp
+++ b/core/opengate_core/opengate_lib/GateMappedElectricField.cpp
@@ -8,14 +8,12 @@
 #include "GateMappedElectricField.h"
 
 GateMappedElectricField::GateMappedElectricField(
-    const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-    std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+    const G4LogicalVolume *logicalVolume,
     GateGridInterpolator::GridDefinition gridDef,
     GateGridInterpolator::FieldValues fieldValues,
     GateGridInterpolator::InterpolationMethod interpMethod)
     : G4ElectroMagneticField(),
-      GateMappedFieldBase(solid, std::move(translations), std::move(rotations),
-                          deltaChordMM, gridDef, std::move(fieldValues),
+      GateMappedFieldBase(logicalVolume, gridDef, std::move(fieldValues),
                           interpMethod) {}
 
 void GateMappedElectricField::GetFieldValue(const G4double Point[4],

--- a/core/opengate_core/opengate_lib/GateMappedElectricField.h
+++ b/core/opengate_core/opengate_lib/GateMappedElectricField.h
@@ -10,17 +10,15 @@
 
 #include "GateMappedFieldBase.h"
 #include <G4ElectroMagneticField.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // grid-based mapped electric field
 class GateMappedElectricField : public G4ElectroMagneticField,
                                 public GateMappedFieldBase {
 public:
   GateMappedElectricField(
-      const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-      std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+      const G4LogicalVolume *logicalVolume,
       GateGridInterpolator::GridDefinition gridDef,
       GateGridInterpolator::FieldValues fieldValues,
       GateGridInterpolator::InterpolationMethod interpMethod);

--- a/core/opengate_core/opengate_lib/GateMappedElectroMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/GateMappedElectroMagneticField.cpp
@@ -8,16 +8,13 @@
 #include "GateMappedElectroMagneticField.h"
 
 GateMappedElectroMagneticField::GateMappedElectroMagneticField(
-    const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-    std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+    const G4LogicalVolume *logicalVolume,
     GateGridInterpolator::GridDefinition gridDefB,
     GateGridInterpolator::FieldValues fieldValuesB,
     GateGridInterpolator::GridDefinition gridDefE,
     GateGridInterpolator::FieldValues fieldValuesE,
     GateGridInterpolator::InterpolationMethod interpMethod)
-    : G4ElectroMagneticField(),
-      GateFieldBase(solid, std::move(translations), std::move(rotations),
-                    deltaChordMM),
+    : G4ElectroMagneticField(), GateFieldBase(logicalVolume),
       m_interpolator_B(gridDefB, std::move(fieldValuesB), interpMethod),
       m_interpolator_E(gridDefE, std::move(fieldValuesE), interpMethod) {}
 

--- a/core/opengate_core/opengate_lib/GateMappedElectroMagneticField.h
+++ b/core/opengate_core/opengate_lib/GateMappedElectroMagneticField.h
@@ -11,17 +11,15 @@
 #include "GateFieldBase.h"
 #include "GateGridInterpolator.h"
 #include <G4ElectroMagneticField.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // grid-based mapped electromagnetic field with separate B and E grids
 class GateMappedElectroMagneticField : public G4ElectroMagneticField,
                                        public GateFieldBase {
 public:
   GateMappedElectroMagneticField(
-      const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-      std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+      const G4LogicalVolume *logicalVolume,
       GateGridInterpolator::GridDefinition gridDefB,
       GateGridInterpolator::FieldValues fieldValuesB,
       GateGridInterpolator::GridDefinition gridDefE,

--- a/core/opengate_core/opengate_lib/GateMappedFieldBase.cpp
+++ b/core/opengate_core/opengate_lib/GateMappedFieldBase.cpp
@@ -9,13 +9,11 @@
 
 // constructor
 GateMappedFieldBase::GateMappedFieldBase(
-    const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-    std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+    const G4LogicalVolume *logicalVolume,
     GateGridInterpolator::GridDefinition gridDef,
     GateGridInterpolator::FieldValues fieldValues,
     GateGridInterpolator::InterpolationMethod interpMethod)
-    : GateFieldBase(solid, std::move(translations), std::move(rotations),
-                    deltaChordMM),
+    : GateFieldBase(logicalVolume),
       m_interpolator(gridDef, std::move(fieldValues), interpMethod) {}
 
 // Compute field value at world point: transform to local, interpolate, rotate

--- a/core/opengate_core/opengate_lib/GateMappedFieldBase.h
+++ b/core/opengate_core/opengate_lib/GateMappedFieldBase.h
@@ -10,18 +10,14 @@
 
 #include "GateFieldBase.h"
 #include "GateGridInterpolator.h"
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // base class for mapped fields that use grid interpolation
 class GateMappedFieldBase : public GateFieldBase {
 public:
   // constructor
-  GateMappedFieldBase(const G4VSolid *solid,
-                      std::vector<G4ThreeVector> translations,
-                      std::vector<G4RotationMatrix> rotations,
-                      double deltaChordMM,
+  GateMappedFieldBase(const G4LogicalVolume *logicalVolume,
                       GateGridInterpolator::GridDefinition gridDef,
                       GateGridInterpolator::FieldValues fieldValues,
                       GateGridInterpolator::InterpolationMethod interpMethod);

--- a/core/opengate_core/opengate_lib/GateMappedMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/GateMappedMagneticField.cpp
@@ -8,14 +8,12 @@
 #include "GateMappedMagneticField.h"
 
 GateMappedMagneticField::GateMappedMagneticField(
-    const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-    std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+    const G4LogicalVolume *logicalVolume,
     GateGridInterpolator::GridDefinition gridDef,
     GateGridInterpolator::FieldValues fieldValues,
     GateGridInterpolator::InterpolationMethod interpMethod)
     : G4MagneticField(),
-      GateMappedFieldBase(solid, std::move(translations), std::move(rotations),
-                          deltaChordMM, gridDef, std::move(fieldValues),
+      GateMappedFieldBase(logicalVolume, gridDef, std::move(fieldValues),
                           interpMethod) {}
 
 void GateMappedMagneticField::GetFieldValue(const G4double Point[4],

--- a/core/opengate_core/opengate_lib/GateMappedMagneticField.h
+++ b/core/opengate_core/opengate_lib/GateMappedMagneticField.h
@@ -10,17 +10,15 @@
 
 #include "GateMappedFieldBase.h"
 #include <G4MagneticField.hh>
-#include <vector>
 
-class G4VSolid;
+class G4LogicalVolume;
 
 // grid-based mapped magnetic field.
 class GateMappedMagneticField : public G4MagneticField,
                                 public GateMappedFieldBase {
 public:
   GateMappedMagneticField(
-      const G4VSolid *solid, std::vector<G4ThreeVector> translations,
-      std::vector<G4RotationMatrix> rotations, double deltaChordMM,
+      const G4LogicalVolume *logicalVolume,
       GateGridInterpolator::GridDefinition gridDef,
       GateGridInterpolator::FieldValues fieldValues,
       GateGridInterpolator::InterpolationMethod interpMethod);

--- a/core/opengate_core/opengate_lib/pyGateElectroMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/pyGateElectroMagneticField.cpp
@@ -7,7 +7,7 @@
 
 #include "GateElectroMagneticField.h"
 #include <G4ElectroMagneticField.hh>
-#include <G4VSolid.hh>
+#include <G4LogicalVolume.hh>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -18,18 +18,9 @@ void init_GateElectroMagneticField(py::module &m) {
              std::unique_ptr<GateElectroMagneticField, py::nodelete>>(
       m, "GateElectroMagneticField")
 
-      .def(py::init([](G4ElectroMagneticField *inner, const G4VSolid *solid,
-                       std::vector<G4ThreeVector> translations,
-                       std::vector<G4RotationMatrix> rotations,
-                       double delta_chord_mm) {
-             return new GateElectroMagneticField(inner, solid, translations,
-                                                 rotations, delta_chord_mm);
+      .def(py::init([](G4ElectroMagneticField *inner,
+                       const G4LogicalVolume *logical_volume) {
+             return new GateElectroMagneticField(inner, logical_volume);
            }),
-           py::arg("inner_field"), py::arg("solid"), py::arg("translations"),
-           py::arg("rotations"), py::arg("delta_chord_mm"))
-
-      .def("SetTransforms", &GateElectroMagneticField::SetTransforms,
-           py::arg("translations"), py::arg("rotations"),
-           "Replace the cached world-to-local transforms. Call between runs "
-           "only after dynamic geometry changes have been applied.");
+           py::arg("inner_field"), py::arg("logical_volume"));
 }

--- a/core/opengate_core/opengate_lib/pyGateMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/pyGateMagneticField.cpp
@@ -6,8 +6,8 @@
    -------------------------------------------------- */
 
 #include "GateMagneticField.h"
+#include <G4LogicalVolume.hh>
 #include <G4MagneticField.hh>
-#include <G4VSolid.hh>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -20,18 +20,9 @@ void init_GateMagneticField(py::module &m) {
              std::unique_ptr<GateMagneticField, py::nodelete>>(
       m, "GateMagneticField")
 
-      .def(py::init([](G4MagneticField *inner, const G4VSolid *solid,
-                       std::vector<G4ThreeVector> translations,
-                       std::vector<G4RotationMatrix> rotations,
-                       double delta_chord_mm) {
-             return new GateMagneticField(inner, solid, translations, rotations,
-                                          delta_chord_mm);
+      .def(py::init([](G4MagneticField *inner,
+                       const G4LogicalVolume *logical_volume) {
+             return new GateMagneticField(inner, logical_volume);
            }),
-           py::arg("inner_field"), py::arg("solid"), py::arg("translations"),
-           py::arg("rotations"), py::arg("delta_chord_mm"))
-
-      .def("SetTransforms", &GateMagneticField::SetTransforms,
-           py::arg("translations"), py::arg("rotations"),
-           "Replace the cached world-to-local transforms. Call between runs "
-           "only after dynamic geometry changes have been applied.");
+           py::arg("inner_field"), py::arg("logical_volume"));
 }

--- a/core/opengate_core/opengate_lib/pyGateMappedElectricField.cpp
+++ b/core/opengate_core/opengate_lib/pyGateMappedElectricField.cpp
@@ -8,7 +8,7 @@
 #include "GateGridInterpolator.h"
 #include "GateMappedElectricField.h"
 #include <G4ElectroMagneticField.hh>
-#include <G4VSolid.hh>
+#include <G4LogicalVolume.hh>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -32,27 +32,20 @@ void init_GateMappedElectricField(py::module &m) {
              std::unique_ptr<GateMappedElectricField, py::nodelete>>(
       m, "GateMappedElectricField")
 
-      .def(py::init([](const G4VSolid *solid,
-                       std::vector<G4ThreeVector> translations,
-                       std::vector<G4RotationMatrix> rotations,
-                       double delta_chord_mm, int nx, int ny, int nz, double x0,
-                       double y0, double z0, double dx, double dy, double dz,
-                       DoubleArray Ex, DoubleArray Ey, DoubleArray Ez,
+      .def(py::init([](const G4LogicalVolume *logical_volume, int nx, int ny,
+                       int nz, double x0, double y0, double z0, double dx,
+                       double dy, double dz, DoubleArray Ex, DoubleArray Ey,
+                       DoubleArray Ez,
                        GateGridInterpolator::InterpolationMethod interp) {
              GateGridInterpolator::GridDefinition gridDef{nx, ny, nz, x0, y0,
                                                           z0, dx, dy, dz};
              GateGridInterpolator::FieldValues fieldValues{
                  to_vec(Ex), to_vec(Ey), to_vec(Ez)};
-             return new GateMappedElectricField(solid, translations, rotations,
-                                                delta_chord_mm, gridDef,
+             return new GateMappedElectricField(logical_volume, gridDef,
                                                 fieldValues, interp);
            }),
-           py::arg("solid"), py::arg("translations"), py::arg("rotations"),
-           py::arg("delta_chord_mm"), py::arg("nx"), py::arg("ny"),
+           py::arg("logical_volume"), py::arg("nx"), py::arg("ny"),
            py::arg("nz"), py::arg("x0"), py::arg("y0"), py::arg("z0"),
            py::arg("dx"), py::arg("dy"), py::arg("dz"), py::arg("Ex"),
-           py::arg("Ey"), py::arg("Ez"), py::arg("interpolation"))
-
-      .def("SetTransforms", &GateMappedElectricField::SetTransforms,
-           py::arg("translations"), py::arg("rotations"));
+           py::arg("Ey"), py::arg("Ez"), py::arg("interpolation"));
 }

--- a/core/opengate_core/opengate_lib/pyGateMappedElectroMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/pyGateMappedElectroMagneticField.cpp
@@ -8,7 +8,7 @@
 #include "GateGridInterpolator.h"
 #include "GateMappedElectroMagneticField.h"
 #include <G4ElectroMagneticField.hh>
-#include <G4VSolid.hh>
+#include <G4LogicalVolume.hh>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -32,16 +32,13 @@ void init_GateMappedElectroMagneticField(py::module &m) {
              std::unique_ptr<GateMappedElectroMagneticField, py::nodelete>>(
       m, "GateMappedElectroMagneticField")
 
-      .def(py::init([](const G4VSolid *solid,
-                       std::vector<G4ThreeVector> translations,
-                       std::vector<G4RotationMatrix> rotations,
-                       double delta_chord_mm, int nx_B, int ny_B, int nz_B,
-                       double x0_B, double y0_B, double z0_B, double dx_B,
-                       double dy_B, double dz_B, DoubleArray Bx, DoubleArray By,
-                       DoubleArray Bz, int nx_E, int ny_E, int nz_E,
-                       double x0_E, double y0_E, double z0_E, double dx_E,
-                       double dy_E, double dz_E, DoubleArray Ex, DoubleArray Ey,
-                       DoubleArray Ez,
+      .def(py::init([](const G4LogicalVolume *logical_volume, int nx_B,
+                       int ny_B, int nz_B, double x0_B, double y0_B,
+                       double z0_B, double dx_B, double dy_B, double dz_B,
+                       DoubleArray Bx, DoubleArray By, DoubleArray Bz, int nx_E,
+                       int ny_E, int nz_E, double x0_E, double y0_E,
+                       double z0_E, double dx_E, double dy_E, double dz_E,
+                       DoubleArray Ex, DoubleArray Ey, DoubleArray Ez,
                        GateGridInterpolator::InterpolationMethod interp) {
              GateGridInterpolator::GridDefinition gridDefB{
                  nx_B, ny_B, nz_B, x0_B, y0_B, z0_B, dx_B, dy_B, dz_B};
@@ -51,19 +48,15 @@ void init_GateMappedElectroMagneticField(py::module &m) {
                  nx_E, ny_E, nz_E, x0_E, y0_E, z0_E, dx_E, dy_E, dz_E};
              GateGridInterpolator::FieldValues fieldValuesE{
                  to_vec(Ex), to_vec(Ey), to_vec(Ez)};
-             return new GateMappedElectroMagneticField(
-                 solid, translations, rotations, delta_chord_mm, gridDefB,
-                 fieldValuesB, gridDefE, fieldValuesE, interp);
+             return new GateMappedElectroMagneticField(logical_volume, gridDefB,
+                                                       fieldValuesB, gridDefE,
+                                                       fieldValuesE, interp);
            }),
-           py::arg("solid"), py::arg("translations"), py::arg("rotations"),
-           py::arg("delta_chord_mm"), py::arg("nx_B"), py::arg("ny_B"),
+           py::arg("logical_volume"), py::arg("nx_B"), py::arg("ny_B"),
            py::arg("nz_B"), py::arg("x0_B"), py::arg("y0_B"), py::arg("z0_B"),
            py::arg("dx_B"), py::arg("dy_B"), py::arg("dz_B"), py::arg("Bx"),
            py::arg("By"), py::arg("Bz"), py::arg("nx_E"), py::arg("ny_E"),
            py::arg("nz_E"), py::arg("x0_E"), py::arg("y0_E"), py::arg("z0_E"),
            py::arg("dx_E"), py::arg("dy_E"), py::arg("dz_E"), py::arg("Ex"),
-           py::arg("Ey"), py::arg("Ez"), py::arg("interpolation"))
-
-      .def("SetTransforms", &GateMappedElectroMagneticField::SetTransforms,
-           py::arg("translations"), py::arg("rotations"));
+           py::arg("Ey"), py::arg("Ez"), py::arg("interpolation"));
 }

--- a/core/opengate_core/opengate_lib/pyGateMappedMagneticField.cpp
+++ b/core/opengate_core/opengate_lib/pyGateMappedMagneticField.cpp
@@ -7,8 +7,8 @@
 
 #include "GateGridInterpolator.h"
 #include "GateMappedMagneticField.h"
+#include <G4LogicalVolume.hh>
 #include <G4MagneticField.hh>
-#include <G4VSolid.hh>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -32,27 +32,20 @@ void init_GateMappedMagneticField(py::module &m) {
              std::unique_ptr<GateMappedMagneticField, py::nodelete>>(
       m, "GateMappedMagneticField")
 
-      .def(py::init([](const G4VSolid *solid,
-                       std::vector<G4ThreeVector> translations,
-                       std::vector<G4RotationMatrix> rotations,
-                       double delta_chord_mm, int nx, int ny, int nz, double x0,
-                       double y0, double z0, double dx, double dy, double dz,
-                       DoubleArray Bx, DoubleArray By, DoubleArray Bz,
+      .def(py::init([](const G4LogicalVolume *logical_volume, int nx, int ny,
+                       int nz, double x0, double y0, double z0, double dx,
+                       double dy, double dz, DoubleArray Bx, DoubleArray By,
+                       DoubleArray Bz,
                        GateGridInterpolator::InterpolationMethod interp) {
              GateGridInterpolator::GridDefinition gridDef{nx, ny, nz, x0, y0,
                                                           z0, dx, dy, dz};
              GateGridInterpolator::FieldValues fieldValues{
                  to_vec(Bx), to_vec(By), to_vec(Bz)};
-             return new GateMappedMagneticField(solid, translations, rotations,
-                                                delta_chord_mm, gridDef,
+             return new GateMappedMagneticField(logical_volume, gridDef,
                                                 fieldValues, interp);
            }),
-           py::arg("solid"), py::arg("translations"), py::arg("rotations"),
-           py::arg("delta_chord_mm"), py::arg("nx"), py::arg("ny"),
+           py::arg("logical_volume"), py::arg("nx"), py::arg("ny"),
            py::arg("nz"), py::arg("x0"), py::arg("y0"), py::arg("z0"),
            py::arg("dx"), py::arg("dy"), py::arg("dz"), py::arg("Bx"),
-           py::arg("By"), py::arg("Bz"), py::arg("interpolation"))
-
-      .def("SetTransforms", &GateMappedMagneticField::SetTransforms,
-           py::arg("translations"), py::arg("rotations"));
+           py::arg("By"), py::arg("Bz"), py::arg("interpolation"));
 }

--- a/docs/source/user_guide/user_guide_fields.rst
+++ b/docs/source/user_guide/user_guide_fields.rst
@@ -278,6 +278,8 @@ Use ``add_field()`` to attach a field to a volume. The volume must already be ad
 
 **Propagation to daughter volumes.** A field attached to a volume automatically propagates to all of its daughter volumes. A daughter volume can override this by attaching its own field. In that case, the parent's field stops at the daughter's boundary and the daughter's field is used inside. This mirrors standard Geant4 behaviour.
 
+**Frame of an inherited field.** A field is always evaluated in the local frame of the volume it is *attached to*, not of the volume the particle happens to be in. So if a daughter inherits its mother's field and is rotated with respect to that mother, the field keeps the mother's orientation: it does not rotate with the daughter. A daughter that attaches its own field uses its own frame instead.
+
 **Behaviour with repeated placements.** When a volume with a field is repeatedly placed (i.e. a logical volume with several physical placements), each physical instance will have the field in its own local coordinate system.
 
 **Behaviour with dynamic geometry changes.** If a field is attached to a volume that is later moved or rotated, the field will move/rotate with it.

--- a/docs/source/user_guide/user_guide_fields.rst
+++ b/docs/source/user_guide/user_guide_fields.rst
@@ -184,7 +184,7 @@ Combined magnetic and electric fields.
 Integration and accuracy parameters
 --------------------------------
 
-All field types inherit the following parameters that control the numerical integration of the equation of motion. The defaults are suitable for most cases, but they can be tuned for better accuracy or performance.
+All field types inherit the following parameters that control the numerical integration of the equation of motion. The defaults are the Geant4 defaults (``G4FieldDefaults``); they can be tuned for better accuracy or performance.
 
 .. list-table::
    :header-rows: 1
@@ -198,21 +198,21 @@ All field types inherit the following parameters that control the numerical inte
      - Stepping algorithm used for integrating the equation of motion. See :ref:`steppers` for available options.
    * - ``step_minimum``
      - 0.01 mm
-     - Minimum step size for the chord finder.
+     - Position error accepted over a step.
    * - ``delta_chord``
-     - 0.001 mm
+     - 0.25 mm
      - Maximum sagitta (miss distance between the chord approximation and the true curved trajectory).
    * - ``delta_one_step``
-     - 0.001 mm
+     - 0.01 mm
      - Positional accuracy per integration step.
    * - ``delta_intersection``
-     - 0.0001 mm
+     - 0.001 mm
      - Positional accuracy at volume boundaries.
    * - ``min_epsilon_step``
-     - 1e-7
+     - 5e-5
      - Minimum relative integration accuracy.
    * - ``max_epsilon_step``
-     - 1e-5
+     - 1e-3
      - Maximum relative integration accuracy.
 
 Example:

--- a/opengate/actors/dynamicactors.py
+++ b/opengate/actors/dynamicactors.py
@@ -60,23 +60,6 @@ class DynamicGeometryActor(DynamicActorBase, g4.GateVActor):
             # CloseGeometry: pOptimise=true, verbose=false, G4VPhysicalVolume *vol=0
             gm.CloseGeometry(self.simulation.dyn_geom_optimise, False, None)
 
-        # Refresh field transforms after geometry changes
-        # This ensures fields attached to moving volumes use the updated transforms
-        self._refresh_field_transforms(run_id)
-
-    def _refresh_field_transforms(self, run_id):
-        """Recompute world-to-local transforms for every registered field.
-
-        Called after the geometry-changers for `run_id` have been applied,
-        so that fields attached to moving volumes see the updated placement
-        transforms in the upcoming run.
-        """
-        fields = getattr(self.simulation.volume_manager, "fields", None)
-        if not fields:
-            return
-        for field in fields.values():
-            field.refresh_transforms()
-
 
 class DynamicSourceActor(DynamicActorBase, g4.GateVActor):
 

--- a/opengate/engines.py
+++ b/opengate/engines.py
@@ -1205,13 +1205,26 @@ class VolumeEngine(g4.G4VUserDetectorConstruction, EngineBase):
             self.volume_manager.world_volume.name,
         )
 
-        for field in self.simulation_engine.simulation.volume_manager.fields.values():
-            for volume_name in field.attached_to:
-                volume_obj = self.volume_manager.get_volume(volume_name)
-                volume_obj.g4_field_manager = field.create_field_manager(volume_obj)
-                volume_obj.g4_logical_volume.SetFieldManager(
-                    volume_obj.g4_field_manager, True
-                )
+        # Fields are attached with forceToAllDaughters=True, so the order of declaration
+        # matters. Assign the outermost volumes first, so that a field attached to a
+        # deeper volume always wins over one inherited from an ancestor,
+        # whatever order the user happened to add the fields in.
+        field_assignments = [
+            (field, volume_name)
+            for field in self.simulation_engine.simulation.volume_manager.fields.values()
+            for volume_name in field.attached_to
+        ]
+        field_assignments.sort(
+            key=lambda assignment: len(
+                self.volume_manager.get_volume(assignment[1]).ancestor_volumes
+            )
+        )
+        for field, volume_name in field_assignments:
+            volume_obj = self.volume_manager.get_volume(volume_name)
+            volume_obj.g4_field_manager = field.create_field_manager(volume_obj)
+            volume_obj.g4_logical_volume.SetFieldManager(
+                volume_obj.g4_field_manager, True
+            )
 
     def get_volume(self, name):
         return self.volume_manager.get_volume(name)

--- a/opengate/geometry/fields.py
+++ b/opengate/geometry/fields.py
@@ -187,7 +187,7 @@ class MagneticField(FieldBase):
         gate_field = g4.GateMagneticField(
             inner, self._field_volume_obj.g4_logical_volume
         )
-        # TODO: allow user choice of stepper and equation type
+        # TODO: allow user choice of the equation of motion?
         return self._build_field_manager(inner, gate_field, g4.G4Mag_UsualEqRhs, 6)
 
 
@@ -316,7 +316,7 @@ class ElectroMagneticField(FieldBase):
         gate_field = g4.GateElectroMagneticField(
             inner, self._field_volume_obj.g4_logical_volume
         )
-        # TODO: allow user choice of stepper and equation type
+        # TODO: allow user choice of the equation of motion?
         # 8 variables: x,y,z + px,py,pz + t + E
         return self._build_field_manager(inner, gate_field, g4.G4EqMagElectricField, 8)
 

--- a/opengate/geometry/fields.py
+++ b/opengate/geometry/fields.py
@@ -39,37 +39,37 @@ class FieldBase(GateObject):
             },
         ),
         "step_minimum": (
-            1e-2 * g4_units.mm,
+            0.01 * g4_units.mm,
             {
                 "doc": "Minimum step size for the chord finder.",
             },
         ),
         "delta_chord": (
-            1e-3 * g4_units.mm,
+            0.25 * g4_units.mm,
             {
                 "doc": "Maximum miss distance between chord and curved trajectory.",
             },
         ),
         "delta_one_step": (
-            1e-3 * g4_units.mm,
+            0.01 * g4_units.mm,
             {
                 "doc": "Positional accuracy per integration step.",
             },
         ),
         "delta_intersection": (
-            1e-4 * g4_units.mm,
+            1e-3 * g4_units.mm,
             {
                 "doc": "Positional accuracy at volume boundaries.",
             },
         ),
         "min_epsilon_step": (
-            1e-7,
+            5e-5,
             {
                 "doc": "Minimum relative integration accuracy.",
             },
         ),
         "max_epsilon_step": (
-            1e-5,
+            1e-3,
             {
                 "doc": "Maximum relative integration accuracy.",
             },

--- a/opengate/geometry/fields.py
+++ b/opengate/geometry/fields.py
@@ -4,13 +4,6 @@ import numpy as np
 import opengate_core as g4
 
 from ..base import GateObject, process_cls
-from ..geometry.utility import (
-    get_transform_world_to_local,
-    vec_np_as_g4,
-    rot_np_as_g4,
-    vec_g4_as_np,
-    rot_g4_as_np,
-)
 from ..utility import g4_units
 
 # ! ======= KNOWN TODO'S ========
@@ -104,53 +97,10 @@ class FieldBase(GateObject):
         """Whether the field changes particle energy (False for magnetic, True for others)."""
         return self._field_changes_energy
 
-    def refresh_transforms(self) -> None:
-        """Recompute and push cached world-to-local transforms after dynamic
-        geometry changes.
-        """
-        for entry in self._g4_runtime_objects:
-            volume = entry.get("volume")
-            g4_field = entry.get("field")
-            if volume is None or g4_field is None:
-                continue
-
-            g4_translations = []
-            g4_rotations = []
-            for i in range(volume.number_of_repetitions):
-                pv = volume.get_g4_physical_volume(i)
-                T = vec_g4_as_np(pv.GetObjectTranslation())
-                rot = pv.GetObjectRotation()
-                R = rot_g4_as_np(rot) if rot is not None else np.eye(3)
-                for anc in volume.ancestor_volumes[::-1]:
-                    # Ancestors are assumed to be singly placed, so we use idx 0
-                    anc_pvs = getattr(anc, "g4_physical_volumes", None)
-                    if not anc_pvs:
-                        continue
-                    anc_pv = anc_pvs[0]
-                    anc_T = vec_g4_as_np(anc_pv.GetObjectTranslation())
-                    anc_rot = anc_pv.GetObjectRotation()
-                    anc_R = rot_g4_as_np(anc_rot) if anc_rot is not None else np.eye(3)
-                    T = anc_R @ T + anc_T
-                    R = anc_R @ R
-                g4_translations.append(vec_np_as_g4(T))
-                g4_rotations.append(rot_np_as_g4(R))
-
-            g4_field.SetTransforms(g4_translations, g4_rotations)
-
     def create_field_manager(self, volume_obj) -> g4.G4FieldManager:
         """Construct the field and return a configured G4FieldManager."""
         msg = "create_field_manager() must be implemented in subclasses."
         raise NotImplementedError(msg)
-
-    def _make_g4_transforms(self):
-        """Return (g4_translations, g4_rotations) for the current field volume."""
-        translations_np, rotations_np = get_transform_world_to_local(
-            self._field_volume_obj
-        )
-        return (
-            [vec_np_as_g4(t) for t in translations_np],
-            [rot_np_as_g4(r) for r in rotations_np],
-        )
 
     def _validate_stepper(self) -> None:
         """Raise ValueError if the current stepper is incompatible with this field type."""
@@ -165,9 +115,7 @@ class FieldBase(GateObject):
                 "Choose a general-purpose stepper for electric or EM fields."
             )
 
-    def _build_field_manager(
-        self, inner_field, gate_field, equation_cls, n_vars, volume_obj
-    ):
+    def _build_field_manager(self, inner_field, gate_field, equation_cls, n_vars):
         """Build equation/stepper/driver/chord_finder/fm, record runtime objects, return fm."""
         self._validate_stepper()
         self.g4_field = gate_field
@@ -198,7 +146,6 @@ class FieldBase(GateObject):
                 "driver": self.g4_integration_driver,
                 "chord_finder": self.g4_chord_finder,
                 "field_manager": fm,
-                "volume": volume_obj,
             }
         )
 
@@ -237,18 +184,11 @@ class MagneticField(FieldBase):
         """Construct the field and return a configured G4FieldManager."""
         self._field_volume_obj = volume_obj
         inner = self._create_inner_field()
-        g4_translations, g4_rotations = self._make_g4_transforms()
         gate_field = g4.GateMagneticField(
-            inner,
-            self._field_volume_obj.g4_solid,
-            g4_translations,
-            g4_rotations,
-            self.delta_chord,
+            inner, self._field_volume_obj.g4_logical_volume
         )
         # TODO: allow user choice of stepper and equation type
-        return self._build_field_manager(
-            inner, gate_field, g4.G4Mag_UsualEqRhs, 6, volume_obj
-        )
+        return self._build_field_manager(inner, gate_field, g4.G4Mag_UsualEqRhs, 6)
 
 
 class UniformMagneticField(MagneticField):
@@ -373,19 +313,12 @@ class ElectroMagneticField(FieldBase):
         """Construct the field and return a configured G4FieldManager."""
         self._field_volume_obj = volume_obj
         inner = self._create_inner_field()
-        g4_translations, g4_rotations = self._make_g4_transforms()
         gate_field = g4.GateElectroMagneticField(
-            inner,
-            self._field_volume_obj.g4_solid,
-            g4_translations,
-            g4_rotations,
-            self.delta_chord,
+            inner, self._field_volume_obj.g4_logical_volume
         )
         # TODO: allow user choice of stepper and equation type
         # 8 variables: x,y,z + px,py,pz + t + E
-        return self._build_field_manager(
-            inner, gate_field, g4.G4EqMagElectricField, 8, volume_obj
-        )
+        return self._build_field_manager(inner, gate_field, g4.G4EqMagElectricField, 8)
 
 
 class ElectricField(ElectroMagneticField):
@@ -652,12 +585,8 @@ class MappedMagneticField(MagneticField):
         nx, ny, nz, x0, y0, z0, dx, dy, dz, (Bx, By, Bz) = _parse_field_matrix(
             self.field_matrix, "MappedMagneticField"
         )
-        g4_translations, g4_rotations = self._make_g4_transforms()
         gate_field = g4.GateMappedMagneticField(
-            self._field_volume_obj.g4_solid,
-            g4_translations,
-            g4_rotations,
-            self.delta_chord,
+            self._field_volume_obj.g4_logical_volume,
             nx,
             ny,
             nz,
@@ -672,9 +601,7 @@ class MappedMagneticField(MagneticField):
             Bz,
             _interp_map[self.interpolation],
         )
-        return self._build_field_manager(
-            None, gate_field, g4.G4Mag_UsualEqRhs, 6, volume_obj
-        )
+        return self._build_field_manager(None, gate_field, g4.G4Mag_UsualEqRhs, 6)
 
 
 class MappedElectricField(ElectricField):
@@ -697,12 +624,8 @@ class MappedElectricField(ElectricField):
         nx, ny, nz, x0, y0, z0, dx, dy, dz, (Ex, Ey, Ez) = _parse_field_matrix(
             self.field_matrix, "MappedElectricField"
         )
-        g4_translations, g4_rotations = self._make_g4_transforms()
         gate_field = g4.GateMappedElectricField(
-            self._field_volume_obj.g4_solid,
-            g4_translations,
-            g4_rotations,
-            self.delta_chord,
+            self._field_volume_obj.g4_logical_volume,
             nx,
             ny,
             nz,
@@ -717,9 +640,7 @@ class MappedElectricField(ElectricField):
             Ez,
             _interp_map[self.interpolation],
         )
-        return self._build_field_manager(
-            None, gate_field, g4.G4EqMagElectricField, 8, volume_obj
-        )
+        return self._build_field_manager(None, gate_field, g4.G4EqMagElectricField, 8)
 
 
 class MappedElectroMagneticField(ElectroMagneticField):
@@ -787,12 +708,8 @@ class MappedElectroMagneticField(ElectroMagneticField):
                 self.field_matrix_E, "MappedElectroMagneticField (E grid)"
             )
         )
-        g4_translations, g4_rotations = self._make_g4_transforms()
         gate_field = g4.GateMappedElectroMagneticField(
-            self._field_volume_obj.g4_solid,
-            g4_translations,
-            g4_rotations,
-            self.delta_chord,
+            self._field_volume_obj.g4_logical_volume,
             nx_B,
             ny_B,
             nz_B,
@@ -819,9 +736,7 @@ class MappedElectroMagneticField(ElectroMagneticField):
             Ez,
             _interp_map[self.interpolation],
         )
-        return self._build_field_manager(
-            None, gate_field, g4.G4EqMagElectricField, 8, volume_obj
-        )
+        return self._build_field_manager(None, gate_field, g4.G4EqMagElectricField, 8)
 
 
 field_types = {

--- a/opengate/tests/src/geometry/test099_fields_daughter_volume.py
+++ b/opengate/tests/src/geometry/test099_fields_daughter_volume.py
@@ -49,7 +49,7 @@ EXPECTED_DEFLECTION = magnetic_deflection(KE, By, PROTON_MASS, 1 * g4_eplus, BOX
 TOL_DEFLECTED = 0.01 * g4_mm  # deflected axis must stay within this of expected
 TOL_ZERO = 0.01 * g4_mm  # non-deflected axis must stay within this
 
-VISU = True  # set True for interactive qt viewer
+VISU = False  # set True for interactive qt viewer
 
 
 if __name__ == "__main__":

--- a/opengate/tests/src/geometry/test099_fields_daughter_volume.py
+++ b/opengate/tests/src/geometry/test099_fields_daughter_volume.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Test 099 - field frame inside a daughter volume.
+
+A field manager is attached to its logical volume with forceToAllDaughters, so
+a track inside a field-less daughter of the field volume is still steered by the field.
+The field must then be evaluated in the frame of the *field volume*, not in the
+frame of the field-less daughter the track happens to be in.
+
+Two boxes carry the same UniformMagneticField with B along local +Y (3 T), and
+both are rotated 90 deg about Z so that the local frame differs from the world
+frame:
+
+  box_ref  is empty.
+  box_dau  contains a daughter without any field that fills it and is itself rotated 45 deg about
+           Z relative to its mother.
+
+Checks:
+  - box_ref deflects in -Y (B_world along -X), no X deflection
+  - box_dau gives the same deflection as box_ref
+
+If the daughter's frame were used instead of the field volume's, the extra
+45 deg would rotate B_world and split the deflection between X and Y.
+"""
+
+import numpy as np
+import uproot
+from scipy.spatial.transform import Rotation
+
+import opengate as gate
+from opengate.geometry import fields
+from opengate.tests import utility
+
+from test099_fields_helpers import (
+    g4_mm,
+    g4_MeV,
+    g4_tesla,
+    g4_eplus,
+    PROTON_MASS,
+    magnetic_deflection,
+)
+
+BOX_SIZE = 100 * g4_mm
+By = 3 * g4_tesla
+KE = 10 * g4_MeV
+SEP = 300 * g4_mm
+
+EXPECTED_DEFLECTION = magnetic_deflection(KE, By, PROTON_MASS, 1 * g4_eplus, BOX_SIZE)
+TOL_DEFLECTED = 0.01 * g4_mm  # deflected axis must stay within this of expected
+TOL_ZERO = 0.01 * g4_mm  # non-deflected axis must stay within this
+
+VISU = True  # set True for interactive qt viewer
+
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test099_fields")
+
+    sim = gate.Simulation()
+    sim.g4_verbose = False
+    sim.visu = False
+    sim.random_seed = 99002
+    sim.number_of_threads = 1
+    sim.output_dir = paths.output
+
+    if VISU:
+        sim.visu = True
+        sim.visu_type = "qt"
+        sim.visu_commands.append("/vis/scene/endOfEventAction accumulate")
+        sim.visu_commands.append("/vis/scene/add/trajectories smooth")
+        sim.visu_commands.append("/vis/scene/add/magneticField 20 fullArrow")
+
+    m = gate.g4_units.m
+    sim.world.size = [2 * m, 2 * m, 2 * m]
+    sim.world.material = "G4_Galactic"
+
+    # box_ref: empty reference, rotated 90 deg about Z
+    box_ref = sim.add_volume("Box", "box_ref")
+    box_ref.size = [BOX_SIZE, BOX_SIZE, BOX_SIZE]
+    box_ref.material = "G4_Galactic"
+    box_ref.translation = [-SEP, 0, 0]
+    box_ref.rotation = Rotation.from_euler("z", 90, degrees=True).as_matrix()
+
+    # box_dau: same placement, but the proton crosses a daughter instead
+    box_dau = sim.add_volume("Box", "box_dau")
+    box_dau.size = [BOX_SIZE, BOX_SIZE, BOX_SIZE]
+    box_dau.material = "G4_Galactic"
+    box_dau.translation = [+SEP, 0, 0]
+    box_dau.rotation = Rotation.from_euler("z", 90, degrees=True).as_matrix()
+
+    # daughter rotated 45 deg about Z w.r.t. its mother
+    inner = sim.add_volume("Box", "inner")
+    inner.mother = "box_dau"
+    inner.size = [BOX_SIZE / 2, BOX_SIZE / 2, BOX_SIZE]
+    inner.material = "G4_Galactic"
+    inner.rotation = Rotation.from_euler("z", 45, degrees=True).as_matrix()
+
+    # Same field on both boxes: B along local +Y
+    field = fields.UniformMagneticField(name="B_shared")
+    field.field_vector = [0, By, 0]
+    box_ref.add_field(field)
+    box_dau.add_field(field)
+
+    for name, x in (("ref", -SEP), ("dau", +SEP)):
+        src = sim.add_source("GenericSource", f"src_{name}")
+        src.particle = "proton"
+        src.number_of_primaries = 1
+        src.energy.type = "mono"
+        src.energy.mono = KE
+        src.position.type = "point"
+        src.position.translation = [x, 0, -300 * g4_mm]
+        src.direction.type = "momentum"
+        src.direction.momentum = [0, 0, 1]
+
+        phsp = sim.add_actor("PhaseSpaceActor", f"phsp_{name}")
+        phsp.attached_to = f"box_{name}"
+        phsp.attributes = ["PostPosition"]
+        phsp.output_filename = f"phsp_daughter_{name}.root"
+        phsp.steps_to_store = "exiting"
+        phsp.root_output.write_to_disk = True
+
+    sim.run()
+
+    df_ref = uproot.open(str(paths.output / "phsp_daughter_ref.root"))[
+        "phsp_ref;1"
+    ].arrays(library="pd")
+    df_dau = uproot.open(str(paths.output / "phsp_daughter_dau.root"))[
+        "phsp_dau;1"
+    ].arrays(library="pd")
+
+    row_ref = df_ref.sort_values("PostPosition_Z").iloc[-1]
+    row_dau = df_dau.sort_values("PostPosition_Z").iloc[-1]
+
+    x_ref = row_ref["PostPosition_X"] - (-SEP)
+    y_ref = row_ref["PostPosition_Y"]
+    x_dau = row_dau["PostPosition_X"] - (+SEP)
+    y_dau = row_dau["PostPosition_Y"]
+
+    print(
+        f"Analytical expected deflection: {-EXPECTED_DEFLECTION:.2f} mm  (threshold: {TOL_DEFLECTED:.2f} mm)"
+    )
+    print(f"box_ref (empty):        X={x_ref:.2f} mm  Y={y_ref:.2f} mm")
+    print(f"box_dau (R_z 45 daughter): X={x_dau:.2f} mm  Y={y_dau:.2f} mm")
+
+    ok_ref = (
+        np.abs(y_ref + EXPECTED_DEFLECTION) < TOL_DEFLECTED and abs(x_ref) < TOL_ZERO
+    )
+    ok_dau = (
+        np.abs(y_dau + EXPECTED_DEFLECTION) < TOL_DEFLECTED and abs(x_dau) < TOL_ZERO
+    )
+    ok_same = np.abs(y_ref - y_dau) < TOL_DEFLECTED and np.abs(x_ref - x_dau) < TOL_ZERO
+
+    print(f"\nbox_ref deflects in -Y: {ok_ref}")
+    print(f"box_dau deflects in -Y (field volume frame, not daughter): {ok_dau}")
+    print(f"box_dau matches box_ref: {ok_same}")
+
+    utility.test_ok(ok_ref and ok_dau and ok_same)

--- a/opengate/tests/src/geometry/test099_fields_mapped_repeated_placements.py
+++ b/opengate/tests/src/geometry/test099_fields_mapped_repeated_placements.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
 
     # --- RIGHT: repeated box (N_REPS slabs along Z) at X = +SEP ---
     translations = get_grid_repetition(
-        [1, 1, N_REPS], [0, 0, SPACING], start=[0, 0, -SPACING]
+        [1, 1, N_REPS], [0, 0, SPACING], start=[0, 0, -(BOX_SIZE - SLAB_SIZE) / 2]
     )
     translations = [[+SEP + t[0], t[1], t[2]] for t in translations]
 

--- a/opengate/tests/src/geometry/test099_fields_multi_volume_refresh.py
+++ b/opengate/tests/src/geometry/test099_fields_multi_volume_refresh.py
@@ -2,8 +2,9 @@
 """
 Test 099 - field attached to two volumes, dynamic geometry between runs.
 
-Verifies that refresh_transforms() updates the GateMagneticField transform
-cache for every volume the field is attached to.
+Verifies that a field attached to several volumes follows each volume's own
+placement, including when one of them is moved by a dynamic parametrisation
+between runs.
 
 Setup:
     Two boxes share one UniformMagneticField with B along local +Y (3 T).
@@ -199,7 +200,7 @@ if __name__ == "__main__":
     print(f"\nbox1 run0 deflects in -X: {ok_r0b1}")
     print(f"box2 run0 deflects in -X: {ok_r0b2}")
     print(f"box2 run1 deflects in -X (unchanged): {ok_r1b2}")
-    print(f"box1 run1 deflects in -Y (verifies refresh): {ok_r1b1}")
+    print(f"box1 run1 deflects in -Y (follows rotated volume): {ok_r1b1}")
 
     is_ok = ok_r0b1 and ok_r0b2 and ok_r1b2 and ok_r1b1
     utility.test_ok(is_ok)

--- a/opengate/tests/src/geometry/test099_fields_nested_fields.py
+++ b/opengate/tests/src/geometry/test099_fields_nested_fields.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     # Same geometry, same seed, identical result to floating point noise.
     is_ok = (
         utility.print_test(
-            np.isclose(dx["outerfirst"], dx["innerfirst"], atol=1e-6),
+            np.isclose(dx["outerfirst"], dx["innerfirst"], atol=1e-3 * g4_mm),
             f"Add order does not change the result "
             f"({dx['outerfirst']:.6f} vs {dx['innerfirst']:.6f} mm)",
         )

--- a/opengate/tests/src/geometry/test099_fields_nested_fields.py
+++ b/opengate/tests/src/geometry/test099_fields_nested_fields.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Test 099 - a field on a volume and a different field on its daughter.
+
+Field managers are attached with forceToAllDaughters=True, which overwrites the
+field manager of every daughter. The assignment must therefore go outermost
+first, so that a field attached to a deeper volume wins over the one it would
+otherwise inherit from its mother, whatever order the user added the fields
+in.
+
+Setup (repeated twice, adding the fields in the two possible orders):
+
+    outer  100 mm cube, B = 3 T along +Y --> deflects a +Z proton in -X
+    inner   40 mm cube inside outer, B = 3 T along +Z.
+
+A proton fired along +Z through the middle therefore bends differently while it is in
+the part of 'outer' that is not 'inner'. Both add orders must give the same
+deflection, and it must be smaller than for an 'outer' with no
+daughter at all.
+
+Checks:
+  - adding the outer field first and adding the inner field first agree exactly
+  - the daughter really shields the proton: |dX| is smaller than the reference
+  - the daughter does not suppress the deflection entirely
+"""
+
+import numpy as np
+import uproot
+
+import opengate as gate
+from opengate.geometry import fields
+from opengate.tests import utility
+
+from test099_fields_helpers import g4_mm, g4_MeV, g4_tesla
+
+OUTER_SIZE = 100 * g4_mm
+INNER_SIZE = 40 * g4_mm
+B = 3 * g4_tesla
+KE = 10 * g4_MeV
+
+VISU = False  # set True for interactive qt viewer
+
+
+def build(sim, name, x_offset, add_order):
+    """Add an 'outer' box at x_offset, optionally with a shielding daughter.
+
+    add_order is 'outer_first', 'inner_first' or 'no_daughter'.
+    """
+    outer = sim.add_volume("Box", f"outer_{name}")
+    outer.size = [OUTER_SIZE, OUTER_SIZE, OUTER_SIZE]
+    outer.material = "G4_Galactic"
+    outer.translation = [x_offset, 0, 0]
+
+    def add_outer_field():
+        f = fields.UniformMagneticField(name=f"B_outer_{name}")
+        f.field_vector = [0, B, 0]  # bends a +Z proton in -X
+        outer.add_field(f)
+
+    def add_inner_field():
+        inner = sim.add_volume("Box", f"inner_{name}")
+        inner.mother = outer.name
+        inner.size = [INNER_SIZE, INNER_SIZE, INNER_SIZE]
+        inner.material = "G4_Galactic"
+        f = fields.UniformMagneticField(name=f"B_inner_{name}")
+        f.field_vector = [0, 0, B]  # parallel to the momentum -> no force
+        inner.add_field(f)
+
+    if add_order == "outer_first":
+        add_outer_field()
+        add_inner_field()
+    elif add_order == "inner_first":
+        add_inner_field()
+        add_outer_field()
+    elif add_order == "no_daughter":
+        add_outer_field()
+    else:
+        raise ValueError(add_order)
+
+    src = sim.add_source("GenericSource", f"src_{name}")
+    src.particle = "proton"
+    src.number_of_primaries = 1
+    src.energy.type = "mono"
+    src.energy.mono = KE
+    src.position.type = "point"
+    src.position.translation = [x_offset, 0, -300 * g4_mm]
+    src.direction.type = "momentum"
+    src.direction.momentum = [0, 0, 1]
+
+    phsp = sim.add_actor("PhaseSpaceActor", f"phsp_{name}")
+    phsp.attached_to = outer.name
+    phsp.attributes = ["PostPosition"]
+    phsp.output_filename = f"phsp_nested_{name}.root"
+    phsp.steps_to_store = "exiting"
+    phsp.root_output.write_to_disk = True
+
+
+def exit_dx(paths, name, x_offset):
+    df = uproot.open(str(paths.output / f"phsp_nested_{name}.root"))[
+        f"phsp_{name};1"
+    ].arrays(library="pd")
+    row = df.sort_values("PostPosition_Z").iloc[-1]
+    return row["PostPosition_X"] - x_offset
+
+
+if __name__ == "__main__":
+    paths = utility.get_default_test_paths(__file__, output_folder="test099_fields")
+
+    sim = gate.Simulation()
+    sim.g4_verbose = False
+    sim.visu = False
+    sim.random_seed = 99003
+    sim.number_of_threads = 1
+    sim.output_dir = paths.output
+
+    if VISU:
+        sim.visu = True
+        sim.visu_type = "qt"
+        sim.visu_commands.append("/vis/scene/endOfEventAction accumulate")
+        sim.visu_commands.append("/vis/scene/add/trajectories smooth")
+        sim.visu_commands.append("/vis/scene/add/magneticField 20 fullArrow")
+
+    m = gate.g4_units.m
+    sim.world.size = [2 * m, 2 * m, 2 * m]
+    sim.world.material = "G4_Galactic"
+
+    # Three independent arms, laterally separated so the protons do not mix.
+    arms = {
+        "outerfirst": (-400 * g4_mm, "outer_first"),
+        "innerfirst": (0.0, "inner_first"),
+        "plain": (+400 * g4_mm, "no_daughter"),
+    }
+    for name, (x, order) in arms.items():
+        build(sim, name, x, order)
+
+    sim.run()
+
+    dx = {name: exit_dx(paths, name, x) for name, (x, _) in arms.items()}
+
+    print(f"outer field added first: dX = {dx['outerfirst']:.4f} mm")
+    print(f"inner field added first: dX = {dx['innerfirst']:.4f} mm")
+    print(f"no daughter (reference): dX = {dx['plain']:.4f} mm")
+
+    is_ok = True
+
+    # The result must not depend on the order the fields were added.
+    # Same geometry, same seed, identical result to floating point noise.
+    is_ok = (
+        utility.print_test(
+            np.isclose(dx["outerfirst"], dx["innerfirst"], atol=1e-6),
+            f"Add order does not change the result "
+            f"({dx['outerfirst']:.6f} vs {dx['innerfirst']:.6f} mm)",
+        )
+        and is_ok
+    )
+
+    # The daughter's own field exerts a different force.
+    # If the daughter's field were clobbered by the mother's, the bendings would be equal.
+    is_ok = (
+        utility.print_test(
+            abs(dx["outerfirst"]) < abs(dx["plain"]) - 0.1 * g4_mm,
+            f"Daughter field is in effect: |dX| {abs(dx['outerfirst']):.4f} mm "
+            f"< reference {abs(dx['plain']):.4f} mm",
+        )
+        and is_ok
+    )
+
+    # ... but the mother still bends the proton outside the daughter.
+    is_ok = (
+        utility.print_test(
+            abs(dx["outerfirst"]) > 0.1 * g4_mm,
+            f"Mother field still acts outside the daughter: "
+            f"|dX| = {abs(dx['outerfirst']):.4f} mm",
+        )
+        and is_ok
+    )
+
+    utility.test_ok(is_ok)

--- a/opengate/tests/src/geometry/test099_fields_repeated_placements.py
+++ b/opengate/tests/src/geometry/test099_fields_repeated_placements.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     # RIGHT: repeated box (N_REPS placements along Z) at X = +SEP
     translations = get_grid_repetition(
-        [1, 1, N_REPS], [0, 0, SPACING], start=[0, 0, -SPACING]
+        [1, 1, N_REPS], [0, 0, SPACING], start=[0, 0, -(BOX_SIZE - SLAB_SIZE) / 2]
     )
     translations = [[+SEP + t[0], t[1], t[2]] for t in translations]
 


### PR DESCRIPTION
# Rationale

A GATE field is defined in the local frame of the volume it is attached to, so every `GetFieldValue` call has to convert a world point into that volume's frame and rotate the field vector back to world corrdinates before returning. Until now each field cached the world->local transform of every physical placement of its volume, and recovered "which placement am I in?" by testing the query point against each one in sequentally. Points outside all of them -which can happen, because of boundary overshoots by the integration machinery- fell back to the nearest placement, unless they exceeded a tolerance derived from an assumed maximum curvature radius of 100 m, in which case the run aborted.

That design had four problems:

- the tolerance rested on a hard-coded value;
- `G4VSolid::DistanceToIn(p)` returns a *safety*, i.e. an underestimate, so the
  "nearest placement" search can be not reliable;
- the cache must be refreshed by hand whenever the geometry moves between runs, and a
  missed refresh silently evaluates the field in the wrong frame;
- rebuilding the transforms assumed every ancestor is singly placed, which is wrong for a field volume nested inside a
  repeated ancestor.

# What changed

**Placement resolution.** `GateFieldBase` now stores the field's `G4LogicalVolume` and reads the transform per query from the navigation history: during tracking from the pre-step touchable, and outside tracking from the navigator, which is what field visualisation needs.

The lookup walks the history outwards from the deepest level to the first level placing
the field's volume. That matters because fields are attached with `forceToAllDaughters=True`, so a track inside a daughter is still steered by the mother's field and must use the mother's frame.

**Nested-volume fields,** `SetFieldManager(fm, forceToAllDaughters=True)`
overwrites a daughter's field manager unconditionally, so a field on a daughter was
silently discarded whenever it was added before its mother's. The documented override
behaviour therefore only worked for one of the two add orders. `VolumeEngine` now assigns fields
outermost-first, so the result no longer depends on the order `add_field` was called.

**Defaults.** The default values for the parameters controlling the numerical integration of the equation of motion and the estimation of boundary crossings have been updated to match the defaults in Geant4 v11.4.1.

# Tests and Documentation

Updated and added new tests to check the nested volume branch. 


Cheers,

Marc ;)
