### PR TITLE
Deprecate time parameter in custom field definitions

### DIFF
--- a/docs/source/user_guide/user_guide_fields.rst
+++ b/docs/source/user_guide/user_guide_fields.rst
@@ -60,11 +60,11 @@ Magnetic fields
    field.gradient = 10 * tesla / m   # field gradient (T/m)
    box.add_field(field)
 
-**CustomMagneticField** -- Arbitrary magnetic field defined by a Python callback. The function receives ``(x, y, z, t)`` in Geant4 internal units and must return ``[Bx, By, Bz]``.
+**CustomMagneticField** -- Arbitrary magnetic field defined by a Python callback. The function receives ``(x, y, z)`` in Geant4 internal units and must return ``[Bx, By, Bz]``.
 
 .. code-block:: python
 
-   def my_B_field(x, y, z, t): # <- relative to the volume's local coordinate system
+   def my_B_field(x, y, z): # <- relative to the volume's local coordinate system
        # Spatially varying field
        return [0, (1 + x * z / m**2) * tesla, 0] # <- relative to the volume's local coordinate system
 
@@ -115,11 +115,11 @@ Electric fields
    field.field_vector = [1e6 * volt / m, 0, 0]   # [Ex, Ey, Ez] <- relative to the volume's local coordinate system
    box.add_field(field)
 
-**CustomElectricField** -- Arbitrary electric field defined by a Python callback. The function receives ``(x, y, z, t)`` in Geant4 internal units and must return ``[Ex, Ey, Ez]``.
+**CustomElectricField** -- Arbitrary electric field defined by a Python callback. The function receives ``(x, y, z)`` in Geant4 internal units and must return ``[Ex, Ey, Ez]``.
 
 .. code-block:: python
 
-   def my_E_field(x, y, z, t): # <- relative to the volume's local coordinate system
+   def my_E_field(x, y, z): # <- relative to the volume's local coordinate system
        return [1e6 * volt / m, 0, 0] # <- relative to the volume's local coordinate system
 
    field = fields.CustomElectricField(name="E_custom")
@@ -160,7 +160,7 @@ Combined magnetic and electric fields.
 
 .. code-block:: python
 
-   def my_EM_field(x, y, z, t):
+   def my_EM_field(x, y, z):
        return [0, 1 * tesla, 0, 1e6 * volt / m, 0, 0]
 
    field = fields.CustomElectroMagneticField(name="EM_custom")

--- a/opengate/geometry/fields.py
+++ b/opengate/geometry/fields.py
@@ -264,7 +264,7 @@ class CustomMagneticField(MagneticField):
         "field_function": (
             None,
             {
-                "doc": "Python function that takes [x, y, z, t] and returns [Bx, By, Bz], all in local volume coordinates.",
+                "doc": "Python function that takes [x, y, z] and returns [Bx, By, Bz], all in local volume coordinates.",
             },
         ),
     }
@@ -272,7 +272,7 @@ class CustomMagneticField(MagneticField):
     def _create_inner_field(self):
         """Create the custom magnetic field using the Python trampoline.
 
-        field_function receives (x, y, z, t) in the local coordinate frame of
+        field_function receives (x, y, z) in the local coordinate frame of
         the attached volume and must return [Bx, By, Bz] in that same local
         frame.  The base class rotates the result to world coordinates.
         """
@@ -284,7 +284,7 @@ class CustomMagneticField(MagneticField):
                 inner_self._callback = callback
 
             def GetFieldValue(inner_self, point):
-                return inner_self._callback(*point)
+                return inner_self._callback(*point[:3])
 
         return _PyMagneticField(self.field_function)
 
@@ -357,7 +357,7 @@ class CustomElectricField(ElectricField):
         "field_function": (
             None,
             {
-                "doc": "Python function that takes [x, y, z, t] and returns [Ex, Ey, Ez], all in local volume coordinates.",
+                "doc": "Python function that takes [x, y, z] and returns [Ex, Ey, Ez], all in local volume coordinates.",
             },
         ),
     }
@@ -371,7 +371,7 @@ class CustomElectricField(ElectricField):
                 inner_self._callback = callback
 
             def GetFieldValue(inner_self, point):
-                return inner_self._callback(*point)
+                return inner_self._callback(*point[:3])
 
             def DoesFieldChangeEnergy(inner_self):
                 return True
@@ -423,7 +423,7 @@ class CustomElectroMagneticField(ElectroMagneticField):
         "field_function": (
             None,
             {
-                "doc": "Python function that takes [x, y, z, t] and returns [Bx, By, Bz, Ex, Ey, Ez], all in local volume coordinates.",
+                "doc": "Python function that takes [x, y, z] and returns [Bx, By, Bz, Ex, Ey, Ez], all in local volume coordinates.",
             },
         ),
     }
@@ -437,7 +437,7 @@ class CustomElectroMagneticField(ElectroMagneticField):
                 inner_self._callback = callback
 
             def GetFieldValue(inner_self, point):
-                return inner_self._callback(*point)
+                return inner_self._callback(*point[:3])
 
             def DoesFieldChangeEnergy(inner_self):
                 return True
@@ -517,7 +517,7 @@ def _validate_field_function(
         raise ValueError(f"field_function must be provided for {class_name}")
     if not callable(func):
         raise TypeError("field_function must be a callable function")
-    result = list(func(0, 0, 0, 0))
+    result = list(func(0, 0, 0))
     if len(result) != n_components:
         raise ValueError(
             f"{class_name}: field_function must return {n_components} components, "

--- a/opengate/tests/src/geometry/test099_fields_api.py
+++ b/opengate/tests/src/geometry/test099_fields_api.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     # 6. Custom field with wrong component count
     print("Test: custom B field returning 6 components instead of 3")
     f = fields.CustomMagneticField(name="B_wrong_dims")
-    f.field_function = lambda x, y, z, t: [0, 0, 0, 0, 0, 0]
+    f.field_function = lambda x, y, z: [0, 0, 0, 0, 0, 0]
     ok = _expect_error(
         lambda: f._create_inner_field(),
         "wrong component count",

--- a/opengate/tests/src/geometry/test099_fields_custom_vs_native_B.py
+++ b/opengate/tests/src/geometry/test099_fields_custom_vs_native_B.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     box_custom.material = "G4_Galactic"
     box_custom.translation = [80 * g4_cm, 0, 0]
 
-    def custom_uniform_B(x, y, z, t):
+    def custom_uniform_B(x, y, z):
         return [0, By, 0]
 
     custom_field = fields.CustomMagneticField(

--- a/opengate/tests/src/geometry/test099_fields_custom_vs_native_E.py
+++ b/opengate/tests/src/geometry/test099_fields_custom_vs_native_E.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     box_custom.material = "G4_Galactic"
     box_custom.translation = [80 * g4_cm, 0, 0]
 
-    def custom_uniform_E(x, y, z, t):
+    def custom_uniform_E(x, y, z):
         return [Ex, 0, 0]
 
     custom_field = fields.CustomElectricField(

--- a/opengate/tests/src/geometry/test099_fields_serialization.py
+++ b/opengate/tests/src/geometry/test099_fields_serialization.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
 
     # Custom fields refuse serialization
     field = fields.CustomMagneticField(name="B_custom")
-    field.field_function = lambda x, y, z, t: [0, 0, 0]
+    field.field_function = lambda x, y, z: [0, 0, 0]
     try:
         field.to_dictionary()
         ok = False  # should not reach here
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     print(f"Custom B serialization raises: {'OK' if ok else 'FAIL'}")
 
     field = fields.CustomElectricField(name="E_custom")
-    field.field_function = lambda x, y, z, t: [0, 0, 0]
+    field.field_function = lambda x, y, z: [0, 0, 0]
     try:
         field.to_dictionary()
         ok = False


### PR DESCRIPTION
I am removing the time parameter on custom field definitions to simplify the user API and avoid unexpected behaviour. This is a feature that, in principle, could be useful to model time-dependent fields within a simulation, but comes with a series of issues:

- The resulting fields are not consistent with Maxwell's equations: a time-dependent magnetic field induces an electric field, and in a vacuum region the converse is also true. This coupling is not modelled by the equations of motion behind `CustomMagneticField` and `CustomElectricField`, so a time-dependent callback would only be physically acceptable for slowly varying fields.
- It never actually worked for magnetic fields: `G4Mag_UsualEqRhs` has only 6 variables and never changes the time.

This is a breaking change in the user API: any existing callback defined as `(x, y, z, t)` has to drop the last argument.

The user guide has been updated accordingly.